### PR TITLE
fix: handle State/Country Picklists in E2E test script

### DIFF
--- a/scripts/e2e-test.apex
+++ b/scripts/e2e-test.apex
@@ -18,6 +18,9 @@ String uid = String.valueOf(Math.mod(Math.abs(Crypto.getRandomInteger()), 100000
 // 1. CREATE TEST DATA
 // =====================================================================
 
+// Detect State/Country Picklists (enabled by default in new dev orgs; off in scratch orgs)
+Boolean statePicklistEnabled = Schema.SObjectType.Account.fields.getMap().containsKey('billingcountrycode');
+
 Account acc = new Account(
     Name = 'E2E-' + uid,
     Industry = 'Technology',
@@ -25,9 +28,14 @@ Account acc = new Account(
     Website = 'www.test.com',
     BillingStreet = '100 Test Dr',
     BillingCity = 'San Francisco',
-    BillingState = 'CA',
     BillingPostalCode = '94105'
 );
+if (statePicklistEnabled) {
+    acc.put('BillingStateCode', 'CA');
+    acc.put('BillingCountryCode', 'US');
+} else {
+    acc.put('BillingState', 'CA');
+}
 Database.insert(acc, dml);
 
 List<Contact> cons = new List<Contact>{


### PR DESCRIPTION
## Summary
- New developer orgs have State and Country/Territory Picklists enabled by default
- Setting `BillingState` without `BillingCountry` caused a silent DML failure (`FIELD_INTEGRITY_EXCEPTION` via `DMLOptions`), leaving `acc.Id` null and crashing the subsequent `update acc`
- Now detects at runtime via `Schema` whether picklist fields exist and uses `BillingStateCode`/`BillingCountryCode` or `BillingState` accordingly — works on both dev orgs and scratch orgs

## Test plan
- [ ] Run `sf apex run --target-org <dev-org-with-picklists> -f scripts/e2e-test.apex` — should pass 24/24
- [ ] Run `sf apex run --target-org <scratch-org> -f scripts/e2e-test.apex` — should pass 24/24

🤖 Generated with [Claude Code](https://claude.com/claude-code)