### PR TITLE
v1.48.0 — Record Filter (SOQL WHERE clause) + runner namespace fix

### DIFF
--- a/force-app/main/default/classes/DocGenBulkController.cls
+++ b/force-app/main/default/classes/DocGenBulkController.cls
@@ -10,7 +10,7 @@ public with sharing class DocGenBulkController {
         List<DocGen_Template__c> all = [
             SELECT Id, Name, Base_Object_API__c, Description__c, Output_Format__c, Query_Config__c,
                    Test_Record_Id__c, Category__c, Sort_Order__c, Lock_Output_Format__c,
-                   Required_Permission_Sets__c
+                   Required_Permission_Sets__c, Record_Filter__c
             FROM DocGen_Template__c
             WITH SYSTEM_MODE
             ORDER BY Sort_Order__c ASC NULLS LAST, Name ASC

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -1001,7 +1001,8 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
         List<DocGen_Template__c> all = [
             SELECT Id, Name, Description__c, Type__c, Output_Format__c, Is_Default__c,
                    Query_Config__c, Category__c, Sort_Order__c, Lock_Output_Format__c,
-                   Specific_Record_Ids__c, Required_Permission_Sets__c
+                   Specific_Record_Ids__c, Required_Permission_Sets__c, Record_Filter__c,
+                   Base_Object_API__c
             FROM DocGen_Template__c
             WHERE Base_Object_API__c = :objectApiName
             WITH SYSTEM_MODE
@@ -1014,9 +1015,13 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
         String recordId18 = (recordId != null) ? String.valueOf(Id.valueOf(recordId)) : null;
         Set<String> userPermSets = getCurrentUserPermissionSetNames();
 
+        // Cache results of per-record-filter evaluations so templates sharing the same
+        // clause incur only one SOQL query per (clause, record) combo.
+        Map<String, Boolean> filterCache = new Map<String, Boolean>();
+
         List<DocGen_Template__c> visible = new List<DocGen_Template__c>();
         for (DocGen_Template__c t : all) {
-            if (!templateMatchesRecord(t, recordId18)) continue;
+            if (!templateMatchesRecord(t, recordId18, filterCache)) continue;
             if (!templateVisibleToUser(t, userPermSets)) continue;
             visible.add(t);
         }
@@ -1045,23 +1050,129 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
     }
 
     /**
-     * Returns true when the template's per-record filter is empty OR contains the given recordId18.
-     * Empty/null filter = template applies to all records of its base object.
+     * Returns true when the template applies to the given record.
+     * Precedence:
+     *   1. Record_Filter__c (SOQL WHERE clause) — if set, evaluate it against the record; wins over Specific_Record_Ids__c.
+     *   2. Specific_Record_Ids__c (comma-separated Ids) — match if recordId is in the list.
+     *   3. Neither set — template applies to all records of its Base Object.
      */
-    private static Boolean templateMatchesRecord(DocGen_Template__c t, String recordId18) {
+    private static Boolean templateMatchesRecord(DocGen_Template__c t, String recordId18, Map<String, Boolean> filterCache) {
+        // Record Filter (WHERE clause) takes precedence when set
+        if (String.isNotBlank(t.Record_Filter__c)) {
+            if (String.isBlank(recordId18)) return false; // filter is set but no record context
+            if (String.isBlank(t.Base_Object_API__c)) return false; // misconfigured template
+            return recordMatchesFilter(t.Base_Object_API__c, recordId18, t.Record_Filter__c, filterCache);
+        }
+        // Fall back to Id list
         if (String.isBlank(t.Specific_Record_Ids__c)) return true;
-        if (String.isBlank(recordId18)) return false; // template is record-bound but caller didn't pass one
+        if (String.isBlank(recordId18)) return false;
         for (String rawId : t.Specific_Record_Ids__c.split(',')) {
             String trimmed = rawId.trim();
             if (String.isBlank(trimmed)) continue;
             try {
                 if (String.valueOf(Id.valueOf(trimmed)) == recordId18) return true;
             } catch (Exception e) {
-                // Bad Id in the list — skip it, don't reject the template
                 continue;
             }
         }
         return false;
+    }
+
+    /**
+     * Evaluates a SOQL WHERE clause against a specific record.
+     * Runs `SELECT Id FROM {base} WHERE Id = :recordId AND ({whereClause}) LIMIT 1` and returns
+     * true when a row comes back. Uses DocGenDataRetriever.sanitizeWhereClause to block DML
+     * keywords / semicolons / subqueries before the clause reaches dynamic SOQL.
+     *
+     * Malformed clauses (throws on sanitize or at query time) return false — the template hides
+     * rather than exposing every record. This is the safer default for a noise-reduction feature.
+     *
+     * filterCache dedupes lookups when multiple templates share the same clause for the same record.
+     */
+    private static Boolean recordMatchesFilter(String baseObjectApiName, String recordId18, String whereClause, Map<String, Boolean> filterCache) {
+        String cacheKey = baseObjectApiName + '|' + recordId18 + '|' + whereClause;
+        if (filterCache != null && filterCache.containsKey(cacheKey)) {
+            return filterCache.get(cacheKey);
+        }
+
+        Boolean matched = false;
+        try {
+            String safeClause = DocGenDataRetriever.sanitizeWhereClause(whereClause);
+            SObjectType objType = Schema.getGlobalDescribe().get(baseObjectApiName);
+            if (objType == null) {
+                matched = false;
+            } else {
+                Id recordId = Id.valueOf(recordId18);
+                String soql = 'SELECT Id FROM ' + String.escapeSingleQuotes(baseObjectApiName) +
+                    ' WHERE Id = :recordId AND (' + safeClause + ') LIMIT 1';
+                /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+                List<SObject> rows = Database.query(soql, AccessLevel.SYSTEM_MODE); // NOPMD ApexSOQLInjection — clause sanitized via DocGenDataRetriever.sanitizeWhereClause; object name escaped; Id param bound
+                matched = !rows.isEmpty();
+            }
+        } catch (Exception e) {
+            // Malformed clause, inaccessible object, or Id parse failure — hide the template.
+            matched = false;
+        }
+
+        if (filterCache != null) filterCache.put(cacheKey, matched);
+        return matched;
+    }
+
+    /**
+     * Shared filter path for the signature sender's template picker.
+     * Applies per-record filter (Record_Filter__c wins over Specific_Record_Ids__c) and
+     * audience filter (Required_Permission_Sets__c). Called from DocGenSignatureSenderController
+     * to avoid duplicating the filter logic in two places.
+     */
+    public static List<DocGen_Template__c> filterTemplatesForSender(List<DocGen_Template__c> all, String relatedRecordId) {
+        if (all == null || all.isEmpty()) return all;
+        String recordId18 = null;
+        if (String.isNotBlank(relatedRecordId)) {
+            try { recordId18 = String.valueOf(Id.valueOf(relatedRecordId)); } catch (Exception e) { recordId18 = null; }
+        }
+        Set<String> userPermSets = getCurrentUserPermissionSetNames();
+        Map<String, Boolean> filterCache = new Map<String, Boolean>();
+
+        List<DocGen_Template__c> visible = new List<DocGen_Template__c>();
+        for (DocGen_Template__c t : all) {
+            if (!templateMatchesRecord(t, recordId18, filterCache)) continue;
+            if (!templateVisibleToUser(t, userPermSets)) continue;
+            visible.add(t);
+        }
+        return visible;
+    }
+
+    /**
+     * Admin utility — lets the template editor test a WHERE clause against a sample record
+     * before saving. Returns { matched: Boolean, error: String|null } so the LWC can show a
+     * green/red indicator with the error text on failure.
+     */
+    @AuraEnabled
+    public static Map<String, Object> testRecordFilter(String baseObjectApiName, String sampleRecordId, String whereClause) {
+        Map<String, Object> result = new Map<String, Object>{ 'matched' => false, 'error' => null };
+        if (String.isBlank(baseObjectApiName) || String.isBlank(sampleRecordId) || String.isBlank(whereClause)) {
+            result.put('error', 'Base Object, Sample Record Id, and WHERE clause are all required.');
+            return result;
+        }
+        try {
+            String safeClause = DocGenDataRetriever.sanitizeWhereClause(whereClause);
+            SObjectType objType = Schema.getGlobalDescribe().get(baseObjectApiName);
+            if (objType == null) {
+                result.put('error', 'Unknown Base Object: ' + baseObjectApiName);
+                return result;
+            }
+            Id recordId = Id.valueOf(sampleRecordId);
+            String soql = 'SELECT Id FROM ' + String.escapeSingleQuotes(baseObjectApiName) +
+                ' WHERE Id = :recordId AND (' + safeClause + ') LIMIT 1';
+            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+            List<SObject> rows = Database.query(soql, AccessLevel.SYSTEM_MODE); // NOPMD ApexSOQLInjection — clause sanitized, object escaped, Id bound
+            result.put('matched', !rows.isEmpty());
+        } catch (DocGenException e) {
+            result.put('error', e.getMessage());
+        } catch (Exception e) {
+            result.put('error', 'Filter invalid or record not accessible: ' + e.getMessage());
+        }
+        return result;
     }
 
     /**
@@ -1089,6 +1200,7 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
         return [SELECT Id, Name, Description__c, Type__c, Base_Object_API__c, Category__c, Query_Config__c,
                    Test_Record_Id__c, Output_Format__c, Document_Title_Format__c, Is_Default__c,
                    Sort_Order__c, Lock_Output_Format__c, Specific_Record_Ids__c, Required_Permission_Sets__c,
+                   Record_Filter__c,
                    (SELECT ContentDocumentId FROM ContentDocumentLinks ORDER BY ContentDocument.CreatedDate DESC LIMIT 1)
             FROM DocGen_Template__c
             WITH SYSTEM_MODE
@@ -1150,6 +1262,9 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             }
             if (fields.containsKey('Required_Permission_Sets__c')) {
                 template.Required_Permission_Sets__c = (String) fields.get('Required_Permission_Sets__c');
+            }
+            if (fields.containsKey('Record_Filter__c')) {
+                template.Record_Filter__c = (String) fields.get('Record_Filter__c');
             }
             // Update Default flag if provided — enforce one default per object
             if (fields.containsKey('Is_Default__c')) {

--- a/force-app/main/default/classes/DocGenControllerTests.cls
+++ b/force-app/main/default/classes/DocGenControllerTests.cls
@@ -4403,4 +4403,144 @@ private class DocGenControllerTests {
         Test.stopTest();
         System.assert(names != null && !names.isEmpty(), 'User should have at least one permission set assigned');
     }
+
+    // =========================================================================
+    // 1.48 — Record Filter (SOQL WHERE clause) feature
+    // =========================================================================
+
+    @isTest
+    static void testRecordFilter_matchesCurrentRecord() {
+        Account matching = TestDataFactory.getTestAccount();
+        matching.Industry = 'Technology';
+        update matching;
+
+        DocGen_Template__c t = new DocGen_Template__c(
+            Name = 'Tech-Only Template', Base_Object_API__c = 'Account',
+            Type__c = 'Word', Output_Format__c = 'PDF',
+            Record_Filter__c = 'Industry = \'Technology\''
+        );
+        insert t;
+
+        Test.startTest();
+        List<DocGen_Template__c> visible = DocGenController.getTemplatesForObjectAndRecord('Account', matching.Id);
+        Test.stopTest();
+
+        Boolean found = false;
+        for (DocGen_Template__c v : visible) if (v.Id == t.Id) found = true;
+        System.assert(found, 'Template with Industry=Technology filter should appear for a Tech account');
+    }
+
+    @isTest
+    static void testRecordFilter_hidesNonMatchingRecord() {
+        Account nonMatching = TestDataFactory.getTestAccount();
+        nonMatching.Industry = 'Retail';
+        update nonMatching;
+
+        DocGen_Template__c t = new DocGen_Template__c(
+            Name = 'Tech-Only Template', Base_Object_API__c = 'Account',
+            Type__c = 'Word', Output_Format__c = 'PDF',
+            Record_Filter__c = 'Industry = \'Technology\''
+        );
+        insert t;
+
+        Test.startTest();
+        List<DocGen_Template__c> visible = DocGenController.getTemplatesForObjectAndRecord('Account', nonMatching.Id);
+        Test.stopTest();
+
+        for (DocGen_Template__c v : visible) {
+            System.assertNotEquals(t.Id, v.Id, 'Tech-only template should NOT appear for a Retail account');
+        }
+    }
+
+    @isTest
+    static void testRecordFilter_precedenceOverSpecificRecordIds() {
+        // When both Record_Filter__c and Specific_Record_Ids__c are set,
+        // Record_Filter__c wins. Set contradictory values and verify.
+        Account a = TestDataFactory.getTestAccount();
+        Account other = new Account(Name = 'Other Ind', Industry = 'Retail'); insert other;
+        a.Industry = 'Retail'; update a;
+
+        DocGen_Template__c t = new DocGen_Template__c(
+            Name = 'Filter Wins', Base_Object_API__c = 'Account',
+            Type__c = 'Word', Output_Format__c = 'PDF',
+            Specific_Record_Ids__c = String.valueOf(a.Id),           // says "appears for a"
+            Record_Filter__c = 'Industry = \'Technology\''           // says "appears for Tech only"
+        );
+        insert t;
+
+        Test.startTest();
+        List<DocGen_Template__c> forA = DocGenController.getTemplatesForObjectAndRecord('Account', a.Id);
+        Test.stopTest();
+
+        for (DocGen_Template__c v : forA) {
+            System.assertNotEquals(t.Id, v.Id,
+                'Record_Filter__c (Industry=Technology) should win over Specific_Record_Ids__c — Retail account hidden');
+        }
+    }
+
+    @isTest
+    static void testRecordFilter_malformedClauseHidesTemplate() {
+        Account acc = TestDataFactory.getTestAccount();
+        DocGen_Template__c t = new DocGen_Template__c(
+            Name = 'Malformed', Base_Object_API__c = 'Account',
+            Type__c = 'Word', Output_Format__c = 'PDF',
+            Record_Filter__c = 'this is ; not valid SOQL'
+        );
+        insert t;
+
+        Test.startTest();
+        List<DocGen_Template__c> visible = DocGenController.getTemplatesForObjectAndRecord('Account', acc.Id);
+        Test.stopTest();
+
+        for (DocGen_Template__c v : visible) {
+            System.assertNotEquals(t.Id, v.Id, 'Malformed clause = template hidden (safer default than exposing every record)');
+        }
+    }
+
+    @isTest
+    static void testRecordFilter_emptyFilterFallsBackToIdList() {
+        Account acc = TestDataFactory.getTestAccount();
+        DocGen_Template__c t = new DocGen_Template__c(
+            Name = 'Id Binding Only', Base_Object_API__c = 'Account',
+            Type__c = 'Word', Output_Format__c = 'PDF',
+            Specific_Record_Ids__c = String.valueOf(acc.Id)
+            // Record_Filter__c intentionally blank
+        );
+        insert t;
+
+        Test.startTest();
+        List<DocGen_Template__c> visible = DocGenController.getTemplatesForObjectAndRecord('Account', acc.Id);
+        Test.stopTest();
+
+        Boolean found = false;
+        for (DocGen_Template__c v : visible) if (v.Id == t.Id) found = true;
+        System.assert(found, 'With blank Record_Filter__c, Specific_Record_Ids__c behavior preserved');
+    }
+
+    @isTest
+    static void testTestRecordFilter_sanitizesBlockedKeywords() {
+        Account acc = TestDataFactory.getTestAccount();
+        Test.startTest();
+        Map<String, Object> res = DocGenController.testRecordFilter('Account', acc.Id, 'Id != null; DELETE Account');
+        Test.stopTest();
+
+        System.assertEquals(false, (Boolean) res.get('matched'), 'Blocked keyword should prevent a match');
+        System.assertNotEquals(null, res.get('error'), 'Error message should explain the block');
+    }
+
+    @isTest
+    static void testTestRecordFilter_happyPath() {
+        Account acc = TestDataFactory.getTestAccount();
+        acc.Industry = 'Technology'; update acc;
+
+        Test.startTest();
+        Map<String, Object> match = DocGenController.testRecordFilter('Account', acc.Id, 'Industry = \'Technology\'');
+        Map<String, Object> noMatch = DocGenController.testRecordFilter('Account', acc.Id, 'Industry = \'Retail\'');
+        Test.stopTest();
+
+        System.assertEquals(true, (Boolean) match.get('matched'));
+        System.assertEquals(null, match.get('error'));
+        System.assertEquals(false, (Boolean) noMatch.get('matched'));
+        System.assertEquals(null, noMatch.get('error'));
+    }
 }

--- a/force-app/main/default/classes/DocGenDataRetriever.cls
+++ b/force-app/main/default/classes/DocGenDataRetriever.cls
@@ -1504,6 +1504,14 @@ public with sharing class DocGenDataRetriever {
     }
 
     /**
+     * Public wrapper so other controllers (e.g. DocGenController's template WHERE-clause evaluator)
+     * can reuse the same sanitize rules without duplicating the keyword blocklist.
+     */
+    public static String sanitizeWhereClause(String clause) {
+        return sanitizeClause(clause, 'WHERE');
+    }
+
+    /**
      * Sanitizes a SOQL clause (WHERE, ORDER BY, LIMIT) with keyword blocklist
      * and optional Schema allowlist validation for ORDER BY field names.
      * @param clause The raw clause value

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -23,47 +23,15 @@ public with sharing class DocGenSignatureSenderController {
     @AuraEnabled(cacheable=true)
     public static List<DocGen_Template__c> getDocGenTemplatesForRecord(String relatedRecordId) {
         /* code-analyzer-suppress ApexFlsViolation */
-        // SYSTEM_MODE — fields are read for in-memory filtering, no FLS surface is widened.
-        // Field-level access for admin-editable fields is still controlled by DocGen_Admin/User permsets.
         List<DocGen_Template__c> all = [
-            SELECT Id, Name, Category__c, Sort_Order__c, Specific_Record_Ids__c, Required_Permission_Sets__c
+            SELECT Id, Name, Category__c, Sort_Order__c, Specific_Record_Ids__c,
+                   Required_Permission_Sets__c, Record_Filter__c, Base_Object_API__c
             FROM DocGen_Template__c
             WITH SYSTEM_MODE
             ORDER BY Sort_Order__c ASC NULLS LAST, Name ASC
         ]; // NOPMD ApexCRUDViolation - package-internal custom object; CRUD controlled by DocGen permission sets
 
-        String recordId18 = null;
-        if (String.isNotBlank(relatedRecordId)) {
-            try { recordId18 = String.valueOf(Id.valueOf(relatedRecordId)); } catch (Exception e) { recordId18 = null; }
-        }
-        Set<String> userPermSets = DocGenController.getCurrentUserPermissionSetNames();
-
-        List<DocGen_Template__c> visible = new List<DocGen_Template__c>();
-        for (DocGen_Template__c t : all) {
-            // Per-record filter
-            if (String.isNotBlank(t.Specific_Record_Ids__c)) {
-                if (recordId18 == null) continue; // template is record-bound but no record passed
-                Boolean recordMatches = false;
-                for (String rawId : t.Specific_Record_Ids__c.split(',')) {
-                    String trimmed = rawId.trim();
-                    if (String.isBlank(trimmed)) continue;
-                    try {
-                        if (String.valueOf(Id.valueOf(trimmed)) == recordId18) { recordMatches = true; break; }
-                    } catch (Exception e) { continue; }
-                }
-                if (!recordMatches) continue;
-            }
-            // Audience filter
-            if (String.isNotBlank(t.Required_Permission_Sets__c)) {
-                Boolean audienceMatches = false;
-                for (String rawName : t.Required_Permission_Sets__c.split(',')) {
-                    if (userPermSets.contains(rawName.trim())) { audienceMatches = true; break; }
-                }
-                if (!audienceMatches) continue;
-            }
-            visible.add(t);
-        }
-        return visible;
+        return DocGenController.filterTemplatesForSender(all, relatedRecordId);
     }
 
     /**

--- a/force-app/main/default/layouts/DocGen_Template__c-DocGen Template Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/DocGen_Template__c-DocGen Template Layout.layout-meta.xml
@@ -74,6 +74,19 @@
         <customLabel>true</customLabel>
         <detailHeading>true</detailHeading>
         <editHeading>false</editHeading>
+        <label>Record Filter (Power Users, 1.48)</label>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Record_Filter__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <style>OneColumn</style>
+    </layoutSections>
+    <layoutSections>
+        <customLabel>true</customLabel>
+        <detailHeading>true</detailHeading>
+        <editHeading>false</editHeading>
         <label>Description</label>
         <layoutColumns>
             <layoutItems>

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -390,6 +390,29 @@
                                         </lightning-textarea>
                                     </div>
                                 </div>
+
+                                <!-- 1.48 — Record Filter (SOQL WHERE clause) — power users -->
+                                <div class="slds-var-m-top_medium">
+                                    <lightning-textarea
+                                        label="Record Filter (SOQL WHERE clause)"
+                                        field-level-help="Advanced / power users. SOQL WHERE clause evaluated against the current record. Examples: Type = 'Customer'  |  Industry IN ('Technology','Media')  |  Annual_Revenue__c > 1000000 AND BillingCountry = 'US'. Wins over Specific Record Ids when both set. Blank = no filter."
+                                        value={editTemplateRecordFilter}
+                                        onchange={handleEditRecordFilterChange}>
+                                    </lightning-textarea>
+                                    <div class="slds-var-m-top_x-small">
+                                        <lightning-button
+                                            label="Test Against Sample Record"
+                                            icon-name="utility:check"
+                                            variant="neutral"
+                                            onclick={handleTestRecordFilter}
+                                            disabled={editTemplateRecordFilterTesting}>
+                                        </lightning-button>
+                                        <span class="slds-text-body_small slds-text-color_weak slds-var-m-left_small">Tests the clause against the Sample Test Record Id on this template.</span>
+                                    </div>
+                                    <div class={recordFilterResultClass}>
+                                        {editTemplateRecordFilterResultMessage}
+                                    </div>
+                                </div>
                             </div>
 
                         </lightning-tab>

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -39,6 +39,8 @@ import SORT_ORDER_FIELD from '@salesforce/schema/DocGen_Template__c.Sort_Order__
 import LOCK_OUTPUT_FORMAT_FIELD from '@salesforce/schema/DocGen_Template__c.Lock_Output_Format__c';
 import SPECIFIC_RECORD_IDS_FIELD from '@salesforce/schema/DocGen_Template__c.Specific_Record_Ids__c';
 import REQUIRED_PERM_SETS_FIELD from '@salesforce/schema/DocGen_Template__c.Required_Permission_Sets__c';
+import RECORD_FILTER_FIELD from '@salesforce/schema/DocGen_Template__c.Record_Filter__c';
+import testRecordFilter from '@salesforce/apex/DocGenController.testRecordFilter';
 // Version fields (DocGen_Template_Version__c)
 import VER_IS_ACTIVE_FIELD from '@salesforce/schema/DocGen_Template_Version__c.Is_Active__c';
 import VER_CV_ID_FIELD from '@salesforce/schema/DocGen_Template_Version__c.Content_Version_Id__c';
@@ -60,6 +62,7 @@ const F = {
     LockOutputFormat: LOCK_OUTPUT_FORMAT_FIELD.fieldApiName,
     SpecificRecordIds: SPECIFIC_RECORD_IDS_FIELD.fieldApiName,
     RequiredPermSets: REQUIRED_PERM_SETS_FIELD.fieldApiName,
+    RecordFilter: RECORD_FILTER_FIELD.fieldApiName,
     // Version fields
     VerIsActive: VER_IS_ACTIVE_FIELD.fieldApiName,
     VerCvId: VER_CV_ID_FIELD.fieldApiName
@@ -143,6 +146,10 @@ const VERSION_COLUMNS = [
     editTemplateLockOutputFormat = false;
     editTemplateSpecificRecordIds;
     editTemplateRequiredPermissionSets;
+    editTemplateRecordFilter;
+    @track editTemplateRecordFilterResult = '';
+    @track editTemplateRecordFilterResultMessage = '';
+    @track editTemplateRecordFilterTesting = false;
 
     @track currentFileId;
     @track uploadedFileName = '';
@@ -848,6 +855,51 @@ const VERSION_COLUMNS = [
     handleEditLockOutputChange(event) { this.editTemplateLockOutputFormat = event.target.checked; }
     handleEditSpecificRecordIdsChange(event) { this.editTemplateSpecificRecordIds = event.detail.value; }
     handleEditRequiredPermSetsChange(event) { this.editTemplateRequiredPermissionSets = event.detail.value; }
+    handleEditRecordFilterChange(event) {
+        this.editTemplateRecordFilter = event.detail.value;
+        this.editTemplateRecordFilterResult = '';
+        this.editTemplateRecordFilterResultMessage = '';
+    }
+
+    async handleTestRecordFilter() {
+        if (!this.editTemplateRecordFilter || !this.editTemplateTestRecordId || !this.editTemplateObject) {
+            this.editTemplateRecordFilterResult = 'error';
+            this.editTemplateRecordFilterResultMessage = 'Need Base Object, Sample Test Record Id (set on the template), and a Record Filter clause to test.';
+            return;
+        }
+        this.editTemplateRecordFilterTesting = true;
+        this.editTemplateRecordFilterResult = '';
+        this.editTemplateRecordFilterResultMessage = '';
+        try {
+            const res = await testRecordFilter({
+                baseObjectApiName: this.editTemplateObject,
+                sampleRecordId: this.editTemplateTestRecordId,
+                whereClause: this.editTemplateRecordFilter
+            });
+            if (res.error) {
+                this.editTemplateRecordFilterResult = 'error';
+                this.editTemplateRecordFilterResultMessage = res.error;
+            } else if (res.matched) {
+                this.editTemplateRecordFilterResult = 'matched';
+                this.editTemplateRecordFilterResultMessage = '✓ Match — this template would appear for the test record.';
+            } else {
+                this.editTemplateRecordFilterResult = 'nomatch';
+                this.editTemplateRecordFilterResultMessage = '✗ No match — the test record does not satisfy this filter.';
+            }
+        } catch (e) {
+            this.editTemplateRecordFilterResult = 'error';
+            this.editTemplateRecordFilterResultMessage = (e.body && e.body.message) ? e.body.message : e.message;
+        } finally {
+            this.editTemplateRecordFilterTesting = false;
+        }
+    }
+
+    get recordFilterResultClass() {
+        if (this.editTemplateRecordFilterResult === 'matched') return 'slds-text-color_success slds-var-m-top_x-small';
+        if (this.editTemplateRecordFilterResult === 'nomatch') return 'slds-text-color_weak slds-var-m-top_x-small';
+        if (this.editTemplateRecordFilterResult === 'error') return 'slds-text-color_error slds-var-m-top_x-small';
+        return 'slds-hide';
+    }
 
     handleQueryTabActive() {
         // lightning-tab lazy-renders content — sync textarea when query tab first activates
@@ -1203,6 +1255,9 @@ const VERSION_COLUMNS = [
             this.editTemplateLockOutputFormat = row[F.LockOutputFormat] || false;
             this.editTemplateSpecificRecordIds = row[F.SpecificRecordIds];
             this.editTemplateRequiredPermissionSets = row[F.RequiredPermSets];
+            this.editTemplateRecordFilter = row[F.RecordFilter];
+            this.editTemplateRecordFilterResult = '';
+            this.editTemplateRecordFilterResultMessage = '';
 
             let cdLinks = [];
             if (row.ContentDocumentLinks) {
@@ -1468,7 +1523,8 @@ const VERSION_COLUMNS = [
             'Sort_Order__c': this.editTemplateSortOrder,
             'Lock_Output_Format__c': this.editTemplateLockOutputFormat,
             'Specific_Record_Ids__c': this.editTemplateSpecificRecordIds,
-            'Required_Permission_Sets__c': this.editTemplateRequiredPermissionSets
+            'Required_Permission_Sets__c': this.editTemplateRequiredPermissionSets,
+            'Record_Filter__c': this.editTemplateRecordFilter
         };
         this.editTemplateQuery = fields['Query_Config__c'];
 
@@ -1503,7 +1559,8 @@ const VERSION_COLUMNS = [
             'Sort_Order__c': this.editTemplateSortOrder,
             'Lock_Output_Format__c': this.editTemplateLockOutputFormat,
             'Specific_Record_Ids__c': this.editTemplateSpecificRecordIds,
-            'Required_Permission_Sets__c': this.editTemplateRequiredPermissionSets
+            'Required_Permission_Sets__c': this.editTemplateRequiredPermissionSets,
+            'Record_Filter__c': this.editTemplateRecordFilter
         };
         this.editTemplateQuery = fields['Query_Config__c'];
 

--- a/force-app/main/default/lwc/docGenRunner/docGenRunner.js
+++ b/force-app/main/default/lwc/docGenRunner/docGenRunner.js
@@ -27,6 +27,8 @@ import { mergePdfs } from './docGenPdfMerger';
 import OUT_FMT_FIELD from '@salesforce/schema/DocGen_Template__c.Output_Format__c';
 import TYPE_FIELD from '@salesforce/schema/DocGen_Template__c.Type__c';
 import IS_DEFAULT_FIELD from '@salesforce/schema/DocGen_Template__c.Is_Default__c';
+import CATEGORY_FIELD from '@salesforce/schema/DocGen_Template__c.Category__c';
+import LOCK_OUTPUT_FORMAT_FIELD from '@salesforce/schema/DocGen_Template__c.Lock_Output_Format__c';
 
 export default class DocGenRunner extends NavigationMixin(LightningElement) {
     @api recordId;
@@ -166,12 +168,13 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
     _rebuildTemplateOptions() {
         const data = this._templateData || [];
         const filtered = (this.selectedCategory && this.selectedCategory !== '__ALL__')
-            ? data.filter(t => (t.Category__c || '__UNCATEGORIZED__') === this.selectedCategory)
+            ? data.filter(t => (t[CATEGORY_FIELD.fieldApiName] || '__UNCATEGORIZED__') === this.selectedCategory)
             : data;
         const defaultTemplate = filtered.find(t => t[IS_DEFAULT_FIELD.fieldApiName]);
         this.templateOptions = filtered.map(t => {
             const isDefault = !!t[IS_DEFAULT_FIELD.fieldApiName];
-            const cat = t.Category__c ? `[${t.Category__c}] ` : '';
+            const catVal = t[CATEGORY_FIELD.fieldApiName];
+            const cat = catVal ? `[${catVal}] ` : '';
             return {
                 label: `${isDefault ? '★ ' : ''}${cat}${t.Name}`,
                 value: t.Id,
@@ -197,7 +200,8 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
         const data = this._templateData || [];
         const distinct = new Set();
         for (const t of data) {
-            distinct.add(t.Category__c ? t.Category__c : '__UNCATEGORIZED__');
+            const v = t[CATEGORY_FIELD.fieldApiName];
+            distinct.add(v ? v : '__UNCATEGORIZED__');
         }
         if (distinct.size <= 1) return [];
         const opts = [{ label: 'All Categories', value: '__ALL__' }];
@@ -222,7 +226,7 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
     get outputFormatPickerOptions() {
         const t = this.selectedTemplate;
         if (!t) return [];
-        if (t.Lock_Output_Format__c) return [];
+        if (t[LOCK_OUTPUT_FORMAT_FIELD.fieldApiName]) return [];
         const tplType = t[TYPE_FIELD.fieldApiName];
         if (tplType === 'PowerPoint') return []; // PPTX only — no choice
         if (tplType === 'Word') {

--- a/force-app/main/default/objects/DocGen_Template__c/fields/Record_Filter__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Template__c/fields/Record_Filter__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Record_Filter__c</fullName>
+    <description>SOQL WHERE clause applied to the current record. When set, this template only appears in the runner / signature sender / Flow when the current record matches the clause. Evaluated against the template's Base Object. Examples: Type = 'Customer' | Industry IN ('Technology','Media') | Annual_Revenue__c &gt; 1000000 AND BillingCountry = 'US'. Leave blank for no filter. If both Record Filter and Specific Record Ids are set, Record Filter wins.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>SOQL WHERE clause (e.g. Type = &apos;Customer&apos;). Runs against the current record. Blank = no filter.</inlineHelpText>
+    <label>Record Filter (WHERE clause)</label>
+    <length>32768</length>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
+</CustomField>

--- a/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
@@ -295,6 +295,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>DocGen_Template__c.Record_Filter__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>DocGen_Template__c.Required_Permission_Sets__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
@@ -279,6 +279,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>DocGen_Template__c.Record_Filter__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>DocGen_Template__c.Required_Permission_Sets__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,9 +1,9 @@
 {
   "packageDirectories": [
     {
-      "versionName": "1.47.0 — Runner UX: per-record templates, category filter, output format override, audience visibility",
-      "versionNumber": "1.47.0.NEXT",
-      "ancestorId": "04tal000006hQ73AAE",
+      "versionName": "1.48.0 — Record Filter (SOQL WHERE) + namespace-safe runner field access",
+      "versionNumber": "1.48.0.NEXT",
+      "ancestorId": "04tal000006hQwfAAE",
       "path": "force-app",
       "default": true,
       "package": "Portwood DocGen Managed",


### PR DESCRIPTION
Extends the per-record filtering from v1.47 (#25) with a full SOQL WHERE clause, and fixes a namespace-resolution bug in the runner that hid the 1.47 category dropdown + output format picker in subscriber orgs.

## What's new

**Record Filter (power-user SOQL WHERE clause)**
- New \`Record_Filter__c\` (LongTextArea) on \`DocGen_Template__c\`. Evaluated against the current record. Examples:
  - \`Type = 'Customer'\`
  - \`Industry IN ('Technology','Media','Finance')\`
  - \`Annual_Revenue__c > 1000000 AND BillingCountry = 'US'\`
  - \`Id IN ('001...', '001...')\` — equivalent of \`Specific_Record_Ids__c\`
- When both \`Record_Filter__c\` and \`Specific_Record_Ids__c\` are set, **Record_Filter wins**.
- Evaluation: parameterized \`SELECT Id FROM <base> WHERE Id = :recordId AND (<clause>)\`. Clause is sanitized via \`DocGenDataRetriever.sanitizeWhereClause\` (blocks DML keywords, semicolons, comments, subqueries). Results cached per \`(baseObject, recordId, clause)\` tuple. Malformed clause → template hidden (safer default).

**"Test Against Sample Record" button in the template editor**
- New \`testRecordFilter\` @AuraEnabled endpoint returns \`{ matched, error }\` for \`(baseObject, sampleRecordId, whereClause)\`.
- Admin editor: button runs the clause against the template's \`Test_Record_Id__c\` with a green ✓ / grey ✗ / red error indicator.

**Runner namespace-safety fix (bug introduced in 1.47)**
- Runner was accessing template fields via raw property names (\`t.Category__c\`, \`t.Lock_Output_Format__c\`). In a namespaced managed-package install the wire returns \`portwoodglobal__Category__c\` — raw access silently returned undefined, so the category dropdown stayed hidden and the output picker lock always read as false.
- Switched to \`@salesforce/schema/...\` imports + \`t[FIELD.fieldApiName]\` resolution, matching the namespace-safe pattern already used in \`docGenAdmin\`.

## Validation

- **Apex RunLocalTests:** 944 / 944 pass, 75% org-wide coverage (7 new tests in \`DocGenControllerTests\`)
- **Code analyzer:** 0 High / 0 Critical, 37 Moderate (same documented false positives)
- **Upgrade-safety validator:** passed; ancestor chain v1.47.0 → v1.48.0 contiguous

## Package

- **Built:** \`04tal000006hhhNAAQ\` (v1.48.0-1)
- **Install URL (unpromoted beta):** https://login.salesforce.com/packaging/installPackage.apexp?p0=04tal000006hhhNAAQ
- **Promoted:** pending Dave's go-ahead

## Backward compatibility

- \`Specific_Record_Ids__c\` continues to work unchanged.
- All 1.47 API surfaces preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)