### PR TITLE
carry run properties from original run when linebreaks occur in textarea fields.

### DIFF
--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -2091,7 +2091,10 @@ public with sharing class DocGenService {
                             output += strVal.escapeXml();
                         } else {
                             // Multiline support: convert newlines to Word line breaks
-                            output += convertMultilineToXml(strVal);
+                            // Carry forward run properties (font, size, bold, etc.) so formatting
+                            // is preserved across line breaks in textarea fields (#32)
+                            String rPr = extractCurrentRunProperties(output);
+                            output += convertMultilineToXml(strVal, rPr);
                         }
                     }
                 }
@@ -2202,8 +2205,9 @@ public with sharing class DocGenService {
     /**
      * Converts a text value with newlines to Word XML with <w:br/> line breaks.
      * Properly closes and reopens <w:r> runs around each break for valid OOXML.
+     * Carries forward run properties (rPr) so formatting is preserved across breaks.
      */
-    private static String convertMultilineToXml(String inputText) {
+    private static String convertMultilineToXml(String inputText, String rPr) {
         if (inputText == null) {
             return '';
         }
@@ -2213,7 +2217,8 @@ public with sharing class DocGenService {
         }
         List<String> lines = normalized.split('\n');
         String result = '';
-        String lineBreakXml = '</w:t></w:r><w:r><w:br/></w:r><w:r><w:t xml:space="preserve">';
+        String rPrXml = String.isNotBlank(rPr) ? rPr : '';
+        String lineBreakXml = '</w:t></w:r><w:r>' + rPrXml + '<w:br/></w:r><w:r>' + rPrXml + '<w:t xml:space="preserve">';
         for (Integer i = 0; i < lines.size(); i++) {
             if (i > 0) {
                 result += lineBreakXml;
@@ -2221,6 +2226,42 @@ public with sharing class DocGenService {
             result += lines[i].escapeXml();
         }
         return result;
+    }
+
+    /**
+     * Extracts the <w:rPr>...</w:rPr> block from the current open <w:r> run in the output.
+     * Returns empty string if no run properties found.
+     */
+    @TestVisible
+    private static String extractCurrentRunProperties(String output) {
+        if (String.isBlank(output)) {
+            return '';
+        }
+        // Find the last <w:r> or <w:r > opening (start of current run)
+        Integer lastRunOpen = output.lastIndexOf('<w:r>');
+        Integer lastRunOpenAttr = output.lastIndexOf('<w:r ');
+        Integer runStart = Math.max(lastRunOpen != null ? lastRunOpen : -1, lastRunOpenAttr != null ? lastRunOpenAttr : -1);
+        if (runStart < 0) {
+            return '';
+        }
+        // If there's a </w:r> after this opening, we're not inside an open run
+        Integer lastRunClose = output.lastIndexOf('</w:r>');
+        if (lastRunClose != null && lastRunClose > runStart) {
+            return '';
+        }
+        // Find <w:rPr>...</w:rPr> within this run
+        Integer rPrStart = output.indexOf('<w:rPr>', runStart);
+        if (rPrStart < 0) {
+            rPrStart = output.indexOf('<w:rPr ', runStart);
+        }
+        if (rPrStart < 0) {
+            return '';
+        }
+        Integer rPrEnd = output.indexOf('</w:rPr>', rPrStart);
+        if (rPrEnd < 0) {
+            return '';
+        }
+        return output.substring(rPrStart, rPrEnd + 8);
     }
 
     private static Object resolveValue(Map<String, Object> data, String path) {

--- a/scripts/e2e-07-syntax.apex
+++ b/scripts/e2e-07-syntax.apex
@@ -313,6 +313,14 @@ try {
     else { fail++; System.debug('DATE de_DE: FAIL — ' + r); }
 } catch (Exception e) { fail++; System.debug('DATE de_DE: FAIL — ' + e.getMessage()); }
 
+// ===== Textarea newline preserves formatting #32 =====
+try {
+    r = DocGenService.processXmlForTest('<w:r><w:rPr><w:sz w:val="28"/></w:rPr><w:t>{Desc}</w:t></w:r>', new Map<String, Object>{'Desc'=>'Line1\nLine2'});
+    Integer brCount = r.countMatches('<w:sz w:val="28"/>');
+    if (r.contains('w:br') && brCount >= 3 && r.contains('Line1') && r.contains('Line2')) { pass++; System.debug('TEXTAREA NEWLINE FMT: PASS'); }
+    else { fail++; System.debug('TEXTAREA NEWLINE FMT: FAIL — szCount=' + brCount + ' — ' + r); }
+} catch (Exception e) { fail++; System.debug('TEXTAREA NEWLINE FMT: FAIL — ' + e.getMessage()); }
+
 System.debug('========================================');
 System.debug('E2E-07 SYNTAX — PASS: ' + pass + '  FAIL: ' + fail + (fail == 0 ? '  ALL TESTS PASSED' : '  FAILURES DETECTED'));
 System.debug('========================================');


### PR DESCRIPTION
## Summary

Fixes issue #32

## Changes

- In DocGenService, convertMultilinetoXml didn't carry over run properties.

Root cause: convertMultilineToXml() in DocGenService.cls:2210 was generating bare <w:r> runs for each line break without carrying forward the <w:rPr> (run properties — font family, size, bold, italic, etc.) from the original run. Word defaults to its base style for runs without explicit properties, so all lines after the first lost their formatting.

## Testing

- [x] Ran E2E tests (`sf apex run --target-org <org> -f scripts/e2e-test.apex`) — all passing
- [x] Ran Apex unit tests (`sf apex run test --synchronous --code-coverage`) — all passing
- [x] Tested manually in a scratch org (my first time using a scratch org instead of a sandbox btw, very cool!)
- [x] Added/updated E2E test assertions for new behavior

## Related Issues

Fixes #32

## Checklist

- [x] No hardcoded IDs, URLs, or credentials
- [x] No `VersionData` in PDF image queries (see CLAUDE.md)
- [x] SOQL uses `WITH USER_MODE` or `Security.stripInaccessible()` where appropriate
- [x] No new external dependencies introduced
