### PR TITLE
feat: Enhance DocGenRunner with configurable output options & UI improvements

### DIFF
--- a/force-app/main/default/lwc/docGenRunner/docGenRunner.html
+++ b/force-app/main/default/lwc/docGenRunner/docGenRunner.html
@@ -1,312 +1,363 @@
 <template>
-    <div class="runner-widget">
-        <div class="widget-header">
-            <div class="header-title">
-                <lightning-icon icon-name="standard:document" size="small" class="slds-var-m-right_x-small"></lightning-icon>
-                <h2>DocGen</h2>
-            </div>
-            <p class="header-subtitle">Create or combine documents for this record.</p>
-        </div>
-
-        <div class="widget-body">
-            <template lwc:if={error}>
-                <div class="error-alert">
-                    <strong>Error:</strong> {error}
-                </div>
-            </template>
-
-            <template lwc:if={isLoading}>
-                 <div class="loading-state">
-                     <lightning-spinner alternative-text="Loading" size="medium"></lightning-spinner>
-                     <template lwc:if={loadingMessage}>
-                         <p class="slds-text-body_small slds-text-color_weak slds-var-m-top_small">{loadingMessage}</p>
-                     </template>
-                     <template lwc:if={showProgressBar}>
-                         <div class="progress-bar-container slds-var-m-top_small">
-                             <div class="progress-bar-track">
-                                 <div class="progress-bar-fill" style={progressBarStyle}></div>
-                             </div>
-                             <p class="progress-bar-label">{progressPercent}%</p>
-                         </div>
-                     </template>
-                 </div>
-            </template>
-
-            <template lwc:else>
-                <!-- Custom Mode Selector (Segmented Control) -->
-                <div class="custom-segmented-control slds-var-m-bottom_medium">
-                    <template for:each={modernModeOptions} for:item="opt">
-                        <button 
-                            key={opt.value} 
-                            class={opt.class} 
-                            data-value={opt.value} 
-                            onclick={handleModeChangeInternal}>
-                            {opt.label}
-                        </button>
-                    </template>
-                </div>
-
-                <!-- GENERATE MODE -->
-                <template lwc:if={isGenerateMode}>
-                    <!-- 1.47 — Empty state -->
-                    <template lwc:if={showEmptyState}>
-                        <div class="slds-box slds-theme_shade slds-var-m-bottom_medium" style="text-align: center;">
-                            <p class="slds-text-body_regular slds-text-color_weak">{emptyStateMessage}</p>
-                        </div>
-                    </template>
-
-                    <!-- 1.47 — Category filter (only shown when 2+ categories exist) -->
-                    <template lwc:if={showCategoryFilter}>
-                        <div class="slds-form-element slds-var-m-bottom_medium">
-                            <label class="slds-form-element__label">Category</label>
-                            <div class="slds-form-element__control">
-                                <select class="custom-select" onchange={handleCategoryChange}>
-                                    <template for:each={categoryOptions} for:item="cat">
-                                        <option key={cat.value} value={cat.value}>{cat.label}</option>
-                                    </template>
-                                </select>
-                            </div>
-                        </div>
-                    </template>
-
-                    <div class="slds-form-element slds-var-m-bottom_medium">
-                        <label class="slds-form-element__label">Select Template</label>
-                        <div class="slds-form-element__control">
-                            <select class="custom-select" onchange={handleTemplateChangeInternal}>
-                                <option value="">Choose a template...</option>
-                                <template for:each={templateOptions} for:item="tmpl">
-                                    <option key={tmpl.value} value={tmpl.value} selected={tmpl.selected}>{tmpl.label}</option>
-                                </template>
-                            </select>
-                        </div>
-                    </div>
-
-                    <!-- 1.47 — Output format override (hidden when template locks format or only one format applies) -->
-                    <template lwc:if={showOutputFormatPicker}>
-                        <div class="slds-form-element slds-var-m-bottom_medium">
-                            <label class="slds-form-element__label">Output As</label>
-                            <div class="slds-form-element__control">
-                                <select class="custom-select" onchange={handleOutputFormatOverrideChange}>
-                                    <option value="">Use template default</option>
-                                    <template for:each={outputFormatPickerOptions} for:item="opt">
-                                        <option key={opt.value} value={opt.value}>{opt.label}</option>
-                                    </template>
-                                </select>
-                            </div>
-                        </div>
-                    </template>
-
-                    <!-- Custom Output Selector -->
-                    <div class="slds-form-element slds-var-m-bottom_medium">
-                        <label class="slds-form-element__label">Output Destination</label>
-                        <div class="custom-mini-pills">
-                            <template for:each={modernOutputOptions} for:item="out">
-                                <button 
-                                    key={out.value} 
-                                    class={out.class} 
-                                    data-value={out.value} 
-                                    onclick={handleOutputModeChangeInternal}>
-                                    {out.label}
-                                </button>
-                            </template>
-                        </div>
-                    </div>
-
-                    <!-- PDF Merge Toggle -->
-                    <template lwc:if={showMergeOption}>
-                        <div class="slds-var-m-bottom_medium">
-                            <lightning-input
-                                type="checkbox"
-                                label="Combine with existing PDFs on this record"
-                                checked={mergeEnabled}
-                                onchange={handleMergeToggle}
-                                class="custom-checkbox">
-                            </lightning-input>
-                        </div>
-
-                        <template lwc:if={mergeEnabled}>
-                            <div class="merge-box">
-                                <template lwc:if={hasRecordPdfs}>
-                                    <p class="slds-text-body_small slds-var-m-bottom_x-small">Select PDFs to append:</p>
-                                    <div class="checkbox-list">
-                                        <template for:each={recordPdfOptions} for:item="pdf">
-                                            <div key={pdf.value} class="checkbox-item">
-                                                <input type="checkbox" value={pdf.value} onchange={handlePdfSelectionInternal} />
-                                                <span>{pdf.label}</span>
-                                            </div>
-                                        </template>
-                                    </div>
-                                </template>
-                                <template lwc:else>
-                                    <p class="slds-text-body_small slds-text-color_weak">No other PDFs found here.</p>
-                                </template>
-                            </div>
-                        </template>
-                    </template>
-
-                    <button class="cool-brand-btn" onclick={handleGenerate} disabled={isGenerateDisabled}>
-                        {generateButtonLabel}
-                    </button>
-                </template>
-
-                <!-- PACKET MODE -->
-                <template lwc:if={isPacketMode}>
-                    <div class="slds-var-m-bottom_medium">
-                        <lightning-dual-listbox
-                            name="packetTemplates"
-                            label="Packet Templates"
-                            source-label="Available"
-                            selected-label="In Packet"
-                            options={pdfTemplateOptions}
-                            value={packetTemplateIds}
-                            onchange={handlePacketTemplateSelection}
-                            variant="label-hidden">
-                        </lightning-dual-listbox>
-                    </div>
-
-                    <div class="slds-var-m-bottom_medium">
-                        <lightning-input
-                            type="checkbox"
-                            label="Include other PDFs from this record"
-                            checked={packetIncludeExisting}
-                            onchange={handlePacketIncludeToggle}
-                            class="custom-checkbox">
-                        </lightning-input>
-                    </div>
-
-                    <div class="slds-form-element slds-var-m-bottom_medium">
-                        <label class="slds-form-element__label">Output Destination</label>
-                        <div class="custom-mini-pills">
-                            <template for:each={modernOutputOptions} for:item="out">
-                                <button 
-                                    key={out.value} 
-                                    class={out.class} 
-                                    data-value={out.value} 
-                                    onclick={handleOutputModeChangeInternal}>
-                                    {out.label}
-                                </button>
-                            </template>
-                        </div>
-                    </div>
-
-                    <button class="cool-brand-btn" onclick={generatePacket} disabled={isPacketDisabled}>
-                        {packetButtonLabel}
-                    </button>
-                </template>
-
-                <!-- MERGE ONLY MODE -->
-                <template lwc:if={isMergeOnlyMode}>
-                    <div class="merge-box">
-                        <template lwc:if={hasRecordPdfs}>
-                            <lightning-dual-listbox
-                                name="mergeOnlySelection"
-                                label="Merge Order"
-                                source-label="Available"
-                                selected-label="Combine"
-                                options={recordPdfOptions}
-                                value={mergeOnlyCvIds}
-                                onchange={handleMergeOnlySelection}
-                                variant="label-hidden">
-                            </lightning-dual-listbox>
-                        </template>
-                        <template lwc:else>
-                            <p class="slds-text-body_small slds-text-color_weak">No PDF files found to combine.</p>
-                        </template>
-                    </div>
-
-                    <div class="slds-form-element slds-var-m-bottom_medium">
-                        <label class="slds-form-element__label">Output Destination</label>
-                        <div class="custom-mini-pills">
-                            <template for:each={modernOutputOptions} for:item="out">
-                                <button 
-                                    key={out.value} 
-                                    class={out.class} 
-                                    data-value={out.value} 
-                                    onclick={handleOutputModeChangeInternal}>
-                                    {out.label}
-                                </button>
-                            </template>
-                        </div>
-                    </div>
-
-                    <button class="cool-brand-btn" onclick={mergeOnlyDocument} disabled={isMergeOnlyDisabled}>
-                        {mergeOnlyButtonLabel}
-                    </button>
-                </template>
-
-                <!-- MERGE CHILD RECORD PDFs MODE -->
-                <template lwc:if={isMergeChildrenMode}>
-                    <div class="slds-form-element slds-var-m-bottom_medium">
-                        <label class="slds-form-element__label">Source List</label>
-                        <div class="slds-form-element__control">
-                            <select class="custom-select" onchange={handleChildRelChangeInternal}>
-                                <option value="">Select a child list...</option>
-                                <template for:each={childRelComboboxOptions} for:item="rel">
-                                    <option key={rel.value} value={rel.value}>{rel.label}</option>
-                                </template>
-                            </select>
-                        </div>
-                    </div>
-
-                    <template lwc:if={selectedChildRel}>
-                        <div class="slds-grid slds-grid_vertical-align-end slds-gutters_x-small slds-var-m-bottom_medium">
-                            <div class="slds-col slds-grow">
-                                <lightning-input
-                                    label="Filter Records"
-                                    placeholder="e.g. StageName = 'Closed Won'"
-                                    value={childFilterClause}
-                                    onchange={handleChildFilterChangeInternal}
-                                    variant="label-hidden">
-                                </lightning-input>
-                            </div>
-                            <div class="slds-col">
-                                <button class="pill-action-btn" onclick={handleLoadChildPdfs}>Find Files</button>
-                            </div>
-                        </div>
-                    </template>
-
-                    <template lwc:if={childPdfsLoaded}>
-                        <div class="merge-box" style="max-height: 250px; overflow-y: auto;">
-                            <template lwc:if={hasChildRecordGroups}>
-                                <template for:each={childRecordGroupsWithState} for:item="group">
-                                    <div key={group.childRecordId} class="slds-var-m-bottom_small">
-                                        <p class="slds-text-title_bold">{group.childRecordName}</p>
-                                        <template for:each={group.pdfs} for:item="pdf">
-                                            <div key={pdf.value} class="checkbox-item slds-var-m-left_small">
-                                                <input type="checkbox" checked={pdf.checked} data-cvid={pdf.value} onchange={handleChildPdfCheckbox} />
-                                                <span>{pdf.label}</span>
-                                            </div>
-                                        </template>
-                                    </div>
-                                </template>
-                            </template>
-                            <template lwc:else>
-                                <p class="slds-text-body_small slds-text-color_weak">No matching files found.</p>
-                            </template>
-                        </div>
-
-                        <div class="slds-form-element slds-var-m-bottom_medium">
-                            <label class="slds-form-element__label">Output Destination</label>
-                            <div class="custom-mini-pills">
-                                <template for:each={modernOutputOptions} for:item="out">
-                                    <button 
-                                        key={out.value} 
-                                        class={out.class} 
-                                        data-value={out.value} 
-                                        onclick={handleOutputModeChangeInternal}>
-                                        {out.label}
-                                    </button>
-                                </template>
-                            </div>
-                        </div>
-
-                        <button class="cool-brand-btn" onclick={mergeChildrenDocument} disabled={isMergeChildrenDisabled}>
-                            {mergeChildrenButtonLabel}
-                        </button>
-                    </template>
-                </template>
-
-            </template>
-        </div>
+  <div class="runner-widget">
+    <div class="widget-header">
+      <div class="header-title">
+        <lightning-icon
+          icon-name="standard:document"
+          size="small"
+          class="slds-var-m-right_x-small"
+        ></lightning-icon>
+        <h2>DocGen</h2>
+      </div>
+      <p class="header-subtitle">Create or combine documents for this record.</p>
     </div>
+
+    <div class="widget-body">
+      <template lwc:if={error}>
+        <div class="error-alert"><strong>Error:</strong> {error}</div>
+      </template>
+
+      <template lwc:if={isLoading}>
+        <div class="loading-state">
+          <lightning-spinner alternative-text="Loading" size="medium"></lightning-spinner>
+          <template lwc:if={loadingMessage}>
+            <p class="slds-text-body_small slds-text-color_weak slds-var-m-top_small">
+              {loadingMessage}
+            </p>
+          </template>
+          <template lwc:if={showProgressBar}>
+            <div class="progress-bar-container slds-var-m-top_small">
+              <lightning-progress-bar value={progressPercent} size="medium"></lightning-progress-bar>
+              <p class="progress-bar-label">{progressPercent}%</p>
+            </div>
+          </template>
+        </div>
+      </template>
+
+      <template lwc:else>
+        <!-- Custom Mode Selector (Segmented Control) -->
+        <div lwc:if={showModeSelector} class="custom-segmented-control slds-var-m-bottom_medium">
+          <template for:each={modernModeOptions} for:item="opt">
+            <button
+              key={opt.value}
+              class={opt.class}
+              data-value={opt.value}
+              onclick={handleModeChangeInternal}
+            >
+              {opt.label}
+            </button>
+          </template>
+        </div>
+
+        <!-- GENERATE MODE -->
+        <template lwc:if={isGenerateMode}>
+          <!-- 1.47 — Empty state -->
+          <template lwc:if={showEmptyState}>
+            <div
+              class="slds-box slds-theme_shade slds-var-m-bottom_medium"
+              style="text-align: center"
+            >
+              <p class="slds-text-body_regular slds-text-color_weak">{emptyStateMessage}</p>
+            </div>
+          </template>
+
+          <!-- 1.47 — Category filter (only shown when 2+ categories exist) -->
+          <template lwc:if={showCategoryFilter}>
+            <div class="slds-form-element slds-var-m-bottom_medium">
+              <label class="slds-form-element__label">Category</label>
+              <div class="slds-form-element__control">
+                <select class="custom-select" onchange={handleCategoryChange}>
+                  <template for:each={categoryOptions} for:item="cat">
+                    <option key={cat.value} value={cat.value}>{cat.label}</option>
+                  </template>
+                </select>
+              </div>
+            </div>
+          </template>
+
+          <div class="slds-form-element slds-var-m-bottom_medium">
+            <label class="slds-form-element__label">Select Template</label>
+            <div class="slds-form-element__control">
+              <select class="custom-select" onchange={handleTemplateChangeInternal}>
+                <option value="">Choose a template...</option>
+                <template for:each={templateOptions} for:item="tmpl">
+                  <option key={tmpl.value} value={tmpl.value} selected={tmpl.selected}>
+                    {tmpl.label}
+                  </option>
+                </template>
+              </select>
+            </div>
+          </div>
+
+          <!-- 1.47 — Output format override (hidden when template locks format or only one format applies) -->
+          <template lwc:if={showOutputFormatPicker}>
+            <div class="slds-form-element slds-var-m-bottom_medium">
+              <label class="slds-form-element__label">Output As</label>
+              <div class="slds-form-element__control">
+                <select class="custom-select" onchange={handleOutputFormatOverrideChange}>
+                  <option value="">Use template default</option>
+                  <template for:each={outputFormatPickerOptions} for:item="opt">
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  </template>
+                </select>
+              </div>
+            </div>
+          </template>
+
+          <!-- Custom Output Selector -->
+          <div
+            lwc:if={showOutputDestinationSelector}
+            class="slds-form-element slds-var-m-bottom_medium"
+          >
+            <label class="slds-form-element__label">Output Destination</label>
+            <div class="custom-mini-pills">
+              <template for:each={modernOutputOptions} for:item="out">
+                <button
+                  key={out.value}
+                  class={out.class}
+                  data-value={out.value}
+                  onclick={handleOutputModeChangeInternal}
+                >
+                  {out.label}
+                </button>
+              </template>
+            </div>
+          </div>
+
+          <!-- PDF Merge Toggle -->
+          <template lwc:if={showMergeOption}>
+            <div class="slds-var-m-bottom_medium">
+              <lightning-input
+                type="checkbox"
+                label="Combine with existing PDFs on this record"
+                checked={mergeEnabled}
+                onchange={handleMergeToggle}
+                class="custom-checkbox"
+              >
+              </lightning-input>
+            </div>
+
+            <template lwc:if={mergeEnabled}>
+              <div class="merge-box">
+                <template lwc:if={hasRecordPdfs}>
+                  <p class="slds-text-body_small slds-var-m-bottom_x-small">
+                    Select PDFs to append:
+                  </p>
+                  <div class="checkbox-list">
+                    <template for:each={recordPdfOptions} for:item="pdf">
+                      <div key={pdf.value} class="checkbox-item">
+                        <input
+                          type="checkbox"
+                          value={pdf.value}
+                          onchange={handlePdfSelectionInternal}
+                        />
+                        <span>{pdf.label}</span>
+                      </div>
+                    </template>
+                  </div>
+                </template>
+                <template lwc:else>
+                  <p class="slds-text-body_small slds-text-color_weak">No other PDFs found here.</p>
+                </template>
+              </div>
+            </template>
+          </template>
+
+          <button class="cool-brand-btn" onclick={handleGenerate} disabled={isGenerateDisabled}>
+            {generateButtonLabel}
+          </button>
+        </template>
+
+        <!-- PACKET MODE -->
+        <template lwc:if={isPacketMode}>
+          <div class="slds-var-m-bottom_medium">
+            <lightning-dual-listbox
+              name="packetTemplates"
+              label="Packet Templates"
+              source-label="Available"
+              selected-label="In Packet"
+              options={pdfTemplateOptions}
+                value={packetTemplateIds}
+              onchange={handlePacketTemplateSelection}
+              variant="label-hidden"
+            >
+            </lightning-dual-listbox>
+          </div>
+
+          <div lwc:if={canUseCombineWithExistingPdfs} class="slds-var-m-bottom_medium">
+            <lightning-input
+              type="checkbox"
+              label="Include other PDFs from this record"
+              checked={packetIncludeExisting}
+              onchange={handlePacketIncludeToggle}
+              class="custom-checkbox"
+            >
+            </lightning-input>
+          </div>
+
+          <div
+            lwc:if={showOutputDestinationSelector}
+            class="slds-form-element slds-var-m-bottom_medium"
+          >
+            <label class="slds-form-element__label">Output Destination</label>
+            <div class="custom-mini-pills">
+              <template for:each={modernOutputOptions} for:item="out">
+                <button
+                  key={out.value}
+                  class={out.class}
+                  data-value={out.value}
+                  onclick={handleOutputModeChangeInternal}
+                >
+                  {out.label}
+                </button>
+              </template>
+            </div>
+          </div>
+
+          <button class="cool-brand-btn" onclick={generatePacket} disabled={isPacketDisabled}>
+            {packetButtonLabel}
+          </button>
+        </template>
+
+        <!-- MERGE ONLY MODE -->
+          <template lwc:if={isMergeOnlyMode}>
+          <div class="merge-box">
+            <template lwc:if={hasRecordPdfs}>
+              <lightning-dual-listbox
+                name="mergeOnlySelection"
+                label="Merge Order"
+                source-label="Available"
+                selected-label="Combine"
+                options={recordPdfOptions}
+                value={mergeOnlyCvIds}
+                onchange={handleMergeOnlySelection}
+                variant="label-hidden"
+              >
+              </lightning-dual-listbox>
+            </template>
+            <template lwc:else>
+              <p class="slds-text-body_small slds-text-color_weak">
+                No PDF files found to combine.
+              </p>
+            </template>
+          </div>
+
+          <div
+            lwc:if={showOutputDestinationSelector}
+            class="slds-form-element slds-var-m-bottom_medium"
+          >
+            <label class="slds-form-element__label">Output Destination</label>
+            <div class="custom-mini-pills">
+              <template for:each={modernOutputOptions} for:item="out">
+                <button
+                  key={out.value}
+                  class={out.class}
+                  data-value={out.value}
+                  onclick={handleOutputModeChangeInternal}
+                >
+                  {out.label}
+                </button>
+              </template>
+            </div>
+          </div>
+
+          <button
+            class="cool-brand-btn"
+            onclick={mergeOnlyDocument}
+            disabled={isMergeOnlyDisabled}
+          >
+            {mergeOnlyButtonLabel}
+          </button>
+        </template>
+
+        <!-- MERGE CHILD RECORD PDFs MODE -->
+          <template lwc:if={isMergeChildrenMode}>
+          <div class="slds-form-element slds-var-m-bottom_medium">
+            <label class="slds-form-element__label">Source List</label>
+            <div class="slds-form-element__control">
+              <select class="custom-select" onchange={handleChildRelChangeInternal}>
+                <option value="">Select a child list...</option>
+                <template for:each={childRelComboboxOptions} for:item="rel">
+                  <option key={rel.value} value={rel.value}>{rel.label}</option>
+                </template>
+              </select>
+            </div>
+          </div>
+
+          <template lwc:if={selectedChildRel}>
+            <div
+              class="slds-grid slds-grid_vertical-align-end slds-gutters_x-small slds-var-m-bottom_medium"
+            >
+              <div class="slds-col slds-grow">
+                <lightning-input
+                  label="Filter Records"
+                  placeholder="e.g. StageName = 'Closed Won'"
+                  value={childFilterClause}
+                  onchange={handleChildFilterChangeInternal}
+                  variant="label-hidden"
+                >
+                </lightning-input>
+              </div>
+              <div class="slds-col">
+                <button class="pill-action-btn" onclick={handleLoadChildPdfs}>Find Files</button>
+              </div>
+            </div>
+          </template>
+
+          <template lwc:if={childPdfsLoaded}>
+            <div class="merge-box" style="max-height: 250px; overflow-y: auto">
+              <template lwc:if={hasChildRecordGroups}>
+                <template for:each={childRecordGroupsWithState} for:item="group">
+                  <div key={group.childRecordId} class="slds-var-m-bottom_small">
+                    <p class="slds-text-title_bold">{group.childRecordName}</p>
+                    <template for:each={group.pdfs} for:item="pdf">
+                      <div key={pdf.value} class="checkbox-item slds-var-m-left_small">
+                        <input
+                          type="checkbox"
+                          checked={pdf.checked}
+                          data-cvid={pdf.value}
+                          onchange={handleChildPdfCheckbox}
+                        />
+                        <span>{pdf.label}</span>
+                      </div>
+                    </template>
+                  </div>
+                </template>
+              </template>
+              <template lwc:else>
+                <p class="slds-text-body_small slds-text-color_weak">No matching files found.</p>
+              </template>
+            </div>
+
+            <div
+              lwc:if={showOutputDestinationSelector}
+              class="slds-form-element slds-var-m-bottom_medium"
+            >
+              <label class="slds-form-element__label">Output Destination</label>
+              <div class="custom-mini-pills">
+                <template for:each={modernOutputOptions} for:item="out">
+                  <button
+                    key={out.value}
+                    class={out.class}
+                    data-value={out.value}
+                    onclick={handleOutputModeChangeInternal}
+                  >
+                    {out.label}
+                  </button>
+                </template>
+              </div>
+            </div>
+
+            <button
+              class="cool-brand-btn"
+              onclick={mergeChildrenDocument}
+              disabled={isMergeChildrenDisabled}
+            >
+              {mergeChildrenButtonLabel}
+            </button>
+          </template>
+        </template>
+      </template>
+    </div>
+  </div>
 </template>

--- a/force-app/main/default/lwc/docGenRunner/docGenRunner.html
+++ b/force-app/main/default/lwc/docGenRunner/docGenRunner.html
@@ -2,7 +2,11 @@
     <div class="runner-widget">
         <div class="widget-header">
             <div class="header-title">
-                <lightning-icon icon-name="standard:document" size="small" class="slds-var-m-right_x-small"></lightning-icon>
+                <lightning-icon
+                    icon-name="standard:document"
+                    size="small"
+                    class="slds-var-m-right_x-small"
+                ></lightning-icon>
                 <h2>DocGen</h2>
             </div>
             <p class="header-subtitle">Create or combine documents for this record.</p>
@@ -32,7 +36,14 @@
                 <!-- Custom Mode Selector (Segmented Control) -->
                 <div lwc:if={showModeSelector} class="custom-segmented-control slds-var-m-bottom_medium">
                     <template for:each={modernModeOptions} for:item="opt">
-                        <button key={opt.value} class={opt.class} data-value={opt.value} onclick={handleModeChangeInternal}>{opt.label}</button>
+                        <button
+                            key={opt.value}
+                            class={opt.class}
+                            data-value={opt.value}
+                            onclick={handleModeChangeInternal}
+                        >
+                            {opt.label}
+                        </button>
                     </template>
                 </div>
 
@@ -65,7 +76,9 @@
                             <select class="custom-select" onchange={handleTemplateChangeInternal}>
                                 <option value="">Choose a template...</option>
                                 <template for:each={templateOptions} for:item="tmpl">
-                                    <option key={tmpl.value} value={tmpl.value} selected={tmpl.selected}>{tmpl.label}</option>
+                                    <option key={tmpl.value} value={tmpl.value} selected={tmpl.selected}>
+                                        {tmpl.label}
+                                    </option>
                                 </template>
                             </select>
                         </div>
@@ -91,7 +104,14 @@
                         <label class="slds-form-element__label">Output Destination</label>
                         <div class="custom-mini-pills">
                             <template for:each={modernOutputOptions} for:item="out">
-                                <button key={out.value} class={out.class} data-value={out.value} onclick={handleOutputModeChangeInternal}>{out.label}</button>
+                                <button
+                                    key={out.value}
+                                    class={out.class}
+                                    data-value={out.value}
+                                    onclick={handleOutputModeChangeInternal}
+                                >
+                                    {out.label}
+                                </button>
                             </template>
                         </div>
                     </div>
@@ -99,7 +119,13 @@
                     <!-- PDF Merge Toggle -->
                     <template lwc:if={showMergeOption}>
                         <div class="slds-var-m-bottom_medium">
-                            <lightning-input type="checkbox" label="Combine with existing PDFs on this record" checked={mergeEnabled} onchange={handleMergeToggle} class="custom-checkbox">
+                            <lightning-input
+                                type="checkbox"
+                                label="Combine with existing PDFs on this record"
+                                checked={mergeEnabled}
+                                onchange={handleMergeToggle}
+                                class="custom-checkbox"
+                            >
                             </lightning-input>
                         </div>
 
@@ -110,7 +136,11 @@
                                     <div class="checkbox-list">
                                         <template for:each={recordPdfOptions} for:item="pdf">
                                             <div key={pdf.value} class="checkbox-item">
-                                                <input type="checkbox" value={pdf.value} onchange={handlePdfSelectionInternal} />
+                                                <input
+                                                    type="checkbox"
+                                                    value={pdf.value}
+                                                    onchange={handlePdfSelectionInternal}
+                                                />
                                                 <span>{pdf.label}</span>
                                             </div>
                                         </template>
@@ -123,7 +153,9 @@
                         </template>
                     </template>
 
-                    <button class="cool-brand-btn" onclick={handleGenerate} disabled={isGenerateDisabled}>{generateButtonLabel}</button>
+                    <button class="cool-brand-btn" onclick={handleGenerate} disabled={isGenerateDisabled}>
+                        {generateButtonLabel}
+                    </button>
                 </template>
 
                 <!-- PACKET MODE -->
@@ -143,7 +175,13 @@
                     </div>
 
                     <div lwc:if={canUseCombineWithExistingPdfs} class="slds-var-m-bottom_medium">
-                        <lightning-input type="checkbox" label="Include other PDFs from this record" checked={packetIncludeExisting} onchange={handlePacketIncludeToggle} class="custom-checkbox">
+                        <lightning-input
+                            type="checkbox"
+                            label="Include other PDFs from this record"
+                            checked={packetIncludeExisting}
+                            onchange={handlePacketIncludeToggle}
+                            class="custom-checkbox"
+                        >
                         </lightning-input>
                     </div>
 
@@ -151,12 +189,21 @@
                         <label class="slds-form-element__label">Output Destination</label>
                         <div class="custom-mini-pills">
                             <template for:each={modernOutputOptions} for:item="out">
-                                <button key={out.value} class={out.class} data-value={out.value} onclick={handleOutputModeChangeInternal}>{out.label}</button>
+                                <button
+                                    key={out.value}
+                                    class={out.class}
+                                    data-value={out.value}
+                                    onclick={handleOutputModeChangeInternal}
+                                >
+                                    {out.label}
+                                </button>
                             </template>
                         </div>
                     </div>
 
-                    <button class="cool-brand-btn" onclick={generatePacket} disabled={isPacketDisabled}>{packetButtonLabel}</button>
+                    <button class="cool-brand-btn" onclick={generatePacket} disabled={isPacketDisabled}>
+                        {packetButtonLabel}
+                    </button>
                 </template>
 
                 <!-- MERGE ONLY MODE -->
@@ -184,12 +231,21 @@
                         <label class="slds-form-element__label">Output Destination</label>
                         <div class="custom-mini-pills">
                             <template for:each={modernOutputOptions} for:item="out">
-                                <button key={out.value} class={out.class} data-value={out.value} onclick={handleOutputModeChangeInternal}>{out.label}</button>
+                                <button
+                                    key={out.value}
+                                    class={out.class}
+                                    data-value={out.value}
+                                    onclick={handleOutputModeChangeInternal}
+                                >
+                                    {out.label}
+                                </button>
                             </template>
                         </div>
                     </div>
 
-                    <button class="cool-brand-btn" onclick={mergeOnlyDocument} disabled={isMergeOnlyDisabled}>{mergeOnlyButtonLabel}</button>
+                    <button class="cool-brand-btn" onclick={mergeOnlyDocument} disabled={isMergeOnlyDisabled}>
+                        {mergeOnlyButtonLabel}
+                    </button>
                 </template>
 
                 <!-- MERGE CHILD RECORD PDFs MODE -->
@@ -207,7 +263,9 @@
                     </div>
 
                     <template lwc:if={selectedChildRel}>
-                        <div class="slds-grid slds-grid_vertical-align-end slds-gutters_x-small slds-var-m-bottom_medium">
+                        <div
+                            class="slds-grid slds-grid_vertical-align-end slds-gutters_x-small slds-var-m-bottom_medium"
+                        >
                             <div class="slds-col slds-grow">
                                 <lightning-input
                                     label="Filter Records"
@@ -232,7 +290,12 @@
                                         <p class="slds-text-title_bold">{group.childRecordName}</p>
                                         <template for:each={group.pdfs} for:item="pdf">
                                             <div key={pdf.value} class="checkbox-item slds-var-m-left_small">
-                                                <input type="checkbox" checked={pdf.checked} data-cvid={pdf.value} onchange={handleChildPdfCheckbox} />
+                                                <input
+                                                    type="checkbox"
+                                                    checked={pdf.checked}
+                                                    data-cvid={pdf.value}
+                                                    onchange={handleChildPdfCheckbox}
+                                                />
                                                 <span>{pdf.label}</span>
                                             </div>
                                         </template>
@@ -248,12 +311,25 @@
                             <label class="slds-form-element__label">Output Destination</label>
                             <div class="custom-mini-pills">
                                 <template for:each={modernOutputOptions} for:item="out">
-                                    <button key={out.value} class={out.class} data-value={out.value} onclick={handleOutputModeChangeInternal}>{out.label}</button>
+                                    <button
+                                        key={out.value}
+                                        class={out.class}
+                                        data-value={out.value}
+                                        onclick={handleOutputModeChangeInternal}
+                                    >
+                                        {out.label}
+                                    </button>
                                 </template>
                             </div>
                         </div>
 
-                        <button class="cool-brand-btn" onclick={mergeChildrenDocument} disabled={isMergeChildrenDisabled}>{mergeChildrenButtonLabel}</button>
+                        <button
+                            class="cool-brand-btn"
+                            onclick={mergeChildrenDocument}
+                            disabled={isMergeChildrenDisabled}
+                        >
+                            {mergeChildrenButtonLabel}
+                        </button>
                     </template>
                 </template>
             </template>

--- a/force-app/main/default/lwc/docGenRunner/docGenRunner.html
+++ b/force-app/main/default/lwc/docGenRunner/docGenRunner.html
@@ -2,16 +2,10 @@
     <div class="runner-widget">
         <div class="widget-header">
             <div class="header-title">
-                <lightning-icon
-                    icon-name="standard:document"
-                    size="small"
-                    class="slds-var-m-right_x-small"
-                ></lightning-icon>
+                <lightning-icon icon-name="standard:document" size="small" class="slds-var-m-right_x-small"></lightning-icon>
                 <h2>DocGen</h2>
             </div>
-            <p class="header-subtitle">
-                Create or combine documents for this record.
-            </p>
+            <p class="header-subtitle">Create or combine documents for this record.</p>
         </div>
 
         <div class="widget-body">
@@ -21,25 +15,13 @@
 
             <template lwc:if={isLoading}>
                 <div class="loading-state">
-                    <lightning-spinner
-                        alternative-text="Loading"
-                        size="medium"
-                    ></lightning-spinner>
+                    <lightning-spinner alternative-text="Loading" size="medium"></lightning-spinner>
                     <template lwc:if={loadingMessage}>
-                        <p
-                            class="slds-text-body_small slds-text-color_weak slds-var-m-top_small"
-                        >
-                            {loadingMessage}
-                        </p>
+                        <p class="slds-text-body_small slds-text-color_weak slds-var-m-top_small">{loadingMessage}</p>
                     </template>
                     <template lwc:if={showProgressBar}>
-                        <div
-                            class="progress-bar-container slds-var-m-top_small"
-                        >
-                            <lightning-progress-bar
-                                value={progressPercent}
-                                size="medium"
-                            ></lightning-progress-bar>
+                        <div class="progress-bar-container slds-var-m-top_small">
+                            <lightning-progress-bar value={progressPercent} size="medium"></lightning-progress-bar>
                             <p class="progress-bar-label">{progressPercent}%</p>
                         </div>
                     </template>
@@ -48,19 +30,9 @@
 
             <template lwc:else>
                 <!-- Custom Mode Selector (Segmented Control) -->
-                <div
-                    lwc:if={showModeSelector}
-                    class="custom-segmented-control slds-var-m-bottom_medium"
-                >
+                <div lwc:if={showModeSelector} class="custom-segmented-control slds-var-m-bottom_medium">
                     <template for:each={modernModeOptions} for:item="opt">
-                        <button
-                            key={opt.value}
-                            class={opt.class}
-                            data-value={opt.value}
-                            onclick={handleModeChangeInternal}
-                        >
-                            {opt.label}
-                        </button>
+                        <button key={opt.value} class={opt.class} data-value={opt.value} onclick={handleModeChangeInternal}>{opt.label}</button>
                     </template>
                 </div>
 
@@ -68,39 +40,19 @@
                 <template lwc:if={isGenerateMode}>
                     <!-- 1.47 — Empty state -->
                     <template lwc:if={showEmptyState}>
-                        <div
-                            class="slds-box slds-theme_shade slds-var-m-bottom_medium"
-                            style="text-align: center"
-                        >
-                            <p
-                                class="slds-text-body_regular slds-text-color_weak"
-                            >
-                                {emptyStateMessage}
-                            </p>
+                        <div class="slds-box slds-theme_shade slds-var-m-bottom_medium" style="text-align: center">
+                            <p class="slds-text-body_regular slds-text-color_weak">{emptyStateMessage}</p>
                         </div>
                     </template>
 
                     <!-- 1.47 — Category filter (only shown when 2+ categories exist) -->
                     <template lwc:if={showCategoryFilter}>
                         <div class="slds-form-element slds-var-m-bottom_medium">
-                            <label class="slds-form-element__label"
-                                >Category</label
-                            >
+                            <label class="slds-form-element__label">Category</label>
                             <div class="slds-form-element__control">
-                                <select
-                                    class="custom-select"
-                                    onchange={handleCategoryChange}
-                                >
-                                    <template
-                                        for:each={categoryOptions}
-                                        for:item="cat"
-                                    >
-                                        <option
-                                            key={cat.value}
-                                            value={cat.value}
-                                        >
-                                            {cat.label}
-                                        </option>
+                                <select class="custom-select" onchange={handleCategoryChange}>
+                                    <template for:each={categoryOptions} for:item="cat">
+                                        <option key={cat.value} value={cat.value}>{cat.label}</option>
                                     </template>
                                 </select>
                             </div>
@@ -108,26 +60,12 @@
                     </template>
 
                     <div class="slds-form-element slds-var-m-bottom_medium">
-                        <label class="slds-form-element__label"
-                            >Select Template</label
-                        >
+                        <label class="slds-form-element__label">Select Template</label>
                         <div class="slds-form-element__control">
-                            <select
-                                class="custom-select"
-                                onchange={handleTemplateChangeInternal}
-                            >
+                            <select class="custom-select" onchange={handleTemplateChangeInternal}>
                                 <option value="">Choose a template...</option>
-                                <template
-                                    for:each={templateOptions}
-                                    for:item="tmpl"
-                                >
-                                    <option
-                                        key={tmpl.value}
-                                        value={tmpl.value}
-                                        selected={tmpl.selected}
-                                    >
-                                        {tmpl.label}
-                                    </option>
+                                <template for:each={templateOptions} for:item="tmpl">
+                                    <option key={tmpl.value} value={tmpl.value} selected={tmpl.selected}>{tmpl.label}</option>
                                 </template>
                             </select>
                         </div>
@@ -136,27 +74,12 @@
                     <!-- 1.47 — Output format override (hidden when template locks format or only one format applies) -->
                     <template lwc:if={showOutputFormatPicker}>
                         <div class="slds-form-element slds-var-m-bottom_medium">
-                            <label class="slds-form-element__label"
-                                >Output As</label
-                            >
+                            <label class="slds-form-element__label">Output As</label>
                             <div class="slds-form-element__control">
-                                <select
-                                    class="custom-select"
-                                    onchange={handleOutputFormatOverrideChange}
-                                >
-                                    <option value="">
-                                        Use template default
-                                    </option>
-                                    <template
-                                        for:each={outputFormatPickerOptions}
-                                        for:item="opt"
-                                    >
-                                        <option
-                                            key={opt.value}
-                                            value={opt.value}
-                                        >
-                                            {opt.label}
-                                        </option>
+                                <select class="custom-select" onchange={handleOutputFormatOverrideChange}>
+                                    <option value="">Use template default</option>
+                                    <template for:each={outputFormatPickerOptions} for:item="opt">
+                                        <option key={opt.value} value={opt.value}>{opt.label}</option>
                                     </template>
                                 </select>
                             </div>
@@ -164,26 +87,11 @@
                     </template>
 
                     <!-- Custom Output Selector -->
-                    <div
-                        lwc:if={showOutputDestinationSelector}
-                        class="slds-form-element slds-var-m-bottom_medium"
-                    >
-                        <label class="slds-form-element__label"
-                            >Output Destination</label
-                        >
+                    <div lwc:if={showOutputDestinationSelector} class="slds-form-element slds-var-m-bottom_medium">
+                        <label class="slds-form-element__label">Output Destination</label>
                         <div class="custom-mini-pills">
-                            <template
-                                for:each={modernOutputOptions}
-                                for:item="out"
-                            >
-                                <button
-                                    key={out.value}
-                                    class={out.class}
-                                    data-value={out.value}
-                                    onclick={handleOutputModeChangeInternal}
-                                >
-                                    {out.label}
-                                </button>
+                            <template for:each={modernOutputOptions} for:item="out">
+                                <button key={out.value} class={out.class} data-value={out.value} onclick={handleOutputModeChangeInternal}>{out.label}</button>
                             </template>
                         </div>
                     </div>
@@ -191,61 +99,31 @@
                     <!-- PDF Merge Toggle -->
                     <template lwc:if={showMergeOption}>
                         <div class="slds-var-m-bottom_medium">
-                            <lightning-input
-                                type="checkbox"
-                                label="Combine with existing PDFs on this record"
-                                checked={mergeEnabled}
-                                onchange={handleMergeToggle}
-                                class="custom-checkbox"
-                            >
+                            <lightning-input type="checkbox" label="Combine with existing PDFs on this record" checked={mergeEnabled} onchange={handleMergeToggle} class="custom-checkbox">
                             </lightning-input>
                         </div>
 
                         <template lwc:if={mergeEnabled}>
                             <div class="merge-box">
                                 <template lwc:if={hasRecordPdfs}>
-                                    <p
-                                        class="slds-text-body_small slds-var-m-bottom_x-small"
-                                    >
-                                        Select PDFs to append:
-                                    </p>
+                                    <p class="slds-text-body_small slds-var-m-bottom_x-small">Select PDFs to append:</p>
                                     <div class="checkbox-list">
-                                        <template
-                                            for:each={recordPdfOptions}
-                                            for:item="pdf"
-                                        >
-                                            <div
-                                                key={pdf.value}
-                                                class="checkbox-item"
-                                            >
-                                                <input
-                                                    type="checkbox"
-                                                    value={pdf.value}
-                                                    onchange={handlePdfSelectionInternal}
-                                                />
+                                        <template for:each={recordPdfOptions} for:item="pdf">
+                                            <div key={pdf.value} class="checkbox-item">
+                                                <input type="checkbox" value={pdf.value} onchange={handlePdfSelectionInternal} />
                                                 <span>{pdf.label}</span>
                                             </div>
                                         </template>
                                     </div>
                                 </template>
                                 <template lwc:else>
-                                    <p
-                                        class="slds-text-body_small slds-text-color_weak"
-                                    >
-                                        No other PDFs found here.
-                                    </p>
+                                    <p class="slds-text-body_small slds-text-color_weak">No other PDFs found here.</p>
                                 </template>
                             </div>
                         </template>
                     </template>
 
-                    <button
-                        class="cool-brand-btn"
-                        onclick={handleGenerate}
-                        disabled={isGenerateDisabled}
-                    >
-                        {generateButtonLabel}
-                    </button>
+                    <button class="cool-brand-btn" onclick={handleGenerate} disabled={isGenerateDisabled}>{generateButtonLabel}</button>
                 </template>
 
                 <!-- PACKET MODE -->
@@ -264,51 +142,21 @@
                         </lightning-dual-listbox>
                     </div>
 
-                    <div
-                        lwc:if={canUseCombineWithExistingPdfs}
-                        class="slds-var-m-bottom_medium"
-                    >
-                        <lightning-input
-                            type="checkbox"
-                            label="Include other PDFs from this record"
-                            checked={packetIncludeExisting}
-                            onchange={handlePacketIncludeToggle}
-                            class="custom-checkbox"
-                        >
+                    <div lwc:if={canUseCombineWithExistingPdfs} class="slds-var-m-bottom_medium">
+                        <lightning-input type="checkbox" label="Include other PDFs from this record" checked={packetIncludeExisting} onchange={handlePacketIncludeToggle} class="custom-checkbox">
                         </lightning-input>
                     </div>
 
-                    <div
-                        lwc:if={showOutputDestinationSelector}
-                        class="slds-form-element slds-var-m-bottom_medium"
-                    >
-                        <label class="slds-form-element__label"
-                            >Output Destination</label
-                        >
+                    <div lwc:if={showOutputDestinationSelector} class="slds-form-element slds-var-m-bottom_medium">
+                        <label class="slds-form-element__label">Output Destination</label>
                         <div class="custom-mini-pills">
-                            <template
-                                for:each={modernOutputOptions}
-                                for:item="out"
-                            >
-                                <button
-                                    key={out.value}
-                                    class={out.class}
-                                    data-value={out.value}
-                                    onclick={handleOutputModeChangeInternal}
-                                >
-                                    {out.label}
-                                </button>
+                            <template for:each={modernOutputOptions} for:item="out">
+                                <button key={out.value} class={out.class} data-value={out.value} onclick={handleOutputModeChangeInternal}>{out.label}</button>
                             </template>
                         </div>
                     </div>
 
-                    <button
-                        class="cool-brand-btn"
-                        onclick={generatePacket}
-                        disabled={isPacketDisabled}
-                    >
-                        {packetButtonLabel}
-                    </button>
+                    <button class="cool-brand-btn" onclick={generatePacket} disabled={isPacketDisabled}>{packetButtonLabel}</button>
                 </template>
 
                 <!-- MERGE ONLY MODE -->
@@ -328,75 +176,38 @@
                             </lightning-dual-listbox>
                         </template>
                         <template lwc:else>
-                            <p
-                                class="slds-text-body_small slds-text-color_weak"
-                            >
-                                No PDF files found to combine.
-                            </p>
+                            <p class="slds-text-body_small slds-text-color_weak">No PDF files found to combine.</p>
                         </template>
                     </div>
 
-                    <div
-                        lwc:if={showOutputDestinationSelector}
-                        class="slds-form-element slds-var-m-bottom_medium"
-                    >
-                        <label class="slds-form-element__label"
-                            >Output Destination</label
-                        >
+                    <div lwc:if={showOutputDestinationSelector} class="slds-form-element slds-var-m-bottom_medium">
+                        <label class="slds-form-element__label">Output Destination</label>
                         <div class="custom-mini-pills">
-                            <template
-                                for:each={modernOutputOptions}
-                                for:item="out"
-                            >
-                                <button
-                                    key={out.value}
-                                    class={out.class}
-                                    data-value={out.value}
-                                    onclick={handleOutputModeChangeInternal}
-                                >
-                                    {out.label}
-                                </button>
+                            <template for:each={modernOutputOptions} for:item="out">
+                                <button key={out.value} class={out.class} data-value={out.value} onclick={handleOutputModeChangeInternal}>{out.label}</button>
                             </template>
                         </div>
                     </div>
 
-                    <button
-                        class="cool-brand-btn"
-                        onclick={mergeOnlyDocument}
-                        disabled={isMergeOnlyDisabled}
-                    >
-                        {mergeOnlyButtonLabel}
-                    </button>
+                    <button class="cool-brand-btn" onclick={mergeOnlyDocument} disabled={isMergeOnlyDisabled}>{mergeOnlyButtonLabel}</button>
                 </template>
 
                 <!-- MERGE CHILD RECORD PDFs MODE -->
                 <template lwc:if={isMergeChildrenMode}>
                     <div class="slds-form-element slds-var-m-bottom_medium">
-                        <label class="slds-form-element__label"
-                            >Source List</label
-                        >
+                        <label class="slds-form-element__label">Source List</label>
                         <div class="slds-form-element__control">
-                            <select
-                                class="custom-select"
-                                onchange={handleChildRelChangeInternal}
-                            >
+                            <select class="custom-select" onchange={handleChildRelChangeInternal}>
                                 <option value="">Select a child list...</option>
-                                <template
-                                    for:each={childRelComboboxOptions}
-                                    for:item="rel"
-                                >
-                                    <option key={rel.value} value={rel.value}>
-                                        {rel.label}
-                                    </option>
+                                <template for:each={childRelComboboxOptions} for:item="rel">
+                                    <option key={rel.value} value={rel.value}>{rel.label}</option>
                                 </template>
                             </select>
                         </div>
                     </div>
 
                     <template lwc:if={selectedChildRel}>
-                        <div
-                            class="slds-grid slds-grid_vertical-align-end slds-gutters_x-small slds-var-m-bottom_medium"
-                        >
+                        <div class="slds-grid slds-grid_vertical-align-end slds-gutters_x-small slds-var-m-bottom_medium">
                             <div class="slds-col slds-grow">
                                 <lightning-input
                                     label="Filter Records"
@@ -408,47 +219,20 @@
                                 </lightning-input>
                             </div>
                             <div class="slds-col">
-                                <button
-                                    class="pill-action-btn"
-                                    onclick={handleLoadChildPdfs}
-                                >
-                                    Find Files
-                                </button>
+                                <button class="pill-action-btn" onclick={handleLoadChildPdfs}>Find Files</button>
                             </div>
                         </div>
                     </template>
 
                     <template lwc:if={childPdfsLoaded}>
-                        <div
-                            class="merge-box"
-                            style="max-height: 250px; overflow-y: auto"
-                        >
+                        <div class="merge-box" style="max-height: 250px; overflow-y: auto">
                             <template lwc:if={hasChildRecordGroups}>
-                                <template
-                                    for:each={childRecordGroupsWithState}
-                                    for:item="group"
-                                >
-                                    <div
-                                        key={group.childRecordId}
-                                        class="slds-var-m-bottom_small"
-                                    >
-                                        <p class="slds-text-title_bold">
-                                            {group.childRecordName}
-                                        </p>
-                                        <template
-                                            for:each={group.pdfs}
-                                            for:item="pdf"
-                                        >
-                                            <div
-                                                key={pdf.value}
-                                                class="checkbox-item slds-var-m-left_small"
-                                            >
-                                                <input
-                                                    type="checkbox"
-                                                    checked={pdf.checked}
-                                                    data-cvid={pdf.value}
-                                                    onchange={handleChildPdfCheckbox}
-                                                />
+                                <template for:each={childRecordGroupsWithState} for:item="group">
+                                    <div key={group.childRecordId} class="slds-var-m-bottom_small">
+                                        <p class="slds-text-title_bold">{group.childRecordName}</p>
+                                        <template for:each={group.pdfs} for:item="pdf">
+                                            <div key={pdf.value} class="checkbox-item slds-var-m-left_small">
+                                                <input type="checkbox" checked={pdf.checked} data-cvid={pdf.value} onchange={handleChildPdfCheckbox} />
                                                 <span>{pdf.label}</span>
                                             </div>
                                         </template>
@@ -456,45 +240,20 @@
                                 </template>
                             </template>
                             <template lwc:else>
-                                <p
-                                    class="slds-text-body_small slds-text-color_weak"
-                                >
-                                    No matching files found.
-                                </p>
+                                <p class="slds-text-body_small slds-text-color_weak">No matching files found.</p>
                             </template>
                         </div>
 
-                        <div
-                            lwc:if={showOutputDestinationSelector}
-                            class="slds-form-element slds-var-m-bottom_medium"
-                        >
-                            <label class="slds-form-element__label"
-                                >Output Destination</label
-                            >
+                        <div lwc:if={showOutputDestinationSelector} class="slds-form-element slds-var-m-bottom_medium">
+                            <label class="slds-form-element__label">Output Destination</label>
                             <div class="custom-mini-pills">
-                                <template
-                                    for:each={modernOutputOptions}
-                                    for:item="out"
-                                >
-                                    <button
-                                        key={out.value}
-                                        class={out.class}
-                                        data-value={out.value}
-                                        onclick={handleOutputModeChangeInternal}
-                                    >
-                                        {out.label}
-                                    </button>
+                                <template for:each={modernOutputOptions} for:item="out">
+                                    <button key={out.value} class={out.class} data-value={out.value} onclick={handleOutputModeChangeInternal}>{out.label}</button>
                                 </template>
                             </div>
                         </div>
 
-                        <button
-                            class="cool-brand-btn"
-                            onclick={mergeChildrenDocument}
-                            disabled={isMergeChildrenDisabled}
-                        >
-                            {mergeChildrenButtonLabel}
-                        </button>
+                        <button class="cool-brand-btn" onclick={mergeChildrenDocument} disabled={isMergeChildrenDisabled}>{mergeChildrenButtonLabel}</button>
                     </template>
                 </template>
             </template>

--- a/force-app/main/default/lwc/docGenRunner/docGenRunner.html
+++ b/force-app/main/default/lwc/docGenRunner/docGenRunner.html
@@ -1,363 +1,503 @@
 <template>
-  <div class="runner-widget">
-    <div class="widget-header">
-      <div class="header-title">
-        <lightning-icon
-          icon-name="standard:document"
-          size="small"
-          class="slds-var-m-right_x-small"
-        ></lightning-icon>
-        <h2>DocGen</h2>
-      </div>
-      <p class="header-subtitle">Create or combine documents for this record.</p>
-    </div>
-
-    <div class="widget-body">
-      <template lwc:if={error}>
-        <div class="error-alert"><strong>Error:</strong> {error}</div>
-      </template>
-
-      <template lwc:if={isLoading}>
-        <div class="loading-state">
-          <lightning-spinner alternative-text="Loading" size="medium"></lightning-spinner>
-          <template lwc:if={loadingMessage}>
-            <p class="slds-text-body_small slds-text-color_weak slds-var-m-top_small">
-              {loadingMessage}
+    <div class="runner-widget">
+        <div class="widget-header">
+            <div class="header-title">
+                <lightning-icon
+                    icon-name="standard:document"
+                    size="small"
+                    class="slds-var-m-right_x-small"
+                ></lightning-icon>
+                <h2>DocGen</h2>
+            </div>
+            <p class="header-subtitle">
+                Create or combine documents for this record.
             </p>
-          </template>
-          <template lwc:if={showProgressBar}>
-            <div class="progress-bar-container slds-var-m-top_small">
-              <lightning-progress-bar value={progressPercent} size="medium"></lightning-progress-bar>
-              <p class="progress-bar-label">{progressPercent}%</p>
-            </div>
-          </template>
-        </div>
-      </template>
-
-      <template lwc:else>
-        <!-- Custom Mode Selector (Segmented Control) -->
-        <div lwc:if={showModeSelector} class="custom-segmented-control slds-var-m-bottom_medium">
-          <template for:each={modernModeOptions} for:item="opt">
-            <button
-              key={opt.value}
-              class={opt.class}
-              data-value={opt.value}
-              onclick={handleModeChangeInternal}
-            >
-              {opt.label}
-            </button>
-          </template>
         </div>
 
-        <!-- GENERATE MODE -->
-        <template lwc:if={isGenerateMode}>
-          <!-- 1.47 — Empty state -->
-          <template lwc:if={showEmptyState}>
-            <div
-              class="slds-box slds-theme_shade slds-var-m-bottom_medium"
-              style="text-align: center"
-            >
-              <p class="slds-text-body_regular slds-text-color_weak">{emptyStateMessage}</p>
-            </div>
-          </template>
+        <div class="widget-body">
+            <template lwc:if={error}>
+                <div class="error-alert"><strong>Error:</strong> {error}</div>
+            </template>
 
-          <!-- 1.47 — Category filter (only shown when 2+ categories exist) -->
-          <template lwc:if={showCategoryFilter}>
-            <div class="slds-form-element slds-var-m-bottom_medium">
-              <label class="slds-form-element__label">Category</label>
-              <div class="slds-form-element__control">
-                <select class="custom-select" onchange={handleCategoryChange}>
-                  <template for:each={categoryOptions} for:item="cat">
-                    <option key={cat.value} value={cat.value}>{cat.label}</option>
-                  </template>
-                </select>
-              </div>
-            </div>
-          </template>
-
-          <div class="slds-form-element slds-var-m-bottom_medium">
-            <label class="slds-form-element__label">Select Template</label>
-            <div class="slds-form-element__control">
-              <select class="custom-select" onchange={handleTemplateChangeInternal}>
-                <option value="">Choose a template...</option>
-                <template for:each={templateOptions} for:item="tmpl">
-                  <option key={tmpl.value} value={tmpl.value} selected={tmpl.selected}>
-                    {tmpl.label}
-                  </option>
-                </template>
-              </select>
-            </div>
-          </div>
-
-          <!-- 1.47 — Output format override (hidden when template locks format or only one format applies) -->
-          <template lwc:if={showOutputFormatPicker}>
-            <div class="slds-form-element slds-var-m-bottom_medium">
-              <label class="slds-form-element__label">Output As</label>
-              <div class="slds-form-element__control">
-                <select class="custom-select" onchange={handleOutputFormatOverrideChange}>
-                  <option value="">Use template default</option>
-                  <template for:each={outputFormatPickerOptions} for:item="opt">
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
-                  </template>
-                </select>
-              </div>
-            </div>
-          </template>
-
-          <!-- Custom Output Selector -->
-          <div
-            lwc:if={showOutputDestinationSelector}
-            class="slds-form-element slds-var-m-bottom_medium"
-          >
-            <label class="slds-form-element__label">Output Destination</label>
-            <div class="custom-mini-pills">
-              <template for:each={modernOutputOptions} for:item="out">
-                <button
-                  key={out.value}
-                  class={out.class}
-                  data-value={out.value}
-                  onclick={handleOutputModeChangeInternal}
-                >
-                  {out.label}
-                </button>
-              </template>
-            </div>
-          </div>
-
-          <!-- PDF Merge Toggle -->
-          <template lwc:if={showMergeOption}>
-            <div class="slds-var-m-bottom_medium">
-              <lightning-input
-                type="checkbox"
-                label="Combine with existing PDFs on this record"
-                checked={mergeEnabled}
-                onchange={handleMergeToggle}
-                class="custom-checkbox"
-              >
-              </lightning-input>
-            </div>
-
-            <template lwc:if={mergeEnabled}>
-              <div class="merge-box">
-                <template lwc:if={hasRecordPdfs}>
-                  <p class="slds-text-body_small slds-var-m-bottom_x-small">
-                    Select PDFs to append:
-                  </p>
-                  <div class="checkbox-list">
-                    <template for:each={recordPdfOptions} for:item="pdf">
-                      <div key={pdf.value} class="checkbox-item">
-                        <input
-                          type="checkbox"
-                          value={pdf.value}
-                          onchange={handlePdfSelectionInternal}
-                        />
-                        <span>{pdf.label}</span>
-                      </div>
+            <template lwc:if={isLoading}>
+                <div class="loading-state">
+                    <lightning-spinner
+                        alternative-text="Loading"
+                        size="medium"
+                    ></lightning-spinner>
+                    <template lwc:if={loadingMessage}>
+                        <p
+                            class="slds-text-body_small slds-text-color_weak slds-var-m-top_small"
+                        >
+                            {loadingMessage}
+                        </p>
                     </template>
-                  </div>
-                </template>
-                <template lwc:else>
-                  <p class="slds-text-body_small slds-text-color_weak">No other PDFs found here.</p>
-                </template>
-              </div>
+                    <template lwc:if={showProgressBar}>
+                        <div
+                            class="progress-bar-container slds-var-m-top_small"
+                        >
+                            <lightning-progress-bar
+                                value={progressPercent}
+                                size="medium"
+                            ></lightning-progress-bar>
+                            <p class="progress-bar-label">{progressPercent}%</p>
+                        </div>
+                    </template>
+                </div>
             </template>
-          </template>
 
-          <button class="cool-brand-btn" onclick={handleGenerate} disabled={isGenerateDisabled}>
-            {generateButtonLabel}
-          </button>
-        </template>
-
-        <!-- PACKET MODE -->
-        <template lwc:if={isPacketMode}>
-          <div class="slds-var-m-bottom_medium">
-            <lightning-dual-listbox
-              name="packetTemplates"
-              label="Packet Templates"
-              source-label="Available"
-              selected-label="In Packet"
-              options={pdfTemplateOptions}
-                value={packetTemplateIds}
-              onchange={handlePacketTemplateSelection}
-              variant="label-hidden"
-            >
-            </lightning-dual-listbox>
-          </div>
-
-          <div lwc:if={canUseCombineWithExistingPdfs} class="slds-var-m-bottom_medium">
-            <lightning-input
-              type="checkbox"
-              label="Include other PDFs from this record"
-              checked={packetIncludeExisting}
-              onchange={handlePacketIncludeToggle}
-              class="custom-checkbox"
-            >
-            </lightning-input>
-          </div>
-
-          <div
-            lwc:if={showOutputDestinationSelector}
-            class="slds-form-element slds-var-m-bottom_medium"
-          >
-            <label class="slds-form-element__label">Output Destination</label>
-            <div class="custom-mini-pills">
-              <template for:each={modernOutputOptions} for:item="out">
-                <button
-                  key={out.value}
-                  class={out.class}
-                  data-value={out.value}
-                  onclick={handleOutputModeChangeInternal}
-                >
-                  {out.label}
-                </button>
-              </template>
-            </div>
-          </div>
-
-          <button class="cool-brand-btn" onclick={generatePacket} disabled={isPacketDisabled}>
-            {packetButtonLabel}
-          </button>
-        </template>
-
-        <!-- MERGE ONLY MODE -->
-          <template lwc:if={isMergeOnlyMode}>
-          <div class="merge-box">
-            <template lwc:if={hasRecordPdfs}>
-              <lightning-dual-listbox
-                name="mergeOnlySelection"
-                label="Merge Order"
-                source-label="Available"
-                selected-label="Combine"
-                options={recordPdfOptions}
-                value={mergeOnlyCvIds}
-                onchange={handleMergeOnlySelection}
-                variant="label-hidden"
-              >
-              </lightning-dual-listbox>
-            </template>
             <template lwc:else>
-              <p class="slds-text-body_small slds-text-color_weak">
-                No PDF files found to combine.
-              </p>
-            </template>
-          </div>
-
-          <div
-            lwc:if={showOutputDestinationSelector}
-            class="slds-form-element slds-var-m-bottom_medium"
-          >
-            <label class="slds-form-element__label">Output Destination</label>
-            <div class="custom-mini-pills">
-              <template for:each={modernOutputOptions} for:item="out">
-                <button
-                  key={out.value}
-                  class={out.class}
-                  data-value={out.value}
-                  onclick={handleOutputModeChangeInternal}
+                <!-- Custom Mode Selector (Segmented Control) -->
+                <div
+                    lwc:if={showModeSelector}
+                    class="custom-segmented-control slds-var-m-bottom_medium"
                 >
-                  {out.label}
-                </button>
-              </template>
-            </div>
-          </div>
-
-          <button
-            class="cool-brand-btn"
-            onclick={mergeOnlyDocument}
-            disabled={isMergeOnlyDisabled}
-          >
-            {mergeOnlyButtonLabel}
-          </button>
-        </template>
-
-        <!-- MERGE CHILD RECORD PDFs MODE -->
-          <template lwc:if={isMergeChildrenMode}>
-          <div class="slds-form-element slds-var-m-bottom_medium">
-            <label class="slds-form-element__label">Source List</label>
-            <div class="slds-form-element__control">
-              <select class="custom-select" onchange={handleChildRelChangeInternal}>
-                <option value="">Select a child list...</option>
-                <template for:each={childRelComboboxOptions} for:item="rel">
-                  <option key={rel.value} value={rel.value}>{rel.label}</option>
-                </template>
-              </select>
-            </div>
-          </div>
-
-          <template lwc:if={selectedChildRel}>
-            <div
-              class="slds-grid slds-grid_vertical-align-end slds-gutters_x-small slds-var-m-bottom_medium"
-            >
-              <div class="slds-col slds-grow">
-                <lightning-input
-                  label="Filter Records"
-                  placeholder="e.g. StageName = 'Closed Won'"
-                  value={childFilterClause}
-                  onchange={handleChildFilterChangeInternal}
-                  variant="label-hidden"
-                >
-                </lightning-input>
-              </div>
-              <div class="slds-col">
-                <button class="pill-action-btn" onclick={handleLoadChildPdfs}>Find Files</button>
-              </div>
-            </div>
-          </template>
-
-          <template lwc:if={childPdfsLoaded}>
-            <div class="merge-box" style="max-height: 250px; overflow-y: auto">
-              <template lwc:if={hasChildRecordGroups}>
-                <template for:each={childRecordGroupsWithState} for:item="group">
-                  <div key={group.childRecordId} class="slds-var-m-bottom_small">
-                    <p class="slds-text-title_bold">{group.childRecordName}</p>
-                    <template for:each={group.pdfs} for:item="pdf">
-                      <div key={pdf.value} class="checkbox-item slds-var-m-left_small">
-                        <input
-                          type="checkbox"
-                          checked={pdf.checked}
-                          data-cvid={pdf.value}
-                          onchange={handleChildPdfCheckbox}
-                        />
-                        <span>{pdf.label}</span>
-                      </div>
+                    <template for:each={modernModeOptions} for:item="opt">
+                        <button
+                            key={opt.value}
+                            class={opt.class}
+                            data-value={opt.value}
+                            onclick={handleModeChangeInternal}
+                        >
+                            {opt.label}
+                        </button>
                     </template>
-                  </div>
-                </template>
-              </template>
-              <template lwc:else>
-                <p class="slds-text-body_small slds-text-color_weak">No matching files found.</p>
-              </template>
-            </div>
+                </div>
 
-            <div
-              lwc:if={showOutputDestinationSelector}
-              class="slds-form-element slds-var-m-bottom_medium"
-            >
-              <label class="slds-form-element__label">Output Destination</label>
-              <div class="custom-mini-pills">
-                <template for:each={modernOutputOptions} for:item="out">
-                  <button
-                    key={out.value}
-                    class={out.class}
-                    data-value={out.value}
-                    onclick={handleOutputModeChangeInternal}
-                  >
-                    {out.label}
-                  </button>
-                </template>
-              </div>
-            </div>
+                <!-- GENERATE MODE -->
+                <template lwc:if={isGenerateMode}>
+                    <!-- 1.47 — Empty state -->
+                    <template lwc:if={showEmptyState}>
+                        <div
+                            class="slds-box slds-theme_shade slds-var-m-bottom_medium"
+                            style="text-align: center"
+                        >
+                            <p
+                                class="slds-text-body_regular slds-text-color_weak"
+                            >
+                                {emptyStateMessage}
+                            </p>
+                        </div>
+                    </template>
 
-            <button
-              class="cool-brand-btn"
-              onclick={mergeChildrenDocument}
-              disabled={isMergeChildrenDisabled}
-            >
-              {mergeChildrenButtonLabel}
-            </button>
-          </template>
-        </template>
-      </template>
+                    <!-- 1.47 — Category filter (only shown when 2+ categories exist) -->
+                    <template lwc:if={showCategoryFilter}>
+                        <div class="slds-form-element slds-var-m-bottom_medium">
+                            <label class="slds-form-element__label"
+                                >Category</label
+                            >
+                            <div class="slds-form-element__control">
+                                <select
+                                    class="custom-select"
+                                    onchange={handleCategoryChange}
+                                >
+                                    <template
+                                        for:each={categoryOptions}
+                                        for:item="cat"
+                                    >
+                                        <option
+                                            key={cat.value}
+                                            value={cat.value}
+                                        >
+                                            {cat.label}
+                                        </option>
+                                    </template>
+                                </select>
+                            </div>
+                        </div>
+                    </template>
+
+                    <div class="slds-form-element slds-var-m-bottom_medium">
+                        <label class="slds-form-element__label"
+                            >Select Template</label
+                        >
+                        <div class="slds-form-element__control">
+                            <select
+                                class="custom-select"
+                                onchange={handleTemplateChangeInternal}
+                            >
+                                <option value="">Choose a template...</option>
+                                <template
+                                    for:each={templateOptions}
+                                    for:item="tmpl"
+                                >
+                                    <option
+                                        key={tmpl.value}
+                                        value={tmpl.value}
+                                        selected={tmpl.selected}
+                                    >
+                                        {tmpl.label}
+                                    </option>
+                                </template>
+                            </select>
+                        </div>
+                    </div>
+
+                    <!-- 1.47 — Output format override (hidden when template locks format or only one format applies) -->
+                    <template lwc:if={showOutputFormatPicker}>
+                        <div class="slds-form-element slds-var-m-bottom_medium">
+                            <label class="slds-form-element__label"
+                                >Output As</label
+                            >
+                            <div class="slds-form-element__control">
+                                <select
+                                    class="custom-select"
+                                    onchange={handleOutputFormatOverrideChange}
+                                >
+                                    <option value="">
+                                        Use template default
+                                    </option>
+                                    <template
+                                        for:each={outputFormatPickerOptions}
+                                        for:item="opt"
+                                    >
+                                        <option
+                                            key={opt.value}
+                                            value={opt.value}
+                                        >
+                                            {opt.label}
+                                        </option>
+                                    </template>
+                                </select>
+                            </div>
+                        </div>
+                    </template>
+
+                    <!-- Custom Output Selector -->
+                    <div
+                        lwc:if={showOutputDestinationSelector}
+                        class="slds-form-element slds-var-m-bottom_medium"
+                    >
+                        <label class="slds-form-element__label"
+                            >Output Destination</label
+                        >
+                        <div class="custom-mini-pills">
+                            <template
+                                for:each={modernOutputOptions}
+                                for:item="out"
+                            >
+                                <button
+                                    key={out.value}
+                                    class={out.class}
+                                    data-value={out.value}
+                                    onclick={handleOutputModeChangeInternal}
+                                >
+                                    {out.label}
+                                </button>
+                            </template>
+                        </div>
+                    </div>
+
+                    <!-- PDF Merge Toggle -->
+                    <template lwc:if={showMergeOption}>
+                        <div class="slds-var-m-bottom_medium">
+                            <lightning-input
+                                type="checkbox"
+                                label="Combine with existing PDFs on this record"
+                                checked={mergeEnabled}
+                                onchange={handleMergeToggle}
+                                class="custom-checkbox"
+                            >
+                            </lightning-input>
+                        </div>
+
+                        <template lwc:if={mergeEnabled}>
+                            <div class="merge-box">
+                                <template lwc:if={hasRecordPdfs}>
+                                    <p
+                                        class="slds-text-body_small slds-var-m-bottom_x-small"
+                                    >
+                                        Select PDFs to append:
+                                    </p>
+                                    <div class="checkbox-list">
+                                        <template
+                                            for:each={recordPdfOptions}
+                                            for:item="pdf"
+                                        >
+                                            <div
+                                                key={pdf.value}
+                                                class="checkbox-item"
+                                            >
+                                                <input
+                                                    type="checkbox"
+                                                    value={pdf.value}
+                                                    onchange={handlePdfSelectionInternal}
+                                                />
+                                                <span>{pdf.label}</span>
+                                            </div>
+                                        </template>
+                                    </div>
+                                </template>
+                                <template lwc:else>
+                                    <p
+                                        class="slds-text-body_small slds-text-color_weak"
+                                    >
+                                        No other PDFs found here.
+                                    </p>
+                                </template>
+                            </div>
+                        </template>
+                    </template>
+
+                    <button
+                        class="cool-brand-btn"
+                        onclick={handleGenerate}
+                        disabled={isGenerateDisabled}
+                    >
+                        {generateButtonLabel}
+                    </button>
+                </template>
+
+                <!-- PACKET MODE -->
+                <template lwc:if={isPacketMode}>
+                    <div class="slds-var-m-bottom_medium">
+                        <lightning-dual-listbox
+                            name="packetTemplates"
+                            label="Packet Templates"
+                            source-label="Available"
+                            selected-label="In Packet"
+                            options={pdfTemplateOptions}
+                            value={packetTemplateIds}
+                            onchange={handlePacketTemplateSelection}
+                            variant="label-hidden"
+                        >
+                        </lightning-dual-listbox>
+                    </div>
+
+                    <div
+                        lwc:if={canUseCombineWithExistingPdfs}
+                        class="slds-var-m-bottom_medium"
+                    >
+                        <lightning-input
+                            type="checkbox"
+                            label="Include other PDFs from this record"
+                            checked={packetIncludeExisting}
+                            onchange={handlePacketIncludeToggle}
+                            class="custom-checkbox"
+                        >
+                        </lightning-input>
+                    </div>
+
+                    <div
+                        lwc:if={showOutputDestinationSelector}
+                        class="slds-form-element slds-var-m-bottom_medium"
+                    >
+                        <label class="slds-form-element__label"
+                            >Output Destination</label
+                        >
+                        <div class="custom-mini-pills">
+                            <template
+                                for:each={modernOutputOptions}
+                                for:item="out"
+                            >
+                                <button
+                                    key={out.value}
+                                    class={out.class}
+                                    data-value={out.value}
+                                    onclick={handleOutputModeChangeInternal}
+                                >
+                                    {out.label}
+                                </button>
+                            </template>
+                        </div>
+                    </div>
+
+                    <button
+                        class="cool-brand-btn"
+                        onclick={generatePacket}
+                        disabled={isPacketDisabled}
+                    >
+                        {packetButtonLabel}
+                    </button>
+                </template>
+
+                <!-- MERGE ONLY MODE -->
+                <template lwc:if={isMergeOnlyMode}>
+                    <div class="merge-box">
+                        <template lwc:if={hasRecordPdfs}>
+                            <lightning-dual-listbox
+                                name="mergeOnlySelection"
+                                label="Merge Order"
+                                source-label="Available"
+                                selected-label="Combine"
+                                options={recordPdfOptions}
+                                value={mergeOnlyCvIds}
+                                onchange={handleMergeOnlySelection}
+                                variant="label-hidden"
+                            >
+                            </lightning-dual-listbox>
+                        </template>
+                        <template lwc:else>
+                            <p
+                                class="slds-text-body_small slds-text-color_weak"
+                            >
+                                No PDF files found to combine.
+                            </p>
+                        </template>
+                    </div>
+
+                    <div
+                        lwc:if={showOutputDestinationSelector}
+                        class="slds-form-element slds-var-m-bottom_medium"
+                    >
+                        <label class="slds-form-element__label"
+                            >Output Destination</label
+                        >
+                        <div class="custom-mini-pills">
+                            <template
+                                for:each={modernOutputOptions}
+                                for:item="out"
+                            >
+                                <button
+                                    key={out.value}
+                                    class={out.class}
+                                    data-value={out.value}
+                                    onclick={handleOutputModeChangeInternal}
+                                >
+                                    {out.label}
+                                </button>
+                            </template>
+                        </div>
+                    </div>
+
+                    <button
+                        class="cool-brand-btn"
+                        onclick={mergeOnlyDocument}
+                        disabled={isMergeOnlyDisabled}
+                    >
+                        {mergeOnlyButtonLabel}
+                    </button>
+                </template>
+
+                <!-- MERGE CHILD RECORD PDFs MODE -->
+                <template lwc:if={isMergeChildrenMode}>
+                    <div class="slds-form-element slds-var-m-bottom_medium">
+                        <label class="slds-form-element__label"
+                            >Source List</label
+                        >
+                        <div class="slds-form-element__control">
+                            <select
+                                class="custom-select"
+                                onchange={handleChildRelChangeInternal}
+                            >
+                                <option value="">Select a child list...</option>
+                                <template
+                                    for:each={childRelComboboxOptions}
+                                    for:item="rel"
+                                >
+                                    <option key={rel.value} value={rel.value}>
+                                        {rel.label}
+                                    </option>
+                                </template>
+                            </select>
+                        </div>
+                    </div>
+
+                    <template lwc:if={selectedChildRel}>
+                        <div
+                            class="slds-grid slds-grid_vertical-align-end slds-gutters_x-small slds-var-m-bottom_medium"
+                        >
+                            <div class="slds-col slds-grow">
+                                <lightning-input
+                                    label="Filter Records"
+                                    placeholder="e.g. StageName = 'Closed Won'"
+                                    value={childFilterClause}
+                                    onchange={handleChildFilterChangeInternal}
+                                    variant="label-hidden"
+                                >
+                                </lightning-input>
+                            </div>
+                            <div class="slds-col">
+                                <button
+                                    class="pill-action-btn"
+                                    onclick={handleLoadChildPdfs}
+                                >
+                                    Find Files
+                                </button>
+                            </div>
+                        </div>
+                    </template>
+
+                    <template lwc:if={childPdfsLoaded}>
+                        <div
+                            class="merge-box"
+                            style="max-height: 250px; overflow-y: auto"
+                        >
+                            <template lwc:if={hasChildRecordGroups}>
+                                <template
+                                    for:each={childRecordGroupsWithState}
+                                    for:item="group"
+                                >
+                                    <div
+                                        key={group.childRecordId}
+                                        class="slds-var-m-bottom_small"
+                                    >
+                                        <p class="slds-text-title_bold">
+                                            {group.childRecordName}
+                                        </p>
+                                        <template
+                                            for:each={group.pdfs}
+                                            for:item="pdf"
+                                        >
+                                            <div
+                                                key={pdf.value}
+                                                class="checkbox-item slds-var-m-left_small"
+                                            >
+                                                <input
+                                                    type="checkbox"
+                                                    checked={pdf.checked}
+                                                    data-cvid={pdf.value}
+                                                    onchange={handleChildPdfCheckbox}
+                                                />
+                                                <span>{pdf.label}</span>
+                                            </div>
+                                        </template>
+                                    </div>
+                                </template>
+                            </template>
+                            <template lwc:else>
+                                <p
+                                    class="slds-text-body_small slds-text-color_weak"
+                                >
+                                    No matching files found.
+                                </p>
+                            </template>
+                        </div>
+
+                        <div
+                            lwc:if={showOutputDestinationSelector}
+                            class="slds-form-element slds-var-m-bottom_medium"
+                        >
+                            <label class="slds-form-element__label"
+                                >Output Destination</label
+                            >
+                            <div class="custom-mini-pills">
+                                <template
+                                    for:each={modernOutputOptions}
+                                    for:item="out"
+                                >
+                                    <button
+                                        key={out.value}
+                                        class={out.class}
+                                        data-value={out.value}
+                                        onclick={handleOutputModeChangeInternal}
+                                    >
+                                        {out.label}
+                                    </button>
+                                </template>
+                            </div>
+                        </div>
+
+                        <button
+                            class="cool-brand-btn"
+                            onclick={mergeChildrenDocument}
+                            disabled={isMergeChildrenDisabled}
+                        >
+                            {mergeChildrenButtonLabel}
+                        </button>
+                    </template>
+                </template>
+            </template>
+        </div>
     </div>
-  </div>
 </template>

--- a/force-app/main/default/lwc/docGenRunner/docGenRunner.js
+++ b/force-app/main/default/lwc/docGenRunner/docGenRunner.js
@@ -42,7 +42,6 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
     @api showDocumentPacketOption;
     @api showCombinePdfsOption;
     @api showCombineWithExistingPdfsOption;
-    @api showCombineChildPdfsOption;
 
     @track templateOptions = [];
     @track selectedTemplateId = '';

--- a/force-app/main/default/lwc/docGenRunner/docGenRunner.js
+++ b/force-app/main/default/lwc/docGenRunner/docGenRunner.js
@@ -37,6 +37,12 @@ import LOCK_OUTPUT_FORMAT_FIELD from '@salesforce/schema/DocGen_Template__c.Lock
 export default class DocGenRunner extends NavigationMixin(LightningElement) {
     @api recordId;
     @api objectApiName;
+    @api showDownloadOption;
+    @api showSaveToRecordOption;
+    @api showDocumentPacketOption;
+    @api showCombinePdfsOption;
+    @api showCombineWithExistingPdfsOption;
+    @api showCombineChildPdfsOption;
 
     @track templateOptions = [];
     @track selectedTemplateId = '';
@@ -76,38 +82,81 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
     _templateData = [];
 
     // --- Modern SaaS Mode Getters ---
-    
+
+    _isEnabled(value) {
+        return value !== false && value !== 'false';
+    }
+
+    get canDownload() { return this._isEnabled(this.showDownloadOption); }
+    get canSaveToRecord() { return this._isEnabled(this.showSaveToRecordOption); }
+    get canUseDocumentPacket() { return this._isEnabled(this.showDocumentPacketOption); }
+    get canUseCombinePdfs() { return this._isEnabled(this.showCombinePdfsOption); }
+    get canUseCombineWithExistingPdfs() { return this._isEnabled(this.showCombineWithExistingPdfsOption); }
+
     get modernModeOptions() {
-        return [
-            { label: 'Create Document', value: 'generate', icon: '📄', class: this.appMode === 'generate' ? 'seg-btn active' : 'seg-btn' },
-            { label: 'Document Packet', value: 'packet', icon: '📚', class: this.appMode === 'packet' ? 'seg-btn active' : 'seg-btn' },
-            { label: 'Combine PDFs', value: 'mergeOnly', icon: '🔗', class: this.appMode === 'mergeOnly' ? 'seg-btn active' : 'seg-btn' }
+        const options = [
+            { label: 'Create Document', value: 'generate', icon: '📄', class: this.appMode === 'generate' ? 'seg-btn active' : 'seg-btn' }
         ];
+        if (this.canUseDocumentPacket) {
+            options.push({ label: 'Document Packet', value: 'packet', icon: '📚', class: this.appMode === 'packet' ? 'seg-btn active' : 'seg-btn' });
+        }
+        if (this.canUseCombinePdfs) {
+            options.push({ label: 'Combine PDFs', value: 'mergeOnly', icon: '🔗', class: this.appMode === 'mergeOnly' ? 'seg-btn active' : 'seg-btn' });
+        }
+        return options;
+    }
+
+    get showModeSelector() {
+        return this.modernModeOptions.length > 1;
     }
 
     get _isMobile() {
         return /Mobi|Android|iPhone|iPad/i.test(navigator.userAgent);
     }
 
-    get modernOutputOptions() {
-        // Mobile can only save to record — no browser download capability
+    get allowedOutputModes() {
         if (this._isMobile) {
-            if (this.outputMode !== 'save') { this.outputMode = 'save'; }
-            return [
-                { label: 'Save to Record', value: 'save', icon: '☁️', class: 'pill-btn active' }
-            ];
+            return this.canSaveToRecord ? ['save'] : [];
         }
-        const isPdfOutput = this.templateOutputFormat === 'PDF';
+        const isPdfOutput = this.appMode !== 'generate' || this.templateOutputFormat === 'PDF';
         if (!isPdfOutput || this.isGiantQueryMode) {
-            return [
-                { label: 'Download', value: 'download', icon: '⬇️', class: 'pill-btn active' }
-            ];
+            return this.canDownload ? ['download'] : [];
         }
-        const isSave = this.outputMode === 'save';
-        return [
-            { label: 'Download', value: 'download', icon: '⬇️', class: !isSave ? 'pill-btn active' : 'pill-btn' },
-            { label: 'Save to Record', value: 'save', icon: '☁️', class: isSave ? 'pill-btn active' : 'pill-btn' }
-        ];
+        const modes = [];
+        if (this.canDownload) { modes.push('download'); }
+        if (this.canSaveToRecord) { modes.push('save'); }
+        return modes;
+    }
+
+    get modernOutputOptions() {
+        const allowedModes = this.allowedOutputModes;
+        const resolvedMode = allowedModes.includes(this.outputMode) ? this.outputMode : allowedModes[0];
+        const options = [];
+        if (allowedModes.includes('download')) {
+            options.push({ label: 'Download', value: 'download', icon: '⬇️', class: resolvedMode === 'download' ? 'pill-btn active' : 'pill-btn' });
+        }
+        if (allowedModes.includes('save')) {
+            options.push({ label: 'Save to Record', value: 'save', icon: '☁️', class: resolvedMode === 'save' ? 'pill-btn active' : 'pill-btn' });
+        }
+        return options;
+    }
+
+    get showOutputDestinationSelector() {
+        return this.modernOutputOptions.length > 0;
+    }
+
+    get resolvedOutputMode() {
+        const allowedModes = this.allowedOutputModes;
+        if (allowedModes.includes(this.outputMode)) {
+            return this.outputMode;
+        }
+        if (allowedModes.includes('download')) {
+            return 'download';
+        }
+        if (allowedModes.includes('save')) {
+            return 'save';
+        }
+        return 'download';
     }
 
     get isGenerateMode() { return this.appMode === 'generate'; }
@@ -120,14 +169,14 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
         return t ? t[OUT_FMT_FIELD.fieldApiName] : null;
     }
 
-    get showMergeOption() { return this.templateOutputFormat === 'PDF'; }
+    get showMergeOption() { return this.templateOutputFormat === 'PDF' && this.canUseCombineWithExistingPdfs; }
     get progressBarStyle() { return `width: ${this.progressPercent}%`; }
     get hasRecordPdfs() { return this.recordPdfOptions.length > 0; }
 
-    get isGenerateDisabled() { return !this.selectedTemplateId || this.isLoading; }
-    get isPacketDisabled() { return this.packetTemplateIds.length < 1 || this.isLoading; }
-    get isMergeOnlyDisabled() { return this.mergeOnlyCvIds.length < 2 || this.isLoading; }
-    get isMergeChildrenDisabled() { return this.selectedChildPdfCvIds.length < 1 || this.isLoading; }
+    get isGenerateDisabled() { return !this.selectedTemplateId || this.isLoading || this.modernOutputOptions.length === 0; }
+    get isPacketDisabled() { return this.packetTemplateIds.length < 1 || this.isLoading || this.modernOutputOptions.length === 0; }
+    get isMergeOnlyDisabled() { return this.mergeOnlyCvIds.length < 2 || this.isLoading || this.modernOutputOptions.length === 0; }
+    get isMergeChildrenDisabled() { return this.selectedChildPdfCvIds.length < 1 || this.isLoading || this.modernOutputOptions.length === 0; }
 
     get generateButtonLabel() {
         if (this.mergeEnabled && this.selectedPdfCvIds.length > 0) {
@@ -175,6 +224,11 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
             ? data.filter(t => (t[CATEGORY_FIELD.fieldApiName] || '__UNCATEGORIZED__') === this.selectedCategory)
             : data;
         const defaultTemplate = filtered.find(t => t[IS_DEFAULT_FIELD.fieldApiName]);
+        const stillSelected = filtered.some(t => t.Id === this.selectedTemplateId);
+        const selectedTemplateId = stillSelected
+            ? this.selectedTemplateId
+            : (defaultTemplate ? defaultTemplate.Id : (filtered[0] ? filtered[0].Id : ''));
+        this.selectedTemplateId = selectedTemplateId;
         this.templateOptions = filtered.map(t => {
             const isDefault = !!t[IS_DEFAULT_FIELD.fieldApiName];
             const catVal = t[CATEGORY_FIELD.fieldApiName];
@@ -182,16 +236,9 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
             return {
                 label: `${isDefault ? '★ ' : ''}${cat}${t.Name}`,
                 value: t.Id,
-                selected: defaultTemplate ? t.Id === defaultTemplate.Id : false
+                selected: t.Id === selectedTemplateId
             };
         });
-        // If the previously-selected template is no longer in the filtered list,
-        // fall back to the new default (or first option, or empty).
-        const stillSelected = this.templateOptions.some(o => o.value === this.selectedTemplateId);
-        if (!stillSelected) {
-            this.selectedTemplateId = defaultTemplate ? defaultTemplate.Id
-                : (this.templateOptions[0] ? this.templateOptions[0].value : '');
-        }
         // Reset override when template list changes — the new selection may be a different type
         this.outputFormatOverride = '';
     }
@@ -368,7 +415,7 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
                 parentRecordId: this.recordId,
                 childObject: rel.childObjectApiName,
                 lookupField: rel.lookupField,
-                filterClause: this.childFilterClause 
+                filterClause: this.childFilterClause
             });
             this.childRecordGroups = data;
             this.childPdfsLoaded = true;
@@ -474,7 +521,7 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
             const isExcel = templateType === 'Excel';
             // Use effectiveOutputFormat so a runtime PDF/Word override re-routes the path.
             const isPDF = this.effectiveOutputFormat === 'PDF' && !isPPT && !isExcel;
-            const saveToRecord = this.outputMode === 'save';
+            const saveToRecord = this.resolvedOutputMode === 'save';
             const shouldMerge = isPDF && this.mergeEnabled && this.selectedPdfCvIds.length > 0;
             const hasOverride = !!this.outputFormatOverride;
 
@@ -613,7 +660,7 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
             if (result.isGiantQuery) {
                 this.showToast('Success', 'Large dataset detected \u2014 generating asynchronously. Check Job History for progress.', 'success');
             } else if (result.base64) {
-                const saveToRecord = this.outputMode === 'save';
+                const saveToRecord = this.resolvedOutputMode === 'save';
                 const docTitle = result.title || 'Document';
                 if (saveToRecord) {
                     // CxSAST: CSRF protection handled by Salesforce Aura/LWC framework
@@ -679,7 +726,7 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
             } else {
                 finalBase64 = this._uint8ArrayToBase64(mergePdfs(pdfBytesArray));
             }
-            const saveToRecord = this.outputMode === 'save';
+            const saveToRecord = this.resolvedOutputMode === 'save';
             if (saveToRecord) {
                 // CxSAST: CSRF protection handled by Salesforce Aura/LWC framework
                 await saveGeneratedDocument({ recordId: this.recordId, fileName: 'Document Packet', base64Data: finalBase64, extension: 'pdf' });
@@ -709,7 +756,7 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
             if (pdfBytesArray.length < 2) { throw new Error('Need at least 2 PDFs to merge.'); }
             const mergedBytes = mergePdfs(pdfBytesArray);
             const mergedBase64 = this._uint8ArrayToBase64(mergedBytes);
-            const saveToRecord = this.outputMode === 'save';
+            const saveToRecord = this.resolvedOutputMode === 'save';
             if (saveToRecord) {
                 // CxSAST: CSRF protection handled by Salesforce Aura/LWC framework
                 await saveGeneratedDocument({ recordId: this.recordId, fileName: 'Merged Document', base64Data: mergedBase64, extension: 'pdf' });
@@ -741,7 +788,7 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
             if (pdfBytesArray.length === 1) { finalBytes = pdfBytesArray[0]; }
             else { finalBytes = mergePdfs(pdfBytesArray); }
             const finalBase64 = this._uint8ArrayToBase64(finalBytes);
-            const saveToRecord = this.outputMode === 'save';
+            const saveToRecord = this.resolvedOutputMode === 'save';
             if (saveToRecord) {
                 // CxSAST: CSRF protection handled by Salesforce Aura/LWC framework
                 await saveGeneratedDocument({ recordId: this.recordId, fileName: 'Merged Child PDFs', base64Data: finalBase64, extension: 'pdf' });
@@ -941,7 +988,7 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
             const fileBase64 = this._uint8ArrayToBase64(fileBytes);
 
             // 8. Download or save
-            const saveToRecord = this.outputMode === 'save';
+            const saveToRecord = this.resolvedOutputMode === 'save';
             if (saveToRecord) {
                 // CxSAST: CSRF protection handled by Salesforce Aura/LWC framework
                 await saveGeneratedDocument({ recordId: this.recordId, fileName: docTitle, base64Data: fileBase64, extension: 'docx' });

--- a/force-app/main/default/lwc/docGenRunner/docGenRunner.js-meta.xml
+++ b/force-app/main/default/lwc/docGenRunner/docGenRunner.js-meta.xml
@@ -12,12 +12,24 @@
     </targets>
     <targetConfigs>
         <targetConfig targets="lightning__RecordPage">
+            <property name="showDownloadOption" type="Boolean" label="Show Download Option" default="true" />
+            <property name="showSaveToRecordOption" type="Boolean" label="Show Save to Record Option" default="true" />
+            <property name="showDocumentPacketOption" type="Boolean" label="Show Document Packet Mode" default="true" />
+            <property name="showCombinePdfsOption" type="Boolean" label="Show Combine PDFs Mode" default="true" />
+            <property name="showCombineWithExistingPdfsOption" type="Boolean" label="Show Combine with Existing PDFs Option" default="true" />
+            <property name="showCombineChildPdfsOption" type="Boolean" label="Show Combine Child PDFs Mode" default="true" />
             <supportedFormFactors>
                 <supportedFormFactor type="Large" />
                 <supportedFormFactor type="Small" />
             </supportedFormFactors>
         </targetConfig>
         <targetConfig targets="lightning__AppPage">
+            <property name="showDownloadOption" type="Boolean" label="Show Download Option" default="true" />
+            <property name="showSaveToRecordOption" type="Boolean" label="Show Save to Record Option" default="true" />
+            <property name="showDocumentPacketOption" type="Boolean" label="Show Document Packet Mode" default="true" />
+            <property name="showCombinePdfsOption" type="Boolean" label="Show Combine PDFs Mode" default="true" />
+            <property name="showCombineWithExistingPdfsOption" type="Boolean" label="Show Combine with Existing PDFs Option" default="true" />
+            <property name="showCombineChildPdfsOption" type="Boolean" label="Show Combine Child PDFs Mode" default="true" />
             <supportedFormFactors>
                 <supportedFormFactor type="Large" />
                 <supportedFormFactor type="Small" />
@@ -26,6 +38,12 @@
         <targetConfig targets="lightning__FlowScreen">
             <property name="recordId" type="String" label="Record ID" />
             <property name="objectApiName" type="String" label="Object API Name" />
+            <property name="showDownloadOption" type="Boolean" label="Show Download Option" default="true" />
+            <property name="showSaveToRecordOption" type="Boolean" label="Show Save to Record Option" default="true" />
+            <property name="showDocumentPacketOption" type="Boolean" label="Show Document Packet Mode" default="true" />
+            <property name="showCombinePdfsOption" type="Boolean" label="Show Combine PDFs Mode" default="true" />
+            <property name="showCombineWithExistingPdfsOption" type="Boolean" label="Show Combine with Existing PDFs Option" default="true" />
+            <property name="showCombineChildPdfsOption" type="Boolean" label="Show Combine Child PDFs Mode" default="true" />
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/docGenRunner/docGenRunner.js-meta.xml
+++ b/force-app/main/default/lwc/docGenRunner/docGenRunner.js-meta.xml
@@ -17,7 +17,6 @@
             <property name="showDocumentPacketOption" type="Boolean" label="Show Document Packet Mode" default="true" />
             <property name="showCombinePdfsOption" type="Boolean" label="Show Combine PDFs Mode" default="true" />
             <property name="showCombineWithExistingPdfsOption" type="Boolean" label="Show Combine with Existing PDFs Option" default="true" />
-            <property name="showCombineChildPdfsOption" type="Boolean" label="Show Combine Child PDFs Mode" default="true" />
             <supportedFormFactors>
                 <supportedFormFactor type="Large" />
                 <supportedFormFactor type="Small" />
@@ -29,7 +28,6 @@
             <property name="showDocumentPacketOption" type="Boolean" label="Show Document Packet Mode" default="true" />
             <property name="showCombinePdfsOption" type="Boolean" label="Show Combine PDFs Mode" default="true" />
             <property name="showCombineWithExistingPdfsOption" type="Boolean" label="Show Combine with Existing PDFs Option" default="true" />
-            <property name="showCombineChildPdfsOption" type="Boolean" label="Show Combine Child PDFs Mode" default="true" />
             <supportedFormFactors>
                 <supportedFormFactor type="Large" />
                 <supportedFormFactor type="Small" />
@@ -43,7 +41,6 @@
             <property name="showDocumentPacketOption" type="Boolean" label="Show Document Packet Mode" default="true" />
             <property name="showCombinePdfsOption" type="Boolean" label="Show Combine PDFs Mode" default="true" />
             <property name="showCombineWithExistingPdfsOption" type="Boolean" label="Show Combine with Existing PDFs Option" default="true" />
-            <property name="showCombineChildPdfsOption" type="Boolean" label="Show Combine Child PDFs Mode" default="true" />
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>


### PR DESCRIPTION
## Summary

This adds configuration-driven visibility to the DocGen Runner LWC, allowing admins and Flow builders to control which generation modes and output destinations are available in each context. Existing behaviour is preserved by default, with all new options defaulting to enabled.

## Changes

- Added new configurable options for showing or hiding DocGen Runner actions, including download, save to record, document packet, combine PDFs, combine with existing PDFs, and combine child PDFs.
- Updated the runner so available mode and output destination options are built dynamically from the new configuration flags, rather than always rendering every option.
- Preserved existing behaviour by defaulting all new configuration properties to enabled in component metadata and treating undefined values as enabled in JavaScript.
- Improved template selection behaviour so that when only one template matches the active filter, it is automatically selected both internally and visually.
- Standardised save-mode logic to use the resolved output mode consistently, which keeps behaviour predictable when output destinations are hidden by configuration.
- Updated disabled-state logic so the component correctly handles scenarios where no output destination options are available.
- Added conditional rendering around configurable UI sections, including the mode selector, output destination selectors, and "Combine with existing PDFs" checkbox.
- Replaced the custom inline-styled progress indicator with the standard `lightning-progress-bar`, resolving the CSS lint warning.
- Cleaned up LWC template syntax, including `lwc:if` / `lwc:else` usage and `for:each` bindings.
- Added the new configuration properties across `lightning__RecordPage`, `lightning__AppPage`, and `lightning__FlowScreen` targets.
- Retained `showCombineChildPdfsOption` as inert metadata for backward compatibility, as Salesforce blocks removal of metadata properties already used on existing flexipages.

## Testing

- [x] Ran E2E tests (`sf apex run --target-org <org> -f scripts/e2e-test.apex`) - all passing
- [x] Ran Apex unit tests (`sf apex run test --synchronous --code-coverage`) - all passing
- [x] Tested manually in a scratch org - Screenshot attached
- [ ] Added/updated E2E test assertions for new behavior - N/A for this functionality

## Related Issues

N/A

## Screenshots

<img width="641" height="425" alt="image" src="https://github.com/user-attachments/assets/7f411f1c-f6f7-4cb5-a073-55df5d93ed89" />

## Checklist

- [x] No hardcoded IDs, URLs, or credentials
- [x] No `VersionData` in PDF image queries (see CLAUDE.md)
- [x] SOQL uses `WITH USER_MODE` or `Security.stripInaccessible()` where appropriate
- [x] No new external dependencies introduced