### PR TITLE
fix(signatures): one verification certificate per packet, not per template

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -1062,9 +1062,11 @@ See [§6.8](#68-signatures).
 
 ### 9.3 Packets (multi-template signing)
 
-Send multiple templates in one session. The signer sees all documents and signs them all before completion. One email, one signing session, multiple PDFs generated and attached to the source record.
+Send multiple templates in one session. The signer sees all documents and signs them all before completion. One email, one signing session, **one combined signed PDF** with a **single verification certificate at the very end** of the packet.
 
 Useful for contract bundles (MSA + SOW + NDA), onboarding packets, etc.
+
+> **v1.78 fix:** earlier versions inserted the verification block after every template (`String.replace` matched all `</body>` tags). v1.78 inserts the certificate exactly once, before the final `</body>`, so the packet ends with one consolidated audit page. Upgrade if your testers reported "verification doc after every template."
 
 ### 9.4 Sequential vs parallel
 

--- a/force-app/main/default/classes/DocGenSignatureService.cls
+++ b/force-app/main/default/classes/DocGenSignatureService.cls
@@ -63,6 +63,29 @@ public without sharing class DocGenSignatureService {
     }
 
     /**
+     * Inserts the verification block immediately before the LAST </body> tag in
+     * an HTML document. Critical for packet PDFs — renderPacketSignaturePdf
+     * concatenates one full <html>...</html> per template, so the document has
+     * a </body> per template. Using String.replace would inject the block after
+     * EVERY template (the v1.77 packet bug Dustin reported). If no </body> is
+     * found, appends to the end as a safe fallback.
+     */
+    @TestVisible
+    private static String injectVerifyBlockBeforeLastBody(String fullHtml, String verifyBlock) {
+        if (String.isBlank(fullHtml)) {
+            return verifyBlock == null ? '' : verifyBlock;
+        }
+        if (String.isBlank(verifyBlock)) {
+            return fullHtml;
+        }
+        Integer lastBodyIdx = fullHtml.lastIndexOf('</body>');
+        if (lastBodyIdx >= 0) {
+            return fullHtml.substring(0, lastBodyIdx) + verifyBlock + fullHtml.substring(lastBodyIdx);
+        }
+        return fullHtml + verifyBlock;
+    }
+
+    /**
      * Builds the HTML verification block appended to the end of the signed PDF.
      * Includes signer details, timestamps, and a verification URL.
      */
@@ -876,7 +899,7 @@ public without sharing class DocGenSignatureService {
                 ORDER BY Sort_Order__c ASC
             ];
             String verifyBlock = buildVerificationBlockHtml(reqId, fullSigners);
-            html = html.replace('</body>', verifyBlock + '</body>');
+            html = injectVerifyBlockBeforeLastBody(html, verifyBlock);
 
             return Blob.toPdf(html);
         }
@@ -1008,7 +1031,10 @@ public without sharing class DocGenSignatureService {
                 ORDER BY Sort_Order__c ASC
             ]; // NOPMD
             String verifyBlock = buildVerificationBlockHtml(reqId, fullSigners);
-            fullHtml = fullHtml.replace('</body>', verifyBlock + '</body>');
+            // injectVerifyBlockBeforeLastBody handles the multi-</body> case —
+            // packet HTML has one </body> per template, so String.replace would
+            // drop the verification block after every template (the v1.77 bug).
+            fullHtml = injectVerifyBlockBeforeLastBody(fullHtml, verifyBlock);
 
             return Blob.toPdf(fullHtml);
         }

--- a/force-app/main/default/classes/DocGenSignatureTests.cls
+++ b/force-app/main/default/classes/DocGenSignatureTests.cls
@@ -5393,4 +5393,81 @@ private class DocGenSignatureTests {
             'Original download must be disabled for the preview link'
         );
     }
+
+    // =========================================================================
+    // Verification block placement — packet path (v1.78 fix for Dustin Bystrom)
+    // =========================================================================
+
+    @IsTest
+    static void verifyBlockSinglePacketHtmlInjectsOnceBeforeLastBody() {
+        // Simulate a 3-template packet HTML — three full <html>...</html> docs
+        // concatenated. Pre-fix, String.replace dropped the verifyBlock after
+        // EVERY </body> (3 times). Post-fix, it lands once before the last.
+        String packetHtml =
+            '<html><body>doc1</body></html>' +
+            '<html><body>doc2</body></html>' +
+            '<html><body>doc3</body></html>';
+        String verifyBlock = '<div class="verify">CERT</div>';
+
+        Test.startTest();
+        String result = DocGenSignatureService.injectVerifyBlockBeforeLastBody(packetHtml, verifyBlock);
+        Test.stopTest();
+
+        Integer occurrences = result.countMatches('CERT');
+        System.assertEquals(1, occurrences, 'Verification block must appear exactly once across packet HTML');
+
+        // Must land before the LAST </body>, after doc3's content
+        Integer certIdx = result.indexOf('CERT');
+        Integer doc3Idx = result.indexOf('doc3');
+        Integer lastBodyIdx = result.lastIndexOf('</body>');
+        System.assert(certIdx > doc3Idx, 'Verification block must follow doc3 content');
+        System.assert(certIdx < lastBodyIdx, 'Verification block must precede the final </body>');
+    }
+
+    @IsTest
+    static void verifyBlockSingleHtmlStillInjectsOnce() {
+        // Single-template path — one </body>, one injection. Regression guard.
+        String html = '<html><body>only doc</body></html>';
+        String verifyBlock = '<div class="verify">CERT</div>';
+
+        Test.startTest();
+        String result = DocGenSignatureService.injectVerifyBlockBeforeLastBody(html, verifyBlock);
+        Test.stopTest();
+
+        System.assertEquals(1, result.countMatches('CERT'));
+        System.assert(
+            result.contains('only doc<div class="verify">CERT</div></body>'),
+            'Single-template injection should land before </body>'
+        );
+    }
+
+    @IsTest
+    static void verifyBlockNoBodyTagAppendsAtEndAsFallback() {
+        // Defensive fallback — if HTML ever ships without a </body>, append.
+        String html = '<div>raw fragment</div>';
+        String verifyBlock = '<p>CERT</p>';
+
+        String result = DocGenSignatureService.injectVerifyBlockBeforeLastBody(html, verifyBlock);
+
+        System.assertEquals('<div>raw fragment</div><p>CERT</p>', result);
+    }
+
+    @IsTest
+    static void verifyBlockBlankInputsHandledSafely() {
+        System.assertEquals(
+            '<p>CERT</p>',
+            DocGenSignatureService.injectVerifyBlockBeforeLastBody(null, '<p>CERT</p>'),
+            'Null html should return verifyBlock'
+        );
+        System.assertEquals(
+            '<html></html>',
+            DocGenSignatureService.injectVerifyBlockBeforeLastBody('<html></html>', null),
+            'Null verifyBlock should return html unchanged'
+        );
+        System.assertEquals(
+            '',
+            DocGenSignatureService.injectVerifyBlockBeforeLastBody(null, null),
+            'Both null should return empty string'
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Bug fix reported by Dustin Bystrom — when sending a multi-template signature packet, the verification certificate was appearing after **every** template instead of once at the end of the packet.

## Root cause

`DocGenSignatureService.renderPacketSignaturePdf` concatenates one full `<html>...</html>` document per template (including per-template `<head>`/`<style>`/`<body>`), then injects the verification block via `fullHtml.replace('</body>', verifyBlock + '</body>')`. Apex `String.replace` replaces **all** occurrences — so a 5-template packet has 5 `</body>` tags, and the certificate gets wedged into the body of every document.

## Fix

New `@TestVisible` helper `injectVerifyBlockBeforeLastBody(html, block)` uses `lastIndexOf('</body>')` + substring-splice to insert the block exactly once before the final `</body>`. Both packet and single-template paths now route through the helper.

## Tests

4 new tests in `DocGenSignatureTests`:
- 3-doc packet → exactly 1 verification block, positioned after doc3 and before final `</body>`
- Single-template regression
- No-body-tag fallback
- Null-input guards

## Validation

- DocGenSignatureTests: **260/260 pass**
- E2E-06 signatures: **23/23 pass**
- E2E-07-syntax3 (RunningUser regression): **8/8 pass**
- RunLocalTests: **1123/1123 (100%, 75% org-wide coverage)**
- Code Analyzer: **0 High, 41 Moderate**

## Test plan

- [x] 3-template packet → exactly 1 certificate at the end
- [x] Single-template path unchanged
- [x] All existing signature tests still pass
- [x] No regression on RunningUser merge tags (v1.77)
- [x] Code Analyzer clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)