### PR TITLE
fix(admin): rank standard objects first in template-wizard base-object picker

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -87,7 +87,7 @@ Three permission sets ship with the package. Assign what each user needs.
 
 1. Open the DocGen app → **My Templates** tab → **+ New Template**.
 2. Pick a template type: **Word** (`.docx`), **HTML** (`.html` / `.htm` / `.zip`), **PowerPoint** (`.pptx`), or **Excel** (`.xlsx`).
-3. Pick a base object (Account, Opportunity, Case, any custom object).
+3. Pick a base object (Account, Opportunity, Case, any custom object). The picker ranks **standard objects first** — when an org has many namespaced custom objects whose names contain `Account`, `Opportunity`, etc. (common with payment processors and managed packages), the standard `Opportunity` always appears at the top of the list with a green **Standard** pill (v1.79+). Up to 50 matches render with a scroll, so nothing falls off the bottom.
 4. Upload your file containing `{FieldName}` merge tags.
 5. Configure the query — which fields, which child relationships (see [§5](#5-query-builder)).
 6. Choose the default **output format** (PDF or the native format).

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -60,7 +60,7 @@
                                                     style="
                                                         position: absolute;
                                                         z-index: 20;
-                                                        max-height: 200px;
+                                                        max-height: 380px;
                                                         overflow-y: auto;
                                                         left: 0;
                                                         right: 0;
@@ -98,6 +98,21 @@
                                                                 "
                                                                 >{obj.value}</span
                                                             >
+                                                            <template if:true={obj.isStandard}>
+                                                                <span
+                                                                    style="
+                                                                        margin-left: auto;
+                                                                        font-size: 0.7rem;
+                                                                        font-weight: 600;
+                                                                        color: #fff;
+                                                                        background: #16a085;
+                                                                        padding: 2px 8px;
+                                                                        border-radius: 10px;
+                                                                        white-space: nowrap;
+                                                                    "
+                                                                    >Standard</span
+                                                                >
+                                                            </template>
                                                         </li>
                                                     </template>
                                                 </ul>

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -1173,9 +1173,36 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
 
     _filterObjects(term) {
         const t = term.toLowerCase();
-        this.filteredObjectOptions = this.objectOptions
-            .filter((o) => o.label.toLowerCase().includes(t) || o.value.toLowerCase().includes(t))
-            .slice(0, 12);
+        const matches = this.objectOptions.filter(
+            (o) => o.label.toLowerCase().includes(t) || o.value.toLowerCase().includes(t)
+        );
+
+        // Rank: exact API/label match → standard prefix match → label prefix → API prefix → contains.
+        // Surfaces standard Opportunity above payment-processor lookalikes when the user types
+        // "opportunity" in an org with 30+ namespaced Opportunity_* custom objects (Sprint NY 2026 feedback).
+        const isStandard = (apiName) => !apiName.includes('__');
+        const score = (o) => {
+            const lbl = o.label.toLowerCase();
+            const api = o.value.toLowerCase();
+            if (api === t || lbl === t) return 0;
+            if (api.startsWith(t) && isStandard(o.value)) return 1;
+            if (lbl.startsWith(t) && isStandard(o.value)) return 2;
+            if (api.startsWith(t)) return 3;
+            if (lbl.startsWith(t)) return 4;
+            if (isStandard(o.value)) return 5;
+            return 6;
+        };
+        matches.sort((a, b) => {
+            const sa = score(a);
+            const sb = score(b);
+            if (sa !== sb) return sa - sb;
+            return a.label.localeCompare(b.label);
+        });
+
+        this.filteredObjectOptions = matches.slice(0, 50).map((o) => ({
+            ...o,
+            isStandard: !o.value.includes('__')
+        }));
         this.showObjectSuggestions = this.filteredObjectOptions.length > 0;
     }
 


### PR DESCRIPTION
## Bug

NY Sprint customer (April 2026) with a payment-processor managed package that ships ~30 namespaced `Opportunity_*` custom objects could not select the **standard** Opportunity object in the template wizard. The picker rendered the first 12 alphabetical `*_Opportunity_*` matches and stopped — no \"see more\", no API-name typeahead, no scroll past the cap. Completely blocked from creating any Opportunity template.

## Root cause

`docGenAdmin._filterObjects` sliced to 12 with no ranking — so when an org has 30+ namespaced lookalikes, the standard object falls off the bottom of the list.

## Fix

- **New ranking:** exact match → standard with API prefix → standard with label prefix → custom prefix matches → contains → standard fallback. Standard objects always rank above custom on otherwise-tied scores.
- **Result cap:** 12 → 50.
- **Dropdown height:** 200px → 380px scroll surface.
- **Green \"Standard\" pill** on rows where the API name has no `__` namespace separator — visually disambiguates `Opportunity` from `CnP_PaaS__Opportunity_*`.

## Validation

Deployed to staging scratch, smoke-tested with real `getObjectOptions` response. Typing `opp` now surfaces standard `Opportunity` at row 1 with the green Standard pill; namespaced rows rank below.

UserGuide §4.1 updated.

## Test plan

- [x] Type \"opp\" — standard Opportunity appears at top with Standard pill
- [x] Type exact \"Opportunity\" — selects standard, not namespaced lookalike
- [x] Custom-only matches (e.g. user types \"CnP_\") still rank correctly by prefix
- [x] Result cap 50 doesn't flood — fits within 380px scroll height

🤖 Generated with [Claude Code](https://claude.com/claude-code)