### PR TITLE
feat(a11y): visual builder accessibility for blind / keyboard users (v1.84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 ## Install
 
 ```bash
-sf package install --package 04tVx000000QKRJIA4 --wait 10 --target-org <your-org>
+sf package install --package 04tVx000000QL2PIAW --wait 10 --target-org <your-org>
 ```
 
-[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000QKRJIA4) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000QKRJIA4)
+[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000QL2PIAW) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000QL2PIAW)
 
 **Then:** Assign **DocGen Admin** permission set | Enable **Blob.toPdf() Release Update** | Open the **DocGen** app
 
@@ -415,7 +415,8 @@ Found a vulnerability? See [SECURITY.md](SECURITY.md).
 
 | Version | Channel                                 | Package ID           |
 | ------- | --------------------------------------- | -------------------- |
-| v1.83.0 | **Latest (Released)**                   | `04tVx000000QKRJIA4` |
+| v1.84.0 | **Latest (Released)**                   | `04tVx000000QL2PIAW` |
+| v1.83.0 | Previous                                | `04tVx000000QKRJIA4` |
 | v1.82.0 | Previous                                | `04tal000006rKBdAAM` |
 | v1.81.0 | Previous                                | `04tal000006rKA1AAM` |
 | v1.80.0 | Previous                                | `04tal000006rJkDAAU` |

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -4,7 +4,7 @@ Build polished Word and PDF documents from any Salesforce record. Author your te
 
 PowerPoint and Excel templates are also supported as **alpha-stage** formats — see [§2](#2-what-docgen-does) for what to expect.
 
-[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000QKRJIA4) · [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000QKRJIA4) · [Support](https://portwood.dev/support)
+[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000QL2PIAW) · [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000QL2PIAW) · [Support](https://portwood.dev/support)
 
 ---
 
@@ -140,7 +140,7 @@ A native Salesforce document generation engine that turns merge-tag templates in
 ### Install the package
 
 ```bash
-sf package install --package 04tVx000000QKRJIA4 --wait 10 --target-org <your-org>
+sf package install --package 04tVx000000QL2PIAW --wait 10 --target-org <your-org>
 ```
 
 Or use the install links at the top of this guide. The install bundles the merge engine, all Lightning components, custom objects, permission sets, and the e-signature Visualforce pages.

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1,5 +1,9 @@
 <template>
-    <div class="admin-workspace">
+    <div class="admin-workspace" onannounce={handleA11yAnnounce}>
+        <!-- Page-level ARIA live region. Children dispatch a bubbling
+             CustomEvent('announce', {detail:{message:'…'}, composed:true}) and
+             we mirror the message text here so screen readers announce it. -->
+        <div aria-live="polite" aria-atomic="true" class="slds-assistive-text">{liveAnnouncement}</div>
         <lightning-tabset variant="scoped" active-tab-value={activeMainTab}>
             <lightning-tab label="Create New" value="new_template" onactive={handleWizardTabActive}>
                 <div class="slds-var-p-around_large">
@@ -986,7 +990,14 @@
 
     <!-- Edit Template Modal -->
     <template if:true={isEditModalOpen}>
-        <section role="dialog" tabindex="-1" class="slds-modal slds-fade-in-open slds-modal_large">
+        <section
+            role="dialog"
+            tabindex="-1"
+            aria-modal="true"
+            aria-labelledby="edit-template-modal-title"
+            onkeydown={handleEditModalKeydown}
+            class="slds-modal slds-fade-in-open slds-modal_large"
+        >
             <div class="slds-modal__container modern-modal">
                 <header class="slds-modal__header">
                     <lightning-button-icon
@@ -997,7 +1008,9 @@
                         class="slds-button slds-button_icon slds-modal__close"
                         onclick={closeEditModal}
                     ></lightning-button-icon>
-                    <h2 class="slds-text-heading_medium slds-hyphenate">Edit Template Configuration</h2>
+                    <h2 id="edit-template-modal-title" class="slds-text-heading_medium slds-hyphenate">
+                        Edit Template Configuration
+                    </h2>
                 </header>
                 <div class="slds-modal__content slds-var-p-around_medium">
                     <!-- Sample Record (persistent across all tabs) — hidden for Apex providers -->
@@ -2173,7 +2186,14 @@
 
     <!-- Preview Modal -->
     <template if:true={isPreviewModalOpen}>
-        <section role="dialog" tabindex="-1" class="slds-modal slds-fade-in-open slds-modal_medium">
+        <section
+            role="dialog"
+            tabindex="-1"
+            aria-modal="true"
+            aria-labelledby="preview-modal-title"
+            onkeydown={handlePreviewModalKeydown}
+            class="slds-modal slds-fade-in-open slds-modal_medium"
+        >
             <div class="slds-modal__container">
                 <header class="slds-modal__header">
                     <lightning-button-icon
@@ -2184,7 +2204,9 @@
                         class="slds-button slds-button_icon slds-modal__close"
                         onclick={closePreviewModal}
                     ></lightning-button-icon>
-                    <h2 class="slds-text-heading_medium">Version Preview: {previewVersion.VersionNumber}</h2>
+                    <h2 id="preview-modal-title" class="slds-text-heading_medium">
+                        Version Preview: {previewVersion.VersionNumber}
+                    </h2>
                 </header>
                 <div class="slds-modal__content slds-var-p-around_large">
                     <div class="slds-grid slds-gutters slds-var-m-bottom_large">

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -710,6 +710,44 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         }
     }
 
+    // --- A11y live region ─────────────────────────────────────
+    // Page-level ARIA live announcement channel. Children dispatch a bubbling
+    // CustomEvent('announce', {detail:{message}, composed:true}); we mirror
+    // the message into a `slds-assistive-text` element with aria-live="polite".
+    @track liveAnnouncement = '';
+
+    handleA11yAnnounce(event) {
+        const msg = event && event.detail && event.detail.message;
+        if (!msg) return;
+        // Re-trigger if same string is announced again. Empty briefly so the
+        // SR re-reads identical messages.
+        if (this.liveAnnouncement === msg) {
+            this.liveAnnouncement = '';
+            // eslint-disable-next-line @lwc/lwc/no-async-operation
+            setTimeout(() => {
+                this.liveAnnouncement = msg;
+            }, 50);
+        } else {
+            this.liveAnnouncement = msg;
+        }
+    }
+
+    // Modal Esc-to-close handlers. Focus restoration is handled by the
+    // standard browser flow when the dialog DOM unmounts; full focus trap
+    // (Tab/Shift+Tab cycling) is deferred to v1.85.
+    handleEditModalKeydown(event) {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            this.closeEditModal();
+        }
+    }
+    handlePreviewModalKeydown(event) {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            this.closePreviewModal();
+        }
+    }
+
     // --- Wizard Logic ---
 
     renderedCallback() {

--- a/force-app/main/default/lwc/docGenColumnBuilder/docGenColumnBuilder.css
+++ b/force-app/main/default/lwc/docGenColumnBuilder/docGenColumnBuilder.css
@@ -28,3 +28,33 @@
     color: var(--slds-g-color-on-surface-2, #181818);
     background: var(--slds-g-color-surface-2, #f3f2f2);
 }
+
+/* Reset chrome on <button> elements that are visually rendered as
+   inline links / pills / clickable list rows. Inline `style` attributes
+   restore per-button visual treatment on top of this reset. */
+.bare-button {
+    background: none;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    text-align: inherit;
+    -webkit-appearance: none;
+    appearance: none;
+    line-height: inherit;
+}
+.bare-button:focus-visible {
+    outline: 2px solid #0176d3;
+    outline-offset: 2px;
+    border-radius: 4px;
+}
+
+/* Visual highlight for the keyboard-active option in any combobox-style
+   listbox inside this component. WCAG 2.4.7 (Focus Visible) — sighted
+   keyboard users need to see which option will be selected. */
+li[role='option'][aria-selected='true'] .slds-listbox__option {
+    background-color: #ecf3fe;
+    box-shadow: inset 2px 0 0 #0176d3;
+}

--- a/force-app/main/default/lwc/docGenColumnBuilder/docGenColumnBuilder.html
+++ b/force-app/main/default/lwc/docGenColumnBuilder/docGenColumnBuilder.html
@@ -294,13 +294,7 @@
                 class="bare-button"
                 onclick={handleAddNode}
                 aria-label="Add related list"
-                style="
-                    padding: 0.5rem 1rem;
-                    color: #0176d3;
-                    font-size: 0.875rem;
-                    font-weight: 600;
-                    white-space: nowrap;
-                "
+                style="padding: 0.5rem 1rem; color: #0176d3; font-size: 0.875rem; font-weight: 600; white-space: nowrap"
             >
                 + Add
             </button>

--- a/force-app/main/default/lwc/docGenColumnBuilder/docGenColumnBuilder.html
+++ b/force-app/main/default/lwc/docGenColumnBuilder/docGenColumnBuilder.html
@@ -51,14 +51,16 @@
                             <ul class="slds-listbox slds-listbox_vertical">
                                 <template for:each={filteredObjectOptions} for:item="opt">
                                     <li key={opt.value} class="slds-listbox__item">
-                                        <div
-                                            class="slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
+                                        <button
+                                            type="button"
+                                            class="bare-button slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
+                                            style="width: 100%; text-align: left"
                                             data-value={opt.value}
                                             data-label={opt.label}
                                             onclick={handleObjectSelect}
                                         >
                                             <span class="slds-truncate">{opt.label}</span>
-                                        </div>
+                                        </button>
                                     </li>
                                 </template>
                             </ul>
@@ -86,8 +88,10 @@
                                 <template if:true={providerOptions.length}>
                                     <template for:each={providerOptions} for:item="cls">
                                         <li key={cls} class="slds-listbox__item">
-                                            <div
-                                                class="slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
+                                            <button
+                                                type="button"
+                                                class="bare-button slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
+                                                style="width: 100%; text-align: left"
                                                 data-value={cls}
                                                 onclick={handleProviderSelect}
                                             >
@@ -99,7 +103,7 @@
                                                     ></lightning-icon
                                                     >{cls}</span
                                                 >
-                                            </div>
+                                            </button>
                                         </li>
                                     </template>
                                 </template>
@@ -164,20 +168,24 @@
                 </p>
                 <div style="display: flex; flex-wrap: wrap; gap: 4px">
                     <template for:each={providerTags} for:item="tag">
-                        <code
+                        <button
                             key={tag.code}
+                            type="button"
+                            class="bare-button"
                             style="
                                 font-size: 0.75rem;
                                 background: #f3f2f2;
                                 padding: 2px 8px;
                                 border-radius: 4px;
                                 color: #0176d3;
-                                cursor: pointer;
+                                font-family: monospace;
                             "
                             data-copy={tag.code}
                             onclick={handleCopyTag}
-                            >{tag.code}</code
+                            title="Copy merge tag"
                         >
+                            {tag.code}
+                        </button>
                     </template>
                 </div>
             </div>
@@ -221,10 +229,17 @@
             </div>
             <div style="font-size: 0.8125rem; font-family: monospace">
                 <template for:each={relationshipTree} for:item="item">
-                    <div key={item.id} style={item.indent} data-node-id={item.id} onclick={handleTreeNodeClick}>
+                    <button
+                        key={item.id}
+                        type="button"
+                        class="bare-button"
+                        style={item.indent}
+                        data-node-id={item.id}
+                        onclick={handleTreeNodeClick}
+                        aria-label={item.ariaLabel}
+                    >
                         <span
                             style="
-                                cursor: pointer;
                                 padding: 2px 6px;
                                 border-radius: 4px;
                                 display: inline-flex;
@@ -239,45 +254,56 @@
                             <span class={item.badgeClass}>{item.badgeLabel}</span>
                             <strong>{item.label}</strong>
                         </span>
-                    </div>
+                    </button>
                 </template>
             </div>
         </div>
 
         <!-- Object Tabs -->
-        <div style="display: flex; border-bottom: 2px solid #e5e5e5; margin-bottom: 1rem; overflow-x: auto">
+        <div
+            role="tablist"
+            aria-label="Object tabs"
+            style="display: flex; border-bottom: 2px solid #e5e5e5; margin-bottom: 1rem; overflow-x: auto"
+        >
             <template for:each={nodeTabs} for:item="tab">
-                <div
+                <button
                     key={tab.id}
+                    type="button"
+                    role="tab"
+                    aria-selected={tab.ariaSelected}
                     data-node-id={tab.id}
                     onclick={handleTabClick}
+                    class={tab.tabButtonClass}
                     style="
                         padding: 0.5rem 1rem;
-                        cursor: pointer;
                         font-size: 0.875rem;
                         font-weight: 600;
                         white-space: nowrap;
+                        border: 0;
                         border-bottom: 3px solid transparent;
+                        background: none;
                         margin-bottom: -2px;
+                        cursor: pointer;
                     "
-                    class={tab.tabClass}
                 >
                     {tab.label}
-                </div>
+                </button>
             </template>
-            <div
+            <button
+                type="button"
+                class="bare-button"
+                onclick={handleAddNode}
+                aria-label="Add related list"
                 style="
                     padding: 0.5rem 1rem;
-                    cursor: pointer;
                     color: #0176d3;
                     font-size: 0.875rem;
                     font-weight: 600;
                     white-space: nowrap;
                 "
-                onclick={handleAddNode}
             >
                 + Add
-            </div>
+            </button>
         </div>
 
         <!-- Active Tab Content -->
@@ -288,12 +314,14 @@
                     <div>
                         <h3 style="font-size: 1rem; font-weight: 700; margin: 0">{activeNode.label}</h3>
                         <template if:true={activeNode.isRoot}>
-                            <a
-                                href="javascript:void(0)"
-                                style="font-size: 0.75rem; color: #706e6b; text-decoration: none"
+                            <button
+                                type="button"
+                                class="bare-button"
+                                style="font-size: 0.75rem; color: #706e6b"
                                 onclick={handleChangeRoot}
-                                >Change root object</a
                             >
+                                Change root object
+                            </button>
                         </template>
                         <template if:true={activeNode.isNotRoot}>
                             <p class="slds-text-body_small slds-text-color_weak" style="margin: 2px 0 0 0">
@@ -390,16 +418,17 @@
                                 "
                             >
                                 <template for:each={filteredParentPickerOptions} for:item="rel">
-                                    <div
+                                    <button
                                         key={rel.value}
-                                        class="slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
-                                        style="cursor: pointer; padding: 0.5rem"
+                                        type="button"
+                                        class="bare-button slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
+                                        style="width: 100%; text-align: left; padding: 0.5rem"
                                         data-value={rel.value}
                                         data-target={rel.targetObject}
                                         onclick={handleParentPickerRelSelect}
                                     >
                                         <span class="slds-truncate">{rel.label}</span>
-                                    </div>
+                                    </button>
                                 </template>
                             </div>
                         </template>
@@ -534,18 +563,21 @@
                                     gap: 4px;
                                 "
                             >
-                                <span
+                                <button
+                                    type="button"
+                                    class="bare-button"
                                     style="
                                         font-size: 0.6875rem;
                                         font-weight: 600;
                                         color: #0176d3;
-                                        cursor: pointer;
                                         text-decoration: underline;
                                     "
                                     data-rel={pg.relationshipName}
                                     onclick={handleEditParentGroup}
-                                    >{pg.relationshipName}:</span
+                                    title="Edit parent fields"
                                 >
+                                    {pg.relationshipName}:
+                                </button>
                                 <template for:each={pg.fields} for:item="pf">
                                     <lightning-pill
                                         key={pf}
@@ -611,20 +643,24 @@
                         </p>
                         <div style="display: flex; flex-wrap: wrap; gap: 4px">
                             <template for:each={activeNodeTags} for:item="tag">
-                                <code
+                                <button
                                     key={tag.code}
+                                    type="button"
+                                    class="bare-button"
                                     style="
                                         font-size: 0.75rem;
                                         background: #f3f2f2;
                                         padding: 2px 8px;
                                         border-radius: 4px;
                                         color: #0176d3;
-                                        cursor: pointer;
+                                        font-family: monospace;
                                     "
                                     data-copy={tag.code}
                                     onclick={handleCopyTag}
-                                    >{tag.code}</code
+                                    title="Copy merge tag"
                                 >
+                                    {tag.code}
+                                </button>
                             </template>
                         </div>
                     </div>
@@ -643,7 +679,14 @@
 
     <!-- ==================== ADD NODE MODAL ==================== -->
     <template if:true={showAddNodeModal}>
-        <section role="dialog" tabindex="-1" class="slds-modal slds-fade-in-open">
+        <section
+            role="dialog"
+            tabindex="-1"
+            aria-modal="true"
+            aria-labelledby="add-node-modal-title"
+            onkeydown={handleAddNodeModalKeydown}
+            class="slds-modal slds-fade-in-open"
+        >
             <div class="slds-modal__container" style="max-width: 480px">
                 <header class="slds-modal__header">
                     <lightning-button-icon
@@ -653,7 +696,7 @@
                         class="slds-button slds-button_icon slds-modal__close"
                         onclick={handleCloseAddNode}
                     ></lightning-button-icon>
-                    <h2 class="slds-text-heading_medium">Add Related Records</h2>
+                    <h2 id="add-node-modal-title" class="slds-text-heading_medium">Add Related Records</h2>
                     <p class="slds-text-body_small slds-text-color_weak slds-var-m-top_x-small">
                         Choose a related list to add to your document.
                     </p>
@@ -671,8 +714,10 @@
                             <ul class="slds-listbox slds-listbox_vertical slds-has-dividers_bottom-space">
                                 <template for:each={filteredAddOptions} for:item="opt">
                                     <li key={opt.value} class="slds-listbox__item">
-                                        <div
-                                            class="slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
+                                        <button
+                                            type="button"
+                                            class="bare-button slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
+                                            style="width: 100%"
                                             data-value={opt.value}
                                             onclick={handleAddNodeSelect}
                                         >
@@ -685,7 +730,7 @@
                                             <span class="slds-media__body"
                                                 ><span class="slds-truncate">{opt.label}</span></span
                                             >
-                                        </div>
+                                        </button>
                                     </li>
                                 </template>
                             </ul>
@@ -699,7 +744,14 @@
 
     <!-- ==================== REPORT IMPORT MODAL ==================== -->
     <template if:true={showReportModal}>
-        <section role="dialog" tabindex="-1" class="slds-modal slds-fade-in-open">
+        <section
+            role="dialog"
+            tabindex="-1"
+            aria-modal="true"
+            aria-labelledby="report-modal-title"
+            onkeydown={handleReportModalKeydown}
+            class="slds-modal slds-fade-in-open"
+        >
             <div class="slds-modal__container">
                 <header class="slds-modal__header">
                     <lightning-button-icon
@@ -709,7 +761,7 @@
                         class="slds-button slds-button_icon slds-modal__close"
                         onclick={handleCloseReportModal}
                     ></lightning-button-icon>
-                    <h2 class="slds-text-heading_medium">Import from Report</h2>
+                    <h2 id="report-modal-title" class="slds-text-heading_medium">Import from Report</h2>
                     <p class="slds-text-body_small slds-text-color_weak slds-var-m-top_x-small">
                         Pick a report and we'll set up your template automatically.
                     </p>
@@ -728,8 +780,10 @@
                                 <ul class="slds-listbox slds-listbox_vertical slds-has-dividers_bottom-space">
                                     <template for:each={reportSearchResults} for:item="report">
                                         <li key={report.id} class="slds-listbox__item">
-                                            <div
-                                                class={report.optionClass}
+                                            <button
+                                                type="button"
+                                                class={report.optionButtonClass}
+                                                style="width: 100%"
                                                 data-id={report.id}
                                                 data-name={report.name}
                                                 onclick={handleReportSelect}
@@ -748,7 +802,7 @@
                                                         ></template
                                                     >
                                                 </span>
-                                            </div>
+                                            </button>
                                         </li>
                                     </template>
                                 </ul>

--- a/force-app/main/default/lwc/docGenColumnBuilder/docGenColumnBuilder.js
+++ b/force-app/main/default/lwc/docGenColumnBuilder/docGenColumnBuilder.js
@@ -113,12 +113,17 @@ export default class DocGenColumnBuilder extends LightningElement {
 
     // Tab items for the tabset
     get nodeTabs() {
-        return this.treeNodes.map((n) => ({
-            ...n,
-            tabLabel: n.isRoot ? n.label : n.label,
-            tabClass: n.id === this.activeNodeId ? 'active-tab' : 'inactive-tab',
-            isActive: n.id === this.activeNodeId
-        }));
+        return this.treeNodes.map((n) => {
+            const active = n.id === this.activeNodeId;
+            return {
+                ...n,
+                tabLabel: n.isRoot ? n.label : n.label,
+                tabClass: active ? 'active-tab' : 'inactive-tab',
+                tabButtonClass: 'bare-button ' + (active ? 'active-tab' : 'inactive-tab'),
+                isActive: active,
+                ariaSelected: active ? 'true' : 'false'
+            };
+        });
     }
 
     // Visual relationship tree (rendered on every tab)
@@ -147,7 +152,12 @@ export default class DocGenColumnBuilder extends LightningElement {
                       : 'badge-base badge-related',
                 badgeLabel: node.isRoot ? 'Main' : node.isJunction ? 'Linked' : 'Child',
                 connector: depth > 0 ? '└─' : '',
-                treeItemClass: node.id === this.activeNodeId ? 'slds-theme_shade' : ''
+                treeItemClass: node.id === this.activeNodeId ? 'slds-theme_shade' : '',
+                ariaLabel:
+                    (node.isRoot ? 'Main' : node.isJunction ? 'Linked' : 'Child') +
+                    ' record ' +
+                    node.label +
+                    (node.id === this.activeNodeId ? ', selected' : '')
             }
         ];
 
@@ -698,10 +708,66 @@ export default class DocGenColumnBuilder extends LightningElement {
         if (!parentNode) return;
         this.addNodeParentId = parentNode.id;
         this.addNodeSearch = '';
+        this._captureModalReturnFocus();
         getChildRelationships({ objectName: parentNode.objectApiName }).then((data) => {
             this.addNodeChildOptions = data;
             this.showAddNodeModal = true;
         });
+    }
+
+    // Modal focus management. Capture activeElement before opening so we can
+    // return focus to it on close (per WAI-ARIA Modal Dialog pattern).
+    _captureModalReturnFocus() {
+        // document.activeElement may be the LWC host; that's still useful.
+        try {
+            this._modalReturnFocusEl = document.activeElement;
+        } catch (e) {
+            this._modalReturnFocusEl = null;
+        }
+    }
+    _restoreModalFocus() {
+        const el = this._modalReturnFocusEl;
+        this._modalReturnFocusEl = null;
+        if (el && typeof el.focus === 'function') {
+            // setTimeout 0 lets the modal teardown finish before focus moves.
+            // eslint-disable-next-line @lwc/lwc/no-async-operation
+            setTimeout(() => {
+                try {
+                    el.focus();
+                } catch (e) {
+                    // host element may be gone or non-focusable; safe to ignore.
+                }
+            }, 0);
+        }
+    }
+    // Set initial focus on the close button when a modal opens. Runs after
+    // each render; uses transition flags to avoid re-focusing on every render.
+    renderedCallback() {
+        if (this.showAddNodeModal && !this._addNodeModalOpened) {
+            this._addNodeModalOpened = true;
+            this._focusFirstModalButton('.slds-modal__close');
+        } else if (!this.showAddNodeModal && this._addNodeModalOpened) {
+            this._addNodeModalOpened = false;
+        }
+        if (this.showReportModal && !this._reportModalOpened) {
+            this._reportModalOpened = true;
+            this._focusFirstModalButton('.slds-modal__close');
+        } else if (!this.showReportModal && this._reportModalOpened) {
+            this._reportModalOpened = false;
+        }
+    }
+    _focusFirstModalButton(selector) {
+        // eslint-disable-next-line @lwc/lwc/no-async-operation
+        setTimeout(() => {
+            const el = this.template.querySelector(selector);
+            if (el && typeof el.focus === 'function') {
+                try {
+                    el.focus();
+                } catch (e) {
+                    /* ignore */
+                }
+            }
+        }, 0);
     }
 
     handleAddNodeSearch(event) {
@@ -709,6 +775,14 @@ export default class DocGenColumnBuilder extends LightningElement {
     }
     handleCloseAddNode() {
         this.showAddNodeModal = false;
+        this._restoreModalFocus();
+    }
+
+    handleAddNodeModalKeydown(event) {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            this.handleCloseAddNode();
+        }
     }
 
     handleAddNodeSelect(event) {
@@ -899,6 +973,7 @@ export default class DocGenColumnBuilder extends LightningElement {
 
     // === REPORT IMPORT ===
     handleOpenReportImport() {
+        this._captureModalReturnFocus();
         this.showReportModal = true;
         this.reportSearchResults = [];
         this.reportSearchTerm = '';
@@ -907,8 +982,16 @@ export default class DocGenColumnBuilder extends LightningElement {
         this.showImportPreview = false;
         this._searchReports('');
     }
+    handleReportModalKeydown(event) {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            this.handleCloseReportModal();
+        }
+    }
+
     handleCloseReportModal() {
         this.showReportModal = false;
+        this._restoreModalFocus();
         this.showImportPreview = false;
     }
     handleReportSearch(event) {
@@ -925,6 +1008,9 @@ export default class DocGenColumnBuilder extends LightningElement {
                     isSelected: r.id === this.selectedReportId,
                     optionClass:
                         'slds-media slds-listbox__option slds-listbox__option_plain slds-media_small' +
+                        (r.id === this.selectedReportId ? ' slds-theme_shade' : ''),
+                    optionButtonClass:
+                        'bare-button slds-media slds-listbox__option slds-listbox__option_plain slds-media_small' +
                         (r.id === this.selectedReportId ? ' slds-theme_shade' : '')
                 }));
             })
@@ -940,6 +1026,9 @@ export default class DocGenColumnBuilder extends LightningElement {
             isSelected: r.id === this.selectedReportId,
             optionClass:
                 'slds-media slds-listbox__option slds-listbox__option_plain slds-media_small' +
+                (r.id === this.selectedReportId ? ' slds-theme_shade' : ''),
+            optionButtonClass:
+                'bare-button slds-media slds-listbox__option slds-listbox__option_plain slds-media_small' +
                 (r.id === this.selectedReportId ? ' slds-theme_shade' : '')
         }));
     }

--- a/force-app/main/default/lwc/docGenFilterBuilder/docGenFilterBuilder.html
+++ b/force-app/main/default/lwc/docGenFilterBuilder/docGenFilterBuilder.html
@@ -7,7 +7,12 @@
         </template>
 
         <template for:each={rows} for:item="row" for:index="index">
-            <div key={row.id} class="slds-grid slds-gutters slds-var-m-bottom_small slds-grid_vertical-align-center" role="group" aria-label="Filter condition">
+            <div
+                key={row.id}
+                class="slds-grid slds-gutters slds-var-m-bottom_small slds-grid_vertical-align-center"
+                role="group"
+                aria-label="Filter condition"
+            >
                 <!-- Logic (AND/OR) -->
                 <template if:true={index}>
                     <div class="slds-col slds-size_2-of-12">

--- a/force-app/main/default/lwc/docGenFilterBuilder/docGenFilterBuilder.html
+++ b/force-app/main/default/lwc/docGenFilterBuilder/docGenFilterBuilder.html
@@ -1,17 +1,18 @@
 <template>
-    <div class="slds-box slds-container_large">
+    <div class="slds-box slds-container_large" role="region" aria-label="Record filter">
         <h3 class="slds-text-heading_small slds-var-m-bottom_medium">Record Filter</h3>
 
         <template if:true={isLoading}>
-            <lightning-spinner size="small"></lightning-spinner>
+            <lightning-spinner size="small" alternative-text="Loading filter"></lightning-spinner>
         </template>
 
         <template for:each={rows} for:item="row" for:index="index">
-            <div key={row.id} class="slds-grid slds-gutters slds-var-m-bottom_small slds-grid_vertical-align-center">
+            <div key={row.id} class="slds-grid slds-gutters slds-var-m-bottom_small slds-grid_vertical-align-center" role="group" aria-label="Filter condition">
                 <!-- Logic (AND/OR) -->
                 <template if:true={index}>
                     <div class="slds-col slds-size_2-of-12">
                         <lightning-combobox
+                            label="Condition logic"
                             variant="label-hidden"
                             value={row.logic}
                             options={logicOptions}
@@ -22,13 +23,14 @@
                 </template>
                 <template if:false={index}>
                     <div class="slds-col slds-size_2-of-12">
-                        <span class="slds-text-color_weak slds-var-p-left_small">WHERE</span>
+                        <span class="slds-text-color_weak slds-var-p-left_small" aria-hidden="true">WHERE</span>
                     </div>
                 </template>
 
                 <!-- Field -->
                 <div class="slds-col slds-size_3-of-12">
                     <lightning-combobox
+                        label="Field"
                         variant="label-hidden"
                         value={row.field}
                         options={fieldOptions}
@@ -41,6 +43,7 @@
                 <!-- Operator -->
                 <div class="slds-col slds-size_2-of-12">
                     <lightning-combobox
+                        label="Operator"
                         variant="label-hidden"
                         value={row.operator}
                         options={operatorOptions}
@@ -54,6 +57,7 @@
                 <div class="slds-col slds-size_4-of-12">
                     <!-- Dynamic input type based on field? For now, text. -->
                     <lightning-input
+                        label="Value"
                         variant="label-hidden"
                         value={row.value}
                         placeholder="Value (e.g. 'Closed Won')"

--- a/force-app/main/default/lwc/docGenQueryBuilder/docGenQueryBuilder.css
+++ b/force-app/main/default/lwc/docGenQueryBuilder/docGenQueryBuilder.css
@@ -1,0 +1,15 @@
+/* Visual highlight for the keyboard-active option in each combobox.
+   Required for WCAG 2.4.7 (Focus Visible) — sighted keyboard users
+   need to see which option will be selected when they press Enter.
+   `aria-activedescendant` keeps actual DOM focus on the input, so
+   without this rule the active option would have no indicator. */
+li[role='option'][aria-selected='true'] .slds-listbox__option {
+    background-color: #ecf3fe;
+    box-shadow: inset 2px 0 0 #0176d3;
+}
+
+/* SLDS-flavored focus ring for the bare search inputs that drive each combobox. */
+.slds-input:focus-visible {
+    outline: 2px solid #0176d3;
+    outline-offset: 1px;
+}

--- a/force-app/main/default/lwc/docGenQueryBuilder/docGenQueryBuilder.html
+++ b/force-app/main/default/lwc/docGenQueryBuilder/docGenQueryBuilder.html
@@ -324,7 +324,10 @@
                                                     aria-label="Child relationship options"
                                                 >
                                                     <ul class="slds-listbox slds-listbox_vertical" role="presentation">
-                                                        <template for:each={filteredChildOptionsForListbox} for:item="opt">
+                                                        <template
+                                                            for:each={filteredChildOptionsForListbox}
+                                                            for:item="opt"
+                                                        >
                                                             <li
                                                                 id={opt._optionId}
                                                                 role="option"

--- a/force-app/main/default/lwc/docGenQueryBuilder/docGenQueryBuilder.html
+++ b/force-app/main/default/lwc/docGenQueryBuilder/docGenQueryBuilder.html
@@ -31,18 +31,32 @@
                         <input
                             type="search"
                             class="slds-input"
+                            role="combobox"
+                            aria-label="Base object"
+                            aria-autocomplete="list"
+                            aria-expanded={showObjectDropdown}
+                            aria-controls={objectDropdownId}
+                            aria-activedescendant={objectActiveDescendantId}
                             placeholder="Search objects..."
                             value={selectedObjectLabel}
                             oninput={handleObjectSearch}
                             onfocus={handleObjectFocus}
+                            onkeydown={handleObjectKeydown}
                         />
                     </div>
                     <template if:true={showObjectDropdown}>
-                        <div class="slds-dropdown slds-dropdown_length-5 slds-dropdown_fluid" role="listbox">
+                        <div
+                            id={objectDropdownId}
+                            class="slds-dropdown slds-dropdown_length-5 slds-dropdown_fluid"
+                            role="listbox"
+                            aria-label="Base object options"
+                        >
                             <ul class="slds-listbox slds-listbox_vertical" role="presentation">
-                                <template for:each={filteredObjectOptions} for:item="opt">
+                                <template for:each={filteredObjectOptionsForListbox} for:item="opt">
                                     <li
-                                        role="presentation"
+                                        id={opt._optionId}
+                                        role="option"
+                                        aria-selected={opt._ariaSelected}
                                         class="slds-listbox__item"
                                         key={opt.value}
                                         onclick={handleObjectSelect}
@@ -51,7 +65,6 @@
                                     >
                                         <div
                                             class="slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
-                                            role="option"
                                         >
                                             <span class="slds-truncate" title={opt.label}>{opt.label}</span>
                                         </div>
@@ -169,21 +182,32 @@
                                         <input
                                             type="search"
                                             class="slds-input"
+                                            role="combobox"
+                                            aria-label="Parent object"
+                                            aria-autocomplete="list"
+                                            aria-expanded={showParentDropdown}
+                                            aria-controls={parentDropdownId}
+                                            aria-activedescendant={parentActiveDescendantId}
                                             placeholder="Search parents..."
                                             value={selectedParentLabel}
                                             oninput={handleParentSearch}
                                             onfocus={handleParentFocus}
+                                            onkeydown={handleParentKeydown}
                                         />
                                     </div>
                                     <template if:true={showParentDropdown}>
                                         <div
+                                            id={parentDropdownId}
                                             class="slds-dropdown slds-dropdown_length-5 slds-dropdown_fluid"
                                             role="listbox"
+                                            aria-label="Parent object options"
                                         >
                                             <ul class="slds-listbox slds-listbox_vertical" role="presentation">
-                                                <template for:each={filteredParentOptions} for:item="opt">
+                                                <template for:each={filteredParentOptionsForListbox} for:item="opt">
                                                     <li
-                                                        role="presentation"
+                                                        id={opt._optionId}
+                                                        role="option"
+                                                        aria-selected={opt._ariaSelected}
                                                         class="slds-listbox__item"
                                                         key={opt.value}
                                                         onclick={handleParentSelect}
@@ -193,7 +217,6 @@
                                                     >
                                                         <div
                                                             class="slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
-                                                            role="option"
                                                         >
                                                             <span class="slds-truncate" title={opt.label}
                                                                 >{opt.label}</span
@@ -280,21 +303,32 @@
                                                 <input
                                                     type="search"
                                                     class="slds-input"
+                                                    role="combobox"
+                                                    aria-label="Child relationship"
+                                                    aria-autocomplete="list"
+                                                    aria-expanded={showChildDropdown}
+                                                    aria-controls={childDropdownId}
+                                                    aria-activedescendant={childActiveDescendantId}
                                                     placeholder="Search relationships..."
                                                     value={selectedChildLabel}
                                                     oninput={handleChildSearch}
                                                     onfocus={handleChildFocus}
+                                                    onkeydown={handleChildKeydown}
                                                 />
                                             </div>
                                             <template if:true={showChildDropdown}>
                                                 <div
+                                                    id={childDropdownId}
                                                     class="slds-dropdown slds-dropdown_length-5 slds-dropdown_fluid"
                                                     role="listbox"
+                                                    aria-label="Child relationship options"
                                                 >
                                                     <ul class="slds-listbox slds-listbox_vertical" role="presentation">
-                                                        <template for:each={filteredChildOptions} for:item="opt">
+                                                        <template for:each={filteredChildOptionsForListbox} for:item="opt">
                                                             <li
-                                                                role="presentation"
+                                                                id={opt._optionId}
+                                                                role="option"
+                                                                aria-selected={opt._ariaSelected}
                                                                 class="slds-listbox__item"
                                                                 key={opt.value}
                                                                 onclick={handleChildSelect}
@@ -303,7 +337,6 @@
                                                             >
                                                                 <div
                                                                     class="slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
-                                                                    role="option"
                                                                 >
                                                                     <span class="slds-truncate" title={opt.label}
                                                                         >{opt.label}</span

--- a/force-app/main/default/lwc/docGenQueryBuilder/docGenQueryBuilder.js
+++ b/force-app/main/default/lwc/docGenQueryBuilder/docGenQueryBuilder.js
@@ -57,6 +57,12 @@ export default class DocGenQueryBuilder extends LightningElement {
     @track showParentFieldDropdown = false;
     @track filteredParentFieldOptions = [];
 
+    // ARIA combobox active-descendant tracking. -1 = no option highlighted.
+    // Reset to -1 on focus/search; advanced by ArrowUp/ArrowDown keys.
+    @track _objectActiveIndex = -1;
+    @track _parentActiveIndex = -1;
+    @track _childActiveIndex = -1;
+
     // --- New Mode ---
     @api showTagsOnly = false;
 
@@ -678,6 +684,7 @@ export default class DocGenQueryBuilder extends LightningElement {
         const searchKey = event.target.value.toLowerCase();
         this.selectedObjectLabel = event.target.value;
         this.showObjectDropdown = true;
+        this._objectActiveIndex = -1;
 
         if (searchKey) {
             this.filteredObjectOptions = this.objectOptions.filter((opt) =>
@@ -690,6 +697,7 @@ export default class DocGenQueryBuilder extends LightningElement {
 
     handleObjectFocus() {
         this.showObjectDropdown = true;
+        this._objectActiveIndex = -1;
         this.filteredObjectOptions = this.objectOptions.filter((opt) =>
             opt.label.toLowerCase().includes((this.selectedObjectLabel || '').toLowerCase())
         );
@@ -698,10 +706,14 @@ export default class DocGenQueryBuilder extends LightningElement {
     handleObjectSelect(event) {
         const value = event.currentTarget.dataset.value;
         const label = event.currentTarget.dataset.label;
+        this._selectObject(value, label);
+    }
 
+    _selectObject(value, label) {
         this._selectedObject = value;
         this.selectedObjectLabel = label;
         this.showObjectDropdown = false;
+        this._objectActiveIndex = -1;
 
         // Reset downstream
         this.selectedFields = [];
@@ -720,6 +732,7 @@ export default class DocGenQueryBuilder extends LightningElement {
         const searchKey = event.target.value.toLowerCase();
         this.selectedChildLabel = event.target.value;
         this.showChildDropdown = true;
+        this._childActiveIndex = -1;
 
         if (searchKey) {
             this.filteredChildOptions = this.childOptions.filter((opt) => opt.label.toLowerCase().includes(searchKey));
@@ -730,6 +743,7 @@ export default class DocGenQueryBuilder extends LightningElement {
 
     handleChildFocus() {
         this.showChildDropdown = true;
+        this._childActiveIndex = -1;
         this.filteredChildOptions = this.childOptions.filter((opt) =>
             opt.label.toLowerCase().includes((this.selectedChildLabel || '').toLowerCase())
         );
@@ -738,10 +752,14 @@ export default class DocGenQueryBuilder extends LightningElement {
     handleChildSelect(event) {
         const value = event.currentTarget.dataset.value;
         const label = event.currentTarget.dataset.label;
+        this._selectChild(value, label);
+    }
 
+    _selectChild(value, label) {
         this.selectedChildRel = value;
         this.selectedChildLabel = label;
         this.showChildDropdown = false;
+        this._childActiveIndex = -1;
     }
 
     // --- Child Clauses ---
@@ -768,6 +786,7 @@ export default class DocGenQueryBuilder extends LightningElement {
         const key = event.target.value.toLowerCase();
         this.selectedParentLabel = event.target.value;
         this.showParentDropdown = true;
+        this._parentActiveIndex = -1;
         this.filteredParentOptions = key
             ? this.parentOptions.filter((o) => o.label.toLowerCase().includes(key))
             : this.parentOptions;
@@ -775,6 +794,7 @@ export default class DocGenQueryBuilder extends LightningElement {
 
     handleParentFocus() {
         this.showParentDropdown = true;
+        this._parentActiveIndex = -1;
         this.filteredParentOptions = this.parentOptions.filter((opt) =>
             opt.label.toLowerCase().includes((this.selectedParentLabel || '').toLowerCase())
         );
@@ -784,10 +804,14 @@ export default class DocGenQueryBuilder extends LightningElement {
         const value = event.currentTarget.dataset.value;
         const label = event.currentTarget.dataset.label;
         const targetObj = event.currentTarget.dataset.target;
+        this._selectParent(value, label, targetObj);
+    }
 
+    _selectParent(value, label, targetObj) {
         this.selectedParentRel = value;
         this.selectedParentLabel = label;
         this.showParentDropdown = false;
+        this._parentActiveIndex = -1;
 
         // Load fields for parent
         this.parentFieldOptions = [];
@@ -915,6 +939,153 @@ export default class DocGenQueryBuilder extends LightningElement {
 
     handleOutsideClick() {
         // ... (Existing)
+    }
+
+    // ── ARIA combobox: ids + active-descendant ──────────────────
+    get objectDropdownId() {
+        return 'qb-obj-dd';
+    }
+    get parentDropdownId() {
+        return 'qb-par-dd';
+    }
+    get childDropdownId() {
+        return 'qb-child-dd';
+    }
+    _optionId(prefix, value) {
+        return 'qb-' + prefix + '-' + String(value || '').replace(/[^A-Za-z0-9_-]/g, '-');
+    }
+
+    get objectActiveDescendantId() {
+        if (!this.showObjectDropdown || this._objectActiveIndex < 0) return null;
+        const opt = this.filteredObjectOptions[this._objectActiveIndex];
+        return opt ? this._optionId('obj', opt.value) : null;
+    }
+    get parentActiveDescendantId() {
+        if (!this.showParentDropdown || this._parentActiveIndex < 0) return null;
+        const opt = this.filteredParentOptions[this._parentActiveIndex];
+        return opt ? this._optionId('par', opt.value) : null;
+    }
+    get childActiveDescendantId() {
+        if (!this.showChildDropdown || this._childActiveIndex < 0) return null;
+        const opt = this.filteredChildOptions[this._childActiveIndex];
+        return opt ? this._optionId('child', opt.value) : null;
+    }
+
+    // Decorated option lists: each item gets _optionId + _ariaSelected so the
+    // template can bind id/aria-selected without inline expressions.
+    get filteredObjectOptionsForListbox() {
+        const idx = this._objectActiveIndex;
+        return (this.filteredObjectOptions || []).map((opt, i) => ({
+            ...opt,
+            _optionId: this._optionId('obj', opt.value),
+            _ariaSelected: i === idx ? 'true' : 'false'
+        }));
+    }
+    get filteredParentOptionsForListbox() {
+        const idx = this._parentActiveIndex;
+        return (this.filteredParentOptions || []).map((opt, i) => ({
+            ...opt,
+            _optionId: this._optionId('par', opt.value),
+            _ariaSelected: i === idx ? 'true' : 'false'
+        }));
+    }
+    get filteredChildOptionsForListbox() {
+        const idx = this._childActiveIndex;
+        return (this.filteredChildOptions || []).map((opt, i) => ({
+            ...opt,
+            _optionId: this._optionId('child', opt.value),
+            _ariaSelected: i === idx ? 'true' : 'false'
+        }));
+    }
+
+    // ── Combobox keyboard navigation ───────────────────────────
+    handleObjectKeydown(event) {
+        this._handleComboKeydown(event, 'object');
+    }
+    handleParentKeydown(event) {
+        this._handleComboKeydown(event, 'parent');
+    }
+    handleChildKeydown(event) {
+        this._handleComboKeydown(event, 'child');
+    }
+
+    _handleComboKeydown(event, type) {
+        let options;
+        let idx;
+        let setIdx;
+        let close;
+        let select;
+        if (type === 'object') {
+            options = this.filteredObjectOptions;
+            idx = this._objectActiveIndex;
+            setIdx = (n) => {
+                this._objectActiveIndex = n;
+            };
+            close = () => {
+                this.showObjectDropdown = false;
+                this._objectActiveIndex = -1;
+            };
+            select = (opt) => this._selectObject(opt.value, opt.label);
+        } else if (type === 'parent') {
+            options = this.filteredParentOptions;
+            idx = this._parentActiveIndex;
+            setIdx = (n) => {
+                this._parentActiveIndex = n;
+            };
+            close = () => {
+                this.showParentDropdown = false;
+                this._parentActiveIndex = -1;
+            };
+            select = (opt) => this._selectParent(opt.value, opt.label, opt.targetObject);
+        } else {
+            options = this.filteredChildOptions;
+            idx = this._childActiveIndex;
+            setIdx = (n) => {
+                this._childActiveIndex = n;
+            };
+            close = () => {
+                this.showChildDropdown = false;
+                this._childActiveIndex = -1;
+            };
+            select = (opt) => this._selectChild(opt.value, opt.label);
+        }
+
+        const len = (options || []).length;
+        switch (event.key) {
+            case 'ArrowDown':
+                event.preventDefault();
+                if (len === 0) return;
+                setIdx(idx < 0 ? 0 : (idx + 1) % len);
+                break;
+            case 'ArrowUp':
+                event.preventDefault();
+                if (len === 0) return;
+                setIdx(idx <= 0 ? len - 1 : idx - 1);
+                break;
+            case 'Home':
+                if (len === 0) return;
+                event.preventDefault();
+                setIdx(0);
+                break;
+            case 'End':
+                if (len === 0) return;
+                event.preventDefault();
+                setIdx(len - 1);
+                break;
+            case 'Enter':
+                if (idx >= 0 && idx < len) {
+                    event.preventDefault();
+                    select(options[idx]);
+                }
+                break;
+            case 'Escape':
+                event.preventDefault();
+                close();
+                break;
+            default:
+                // Other keys: typing in the input — handled by oninput.
+                break;
+        }
     }
 
     // --- Child Logic ---

--- a/force-app/main/default/lwc/docGenTreeBuilder/docGenTreeBuilder.html
+++ b/force-app/main/default/lwc/docGenTreeBuilder/docGenTreeBuilder.html
@@ -31,7 +31,9 @@
                 style="flex: 1"
             >
             </lightning-input>
-            <span style="font-size: 0.75rem; color: #706e6b; white-space: nowrap" aria-live="polite">{selectedCount} fields</span>
+            <span style="font-size: 0.75rem; color: #706e6b; white-space: nowrap" aria-live="polite"
+                >{selectedCount} fields</span
+            >
         </div>
 
         <template if:true={hasRoot}>

--- a/force-app/main/default/lwc/docGenTreeBuilder/docGenTreeBuilder.html
+++ b/force-app/main/default/lwc/docGenTreeBuilder/docGenTreeBuilder.html
@@ -1,8 +1,12 @@
 <template>
-    <div style="border: 1px solid #e5e5e5; border-radius: 8px; background: #fff; font-size: 0.82rem">
+    <div
+        role="region"
+        aria-label="Query builder"
+        style="border: 1px solid #e5e5e5; border-radius: 8px; background: #fff; font-size: 0.82rem"
+    >
         <!-- Header bar -->
         <div style="padding: 8px 14px; border-bottom: 1px solid #e5e5e5; display: flex; align-items: center; gap: 10px">
-            <span
+            <h2
                 style="
                     font-weight: 700;
                     color: #181818;
@@ -10,13 +14,16 @@
                     align-items: center;
                     gap: 6px;
                     white-space: nowrap;
+                    font-size: inherit;
+                    margin: 0;
                 "
             >
                 <lightning-icon icon-name="standard:record" size="xx-small"></lightning-icon>
                 {selectedObject}
-            </span>
+            </h2>
             <lightning-input
                 type="search"
+                label="Search all fields and relationships"
                 placeholder="Search all fields and relationships..."
                 variant="label-hidden"
                 value={globalSearch}
@@ -24,7 +31,7 @@
                 style="flex: 1"
             >
             </lightning-input>
-            <span style="font-size: 0.75rem; color: #706e6b; white-space: nowrap">{selectedCount} fields</span>
+            <span style="font-size: 0.75rem; color: #706e6b; white-space: nowrap" aria-live="polite">{selectedCount} fields</span>
         </div>
 
         <template if:true={hasRoot}>

--- a/force-app/main/default/lwc/docGenTreeNode/docGenTreeNode.css
+++ b/force-app/main/default/lwc/docGenTreeNode/docGenTreeNode.css
@@ -1,0 +1,32 @@
+/* Reset for <button> elements that visually look like inline links/pills.
+   Inline `style` attributes (more specific than this class) restore any
+   per-button visual treatment (border, padding, background) on top of
+   the reset. */
+.bare-button {
+    background: none;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    text-align: inherit;
+    -webkit-appearance: none;
+    appearance: none;
+    line-height: inherit;
+}
+
+/* SLDS-flavored visible focus indicator for keyboard users only.
+   Mouse clicks do not trigger :focus-visible in modern browsers. */
+.bare-button:focus-visible {
+    outline: 2px solid #0176d3;
+    outline-offset: 2px;
+    border-radius: 4px;
+}
+
+/* Same focus-visible treatment for native inputs that lost their
+   default outline via removal of `outline: none`. */
+input:focus-visible {
+    outline: 2px solid #0176d3;
+    outline-offset: 1px;
+}

--- a/force-app/main/default/lwc/docGenTreeNode/docGenTreeNode.html
+++ b/force-app/main/default/lwc/docGenTreeNode/docGenTreeNode.html
@@ -531,12 +531,7 @@
                                 data-rel={cr.slotKey}
                                 onclick={handleRemoveChild}
                                 aria-label={cr.removeLabel}
-                                style="
-                                    color: #ccc;
-                                    font-size: 0.85rem;
-                                    margin-left: auto;
-                                    padding: 0 4px;
-                                "
+                                style="color: #ccc; font-size: 0.85rem; margin-left: auto; padding: 0 4px"
                                 title={cr.removeLabel}
                             >
                                 &times;

--- a/force-app/main/default/lwc/docGenTreeNode/docGenTreeNode.html
+++ b/force-app/main/default/lwc/docGenTreeNode/docGenTreeNode.html
@@ -1,5 +1,6 @@
 <template>
-    <div style={indentStyle}>
+    <div style={indentStyle} role="group" aria-labelledby={headingId}>
+        <h3 id={headingId} class="slds-assistive-text">{nodeAccessibleHeading}</h3>
         <div style="padding: 8px 14px; border-bottom: 1px solid #f0f0f0">
             <!-- ═══ Selected field pills + picker toggle ═══ -->
             <div style="display: flex; align-items: flex-start; gap: 8px; flex-wrap: wrap">
@@ -21,13 +22,17 @@
                     >
                         <span style="color: #1a56db">{sf.displayLabel}</span>
                         <span style="color: #aaa; font-family: monospace; font-size: 0.65rem">{sf.apiName}</span>
-                        <a
-                            href="javascript:void(0)"
+                        <button
+                            type="button"
+                            class="bare-button"
                             data-api={sf.apiName}
                             onclick={handleRemoveField}
-                            style="color: #999; text-decoration: none; margin-left: 2px; font-size: 0.7rem"
-                            >&times;</a
+                            aria-label={sf.removeLabel}
+                            title={sf.removeLabel}
+                            style="color: #999; margin-left: 2px; font-size: 0.7rem"
                         >
+                            &times;
+                        </button>
                     </span>
                 </template>
 
@@ -55,23 +60,30 @@
                                 <span style="color: #aaa; font-family: monospace; font-size: 0.65rem"
                                     >{pr.value}.{pf.apiName}</span
                                 >
-                                <a
-                                    href="javascript:void(0)"
+                                <button
+                                    type="button"
+                                    class="bare-button"
                                     data-api={pf.apiName}
                                     data-rel={pr.value}
                                     onclick={handleRemoveParentField}
-                                    style="color: #999; text-decoration: none; margin-left: 2px; font-size: 0.7rem"
-                                    >&times;</a
+                                    aria-label={pf.removeLabel}
+                                    title={pf.removeLabel}
+                                    style="color: #999; margin-left: 2px; font-size: 0.7rem"
                                 >
+                                    &times;
+                                </button>
                             </span>
                         </template>
                     </template>
                 </template>
 
                 <!-- Add fields button -->
-                <a
-                    href="javascript:void(0)"
+                <button
+                    type="button"
+                    class="bare-button"
                     onclick={togglePicker}
+                    aria-expanded={showPicker}
+                    aria-controls={fieldPickerId}
                     style="
                         display: inline-flex;
                         align-items: center;
@@ -81,18 +93,20 @@
                         font-size: 0.75rem;
                         color: #1a56db;
                         border: 1px dashed #c7d7f5;
-                        text-decoration: none;
                         white-space: nowrap;
                         background: #fafbff;
                     "
                 >
                     + fields
-                </a>
+                </button>
             </div>
 
             <!-- ═══ Field picker dropdown ═══ -->
             <template if:true={showPicker}>
                 <div
+                    id={fieldPickerId}
+                    role="group"
+                    aria-label="Field picker"
                     style="
                         margin-top: 8px;
                         border: 1px solid #e5e5e5;
@@ -104,6 +118,7 @@
                     <input
                         type="text"
                         placeholder="Search fields..."
+                        aria-label="Search fields"
                         value={_pickerSearch}
                         oninput={handlePickerSearch}
                         style="
@@ -113,7 +128,6 @@
                             border-radius: 6px;
                             font-size: 0.8rem;
                             margin-bottom: 6px;
-                            outline: none;
                         "
                     />
                     <div
@@ -172,15 +186,16 @@
                     style="margin-top: 6px; margin-left: 12px; border-left: 2px solid #e9d5ff; padding-left: 10px"
                 >
                     <div style="display: flex; align-items: center; gap: 6px; margin-bottom: 4px">
-                        <a
-                            href="javascript:void(0)"
+                        <button
+                            type="button"
+                            class="bare-button"
                             data-rel={pr.value}
                             onclick={handleExpandParent}
+                            aria-expanded={pr.expanded}
                             style="
                                 font-weight: 600;
                                 font-size: 0.78rem;
                                 color: #7c3aed;
-                                text-decoration: none;
                                 display: flex;
                                 align-items: center;
                                 gap: 4px;
@@ -192,17 +207,36 @@
                                 style="--sds-c-icon-color-foreground-default: #7c3aed"
                             ></lightning-icon>
                             {pr.displayLabel}
-                        </a>
-                        <a
-                            href="javascript:void(0)"
+                        </button>
+                        <button
+                            type="button"
+                            class="bare-button"
                             data-rel={pr.value}
                             onclick={handleRemoveParent}
-                            style="color: #ccc; text-decoration: none; font-size: 0.8rem; margin-left: auto"
-                            title="Remove"
-                            >&times;</a
+                            aria-label={pr.removeLabel}
+                            style="color: #ccc; font-size: 0.8rem; margin-left: auto"
+                            title={pr.removeLabel}
                         >
+                            &times;
+                        </button>
                     </div>
                     <template if:true={pr.expanded}>
+                        <input
+                            type="text"
+                            placeholder="Search fields..."
+                            aria-label={pr.fieldSearchAriaLabel}
+                            value={pr.fieldSearchValue}
+                            data-rel={pr.value}
+                            oninput={handleParentFieldSearch}
+                            style="
+                                width: 100%;
+                                padding: 5px 9px;
+                                border: 1px solid #d8dde6;
+                                border-radius: 6px;
+                                font-size: 0.75rem;
+                                margin-bottom: 4px;
+                            "
+                        />
                         <div
                             style="
                                 max-height: 160px;
@@ -261,9 +295,12 @@
 
             <!-- ═══ Add related data / parent lookup buttons ═══ -->
             <div style="margin-top: 8px; display: flex; gap: 6px; flex-wrap: wrap">
-                <a
-                    href="javascript:void(0)"
+                <button
+                    type="button"
+                    class="bare-button"
                     onclick={toggleRelPicker}
+                    aria-expanded={showRelPicker}
+                    aria-controls={relPickerId}
                     style="
                         display: inline-flex;
                         align-items: center;
@@ -273,15 +310,17 @@
                         font-size: 0.75rem;
                         color: #065f46;
                         border: 1px dashed #a7f3d0;
-                        text-decoration: none;
                         background: #f0fdf4;
                     "
                 >
                     + related list
-                </a>
-                <a
-                    href="javascript:void(0)"
+                </button>
+                <button
+                    type="button"
+                    class="bare-button"
                     onclick={toggleParentPicker}
+                    aria-expanded={showParentPicker}
+                    aria-controls={parentPickerId}
                     style="
                         display: inline-flex;
                         align-items: center;
@@ -291,17 +330,19 @@
                         font-size: 0.75rem;
                         color: #7c3aed;
                         border: 1px dashed #d8c4f0;
-                        text-decoration: none;
                         background: #faf5ff;
                     "
                 >
                     + parent lookup
-                </a>
+                </button>
             </div>
 
             <!-- ═══ Related list picker dropdown ═══ -->
             <template if:true={showRelPicker}>
                 <div
+                    id={relPickerId}
+                    role="group"
+                    aria-label="Related list picker"
                     style="
                         margin-top: 6px;
                         border: 1px solid #e5e5e5;
@@ -313,6 +354,7 @@
                     <input
                         type="text"
                         placeholder="Search related lists..."
+                        aria-label="Search related lists"
                         value={_relPickerSearch}
                         oninput={handleRelPickerSearch}
                         style="
@@ -322,14 +364,14 @@
                             border-radius: 6px;
                             font-size: 0.8rem;
                             margin-bottom: 6px;
-                            outline: none;
                         "
                     />
                     <div style="max-height: 180px; overflow-y: auto">
                         <template for:each={filteredChildRels} for:item="cr">
-                            <a
+                            <button
                                 key={cr.value}
-                                href="javascript:void(0)"
+                                type="button"
+                                class="bare-button"
                                 data-rel={cr.value}
                                 onclick={handleExpandChildFromPicker}
                                 style="
@@ -338,10 +380,9 @@
                                     gap: 6px;
                                     padding: 5px 8px;
                                     font-size: 0.8rem;
-                                    text-decoration: none;
                                     color: #065f46;
                                     border-radius: 4px;
-                                    cursor: pointer;
+                                    width: 100%;
                                 "
                                 onmouseover={_hoverIn}
                                 onmouseout={_hoverOut}
@@ -349,7 +390,7 @@
                                 <lightning-icon icon-name="standard:related_list" size="xx-small"></lightning-icon>
                                 <span style="font-weight: 500">{cr.displayLabel}</span>
                                 <span style="color: #999; font-size: 0.68rem; font-family: monospace">{cr.value}</span>
-                            </a>
+                            </button>
                         </template>
                     </div>
                 </div>
@@ -358,6 +399,9 @@
             <!-- ═══ Parent lookup picker dropdown ═══ -->
             <template if:true={showParentPicker}>
                 <div
+                    id={parentPickerId}
+                    role="group"
+                    aria-label="Parent lookup picker"
                     style="
                         margin-top: 6px;
                         border: 1px solid #e5e5e5;
@@ -369,6 +413,7 @@
                     <input
                         type="text"
                         placeholder="Search parent lookups..."
+                        aria-label="Search parent lookups"
                         value={_parentRelPickerSearch}
                         oninput={handleParentRelPickerSearch}
                         style="
@@ -378,14 +423,14 @@
                             border-radius: 6px;
                             font-size: 0.8rem;
                             margin-bottom: 6px;
-                            outline: none;
                         "
                     />
                     <div style="max-height: 180px; overflow-y: auto">
                         <template for:each={filteredParentRels} for:item="pr">
-                            <a
+                            <button
                                 key={pr.value}
-                                href="javascript:void(0)"
+                                type="button"
+                                class="bare-button"
                                 data-rel={pr.value}
                                 onclick={handleExpandParentFromPicker}
                                 style="
@@ -394,10 +439,9 @@
                                     gap: 6px;
                                     padding: 5px 8px;
                                     font-size: 0.8rem;
-                                    text-decoration: none;
                                     color: #7c3aed;
                                     border-radius: 4px;
-                                    cursor: pointer;
+                                    width: 100%;
                                 "
                                 onmouseover={_hoverIn}
                                 onmouseout={_hoverOut}
@@ -409,7 +453,7 @@
                                 ></lightning-icon>
                                 <span style="font-weight: 500">{pr.displayLabel}</span>
                                 <span style="color: #999; font-size: 0.68rem; font-family: monospace">{pr.value}</span>
-                            </a>
+                            </button>
                         </template>
                     </div>
                 </div>
@@ -481,20 +525,22 @@
                             <span style="font-size: 0.65rem; color: #999; font-weight: 400; font-family: monospace"
                                 >{cr.value}</span
                             >
-                            <a
-                                href="javascript:void(0)"
+                            <button
+                                type="button"
+                                class="bare-button"
                                 data-rel={cr.slotKey}
                                 onclick={handleRemoveChild}
+                                aria-label={cr.removeLabel}
                                 style="
                                     color: #ccc;
-                                    text-decoration: none;
                                     font-size: 0.85rem;
                                     margin-left: auto;
                                     padding: 0 4px;
                                 "
-                                title="Remove"
-                                >&times;</a
+                                title={cr.removeLabel}
                             >
+                                &times;
+                            </button>
                         </div>
                         <c-doc-gen-tree-node
                             node-data={cr.nodeData}

--- a/force-app/main/default/lwc/docGenTreeNode/docGenTreeNode.js
+++ b/force-app/main/default/lwc/docGenTreeNode/docGenTreeNode.js
@@ -39,9 +39,12 @@ export default class DocGenTreeNode extends LightningElement {
     get pickerFields() {
         if (!this.nodeData || !this.nodeData.fields) return [];
         const s = this._pickerSearch || this.globalSearch || '';
-        return this.nodeData.fields
-            .filter((f) => !s || f.displayLabel.toLowerCase().includes(s) || f.apiName.toLowerCase().includes(s))
-            .slice(0, 100);
+        const filtered = this.nodeData.fields.filter(
+            (f) => !s || f.displayLabel.toLowerCase().includes(s) || f.apiName.toLowerCase().includes(s)
+        );
+        // Cap exists to protect the DOM when there's no search; once the user
+        // is actively filtering, show every match so nothing is hidden.
+        return s ? filtered : filtered.slice(0, 200);
     }
 
     handlePickerToggleField(event) {
@@ -186,7 +189,12 @@ export default class DocGenTreeNode extends LightningElement {
     // ── Template getters ────────────────────────────────────────
     get selectedFields() {
         if (!this.nodeData || !this.nodeData.fields) return [];
-        return this.nodeData.fields.filter((f) => f.checked);
+        return this.nodeData.fields
+            .filter((f) => f.checked)
+            .map((f) => ({
+                ...f,
+                removeLabel: 'Remove field ' + (f.displayLabel || f.apiName)
+            }));
     }
 
     get hasSelectedFields() {
@@ -216,6 +224,36 @@ export default class DocGenTreeNode extends LightningElement {
         return 'padding-left: ' + px + 'px;';
     }
 
+    // ── A11y identifiers + labels ───────────────────────────────
+    // path strings can contain dots and colons (e.g. "Account.child:Contacts");
+    // sanitize for use as DOM ids referenced by aria-controls / aria-labelledby.
+    get _safePath() {
+        const p = this.nodeData && this.nodeData.path ? this.nodeData.path : 'root';
+        return p.replace(/[^A-Za-z0-9_-]/g, '-');
+    }
+    get headingId() {
+        return 'dgt-h-' + this._safePath;
+    }
+    get fieldPickerId() {
+        return 'dgt-fp-' + this._safePath;
+    }
+    get relPickerId() {
+        return 'dgt-rp-' + this._safePath;
+    }
+    get parentPickerId() {
+        return 'dgt-pp-' + this._safePath;
+    }
+    get nodeAccessibleHeading() {
+        if (!this.nodeData) return '';
+        const obj = this.nodeData.objectLabel || this.nodeData.objectName || 'Object';
+        const cnt = this.selectedFields.length;
+        const depth = this.depth || 0;
+        const parts = [obj + ' fields'];
+        if (depth > 0) parts.push('depth ' + depth);
+        if (cnt > 0) parts.push(cnt + ' selected');
+        return parts.join(', ');
+    }
+
     get nodeAlias() {
         return this.nodeData ? this.nodeData.alias || '' : '';
     }
@@ -229,6 +267,18 @@ export default class DocGenTreeNode extends LightningElement {
         return this.nodeData ? this.nodeData.limitAmount || '' : '';
     }
 
+    // Per-parent-rel field-picker search. Keyed by pr.value so multiple
+    // expanded parents keep independent filters. Reassigned (not mutated)
+    // so LWC reactivity picks up the change.
+    @track _parentFieldSearches = {};
+
+    handleParentFieldSearch(event) {
+        const rel = event.currentTarget.dataset.rel;
+        if (!rel) return;
+        const v = (event.target.value || '').toLowerCase();
+        this._parentFieldSearches = { ...this._parentFieldSearches, [rel]: v };
+    }
+
     // Parent rel data for template — filtered by global search
     get parentRelsList() {
         if (!this.nodeData || !this.nodeData.parentRels) return [];
@@ -239,13 +289,35 @@ export default class DocGenTreeNode extends LightningElement {
                     !gs || pr.expanded || this._matchesSearch(pr, gs) || (pr.fields && pr.fields.some((f) => f.checked))
             )
             .map((pr) => {
-                const selFields = pr.fields ? pr.fields.filter((f) => f.checked) : [];
+                const prLabel = pr.displayLabel || pr.value;
+                const selFields = pr.fields
+                    ? pr.fields
+                          .filter((f) => f.checked)
+                          .map((f) => ({
+                              ...f,
+                              removeLabel: 'Remove ' + prLabel + ' ' + (f.displayLabel || f.apiName)
+                          }))
+                    : [];
+                const fieldSearch = (this._parentFieldSearches[pr.value] || gs || '').toLowerCase();
+                const allFields = pr.fields || [];
+                const filteredFields = fieldSearch
+                    ? allFields.filter(
+                          (f) =>
+                              (f.displayLabel && f.displayLabel.toLowerCase().includes(fieldSearch)) ||
+                              (f.apiName && f.apiName.toLowerCase().includes(fieldSearch))
+                      )
+                    : allFields;
                 return {
                     ...pr,
                     selectedFields: selFields,
                     hasSelectedFields: selFields.length > 0,
                     selectedFieldCount: selFields.length,
-                    pickerFields: pr.fields ? pr.fields.slice(0, 100) : []
+                    // Same rule as the base field picker: when actively
+                    // searching, show every match; cap only the unfiltered case.
+                    pickerFields: fieldSearch ? filteredFields : filteredFields.slice(0, 200),
+                    fieldSearchValue: this._parentFieldSearches[pr.value] || '',
+                    fieldSearchAriaLabel: 'Search fields on ' + prLabel,
+                    removeLabel: 'Remove parent lookup ' + prLabel
                 };
             });
     }
@@ -291,23 +363,25 @@ export default class DocGenTreeNode extends LightningElement {
         // clicking again creates a filtered-subset slot rather than toggling
         // the existing one.
         const seen = new Set();
-        return this.nodeData.childRels
+        const filtered = this.nodeData.childRels
             .filter((cr) => {
                 if (seen.has(cr.value)) return false;
                 seen.add(cr.value);
                 return true;
             })
-            .filter((cr) => !s || cr.displayLabel.toLowerCase().includes(s) || cr.value.toLowerCase().includes(s))
-            .slice(0, 50);
+            .filter((cr) => !s || cr.displayLabel.toLowerCase().includes(s) || cr.value.toLowerCase().includes(s));
+        // Cap protects the DOM when unfiltered; with a search term the user
+        // is actively narrowing, so show every match.
+        return s ? filtered : filtered.slice(0, 100);
     }
 
     get filteredParentRels() {
         if (!this.nodeData || !this.nodeData.parentRels) return [];
         const s = this._parentRelPickerSearch;
-        return this.nodeData.parentRels
+        const filtered = this.nodeData.parentRels
             .filter((pr) => !pr.expanded)
-            .filter((pr) => !s || pr.displayLabel.toLowerCase().includes(s) || pr.value.toLowerCase().includes(s))
-            .slice(0, 50);
+            .filter((pr) => !s || pr.displayLabel.toLowerCase().includes(s) || pr.value.toLowerCase().includes(s));
+        return s ? filtered : filtered.slice(0, 100);
     }
 
     handleExpandChildFromPicker(event) {
@@ -349,13 +423,15 @@ export default class DocGenTreeNode extends LightningElement {
             .filter((cr) => !gs || cr.expanded || this._matchesSearch(cr, gs))
             .map((cr) => {
                 const count = cr.nodeData ? this._countNodeFields(cr.nodeData) : 0;
+                const crLabel = cr.displayLabel || cr.value;
                 return {
                     ...cr,
                     slotKey: cr._slotKey || cr.value,
                     hasSelectedCount: count > 0,
                     selectedCount: count,
                     nextDepth: parseInt(this.depth, 10) + 1,
-                    icon: cr.expanded ? 'utility:chevrondown' : 'utility:chevronright'
+                    icon: cr.expanded ? 'utility:chevrondown' : 'utility:chevronright',
+                    removeLabel: 'Remove related list ' + crLabel
                 };
             });
     }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -127,6 +127,7 @@
     "Portwood DocGen Managed@1.83.0-2": "04tVx000000Q4ZRIA0",
     "Portwood DocGen Managed@1.83.0-3": "04tVx000000Q4b3IAC",
     "Portwood DocGen Managed@1.83.0-4": "04tVx000000QE7NIAW",
-    "Portwood DocGen Managed@1.83.0-5": "04tVx000000QKRJIA4"
+    "Portwood DocGen Managed@1.83.0-5": "04tVx000000QKRJIA4",
+    "Portwood DocGen Managed@1.84.0-1": "04tVx000000QL2PIAW"
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,9 +1,9 @@
 {
   "packageDirectories": [
     {
-      "versionName": "1.83.0 — Rich Text & Nested Table Bug Fixes",
-      "versionNumber": "1.83.0.NEXT",
-      "ancestorId": "04tal000006rKBdAAM",
+      "versionName": "1.84.0 — Visual Builder Accessibility",
+      "versionNumber": "1.84.0.NEXT",
+      "ancestorId": "04tVx000000QKRJIA4",
       "path": "force-app",
       "default": true,
       "package": "Portwood DocGen Managed",


### PR DESCRIPTION
## Summary

- v1.84 release theme: **WCAG 2.1 AA accessibility** for the visual query builder, so blind / keyboard-only admins can author templates without using a mouse.
- 5 builder LWCs + the `docGenAdmin` embed got semantic-HTML + ARIA + keyboard support refactors. All non-semantic `<a>` / `<div>` / `<span>` / `<code>` click targets are now native `<button>` (35+ across the surface) so screen readers announce them as interactive.
- 3 custom listbox dropdowns in `docGenQueryBuilder` got full WAI-ARIA combobox: `role=combobox` + `aria-expanded/controls/activedescendant/autocomplete`, Arrow Up/Down/Home/End/Enter/Escape navigation, visual highlight on the keyboard-active option (WCAG 2.4.7).
- Both `docGenColumnBuilder` modals and both `docGenAdmin` modals got `aria-modal` + `aria-labelledby` + Esc-to-close. Initial focus moves to the close button on open, focus restores to the trigger on close.
- Page-level `aria-live="polite"` channel established at `docGenAdmin` — children dispatch a bubbling `CustomEvent('announce', {detail:{message}, composed:true})` and the message mirrors into the region. Wired but not yet instrumented (v1.85 polish).
- **Aesthetic preserved.** Inline styles kept; a `bare-button` CSS class resets browser button chrome so mouse users see no visual change. Custom dropdowns stay custom — no `<lightning-combobox>` swap.

### Side-improvements bundled in
- Per-pill `aria-label` includes the field name (so SR users hear "Remove field Name", not generic "Remove field").
- Expanded parent-lookup blocks in `docGenTreeNode` now have their own per-rel **search input** — fixes the wall-of-checkboxes problem on objects with many parent fields.
- Search result caps removed when a search term is active (was capping at 100/200 even mid-search).

## Package

- **04tVx000000QL2PIAW** — Portwood DocGen Managed @ 1.84.0-1 (Released)
- Install: https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000QL2PIAW
- Ancestor: 04tVx000000QKRJIA4 (1.83.0-5)

## Test plan

- [x] E2E: 192/192 assertions across 9 scripts on `docgen-designer`
- [x] Apex: 1201/1201 passing, 75% org-wide coverage
- [x] Code Analyzer: 0 High, 41 Moderate (all `pmd:ProtectSensitiveData` false positives)
- [x] Manual visual-parity smoke on `docgen-designer` (mouse interaction unchanged)
- [ ] Manual VoiceOver walkthrough on a deployed scratch — author a 3-field / 1-parent / 1-child template start-to-finish without mouse
- [ ] axe DevTools scan — 0 critical/serious violations under WCAG 2.1 AA
- [ ] Smoke install of `04tVx000000QL2PIAW` into `portwood-staging`

🤖 Generated with [Claude Code](https://claude.com/claude-code)