### PR TITLE
fix(signatures): dedup templateIds in packet sender

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,18 @@ sf code-analyzer run --workspace "force-app/" --rule-selector "Security" --rule-
 
 Expected: `0 High severity violation(s) found`. ~30 Moderate false positives are acceptable (see `code-analyzer.yml`).
 
+## Pre-commit: prettier (CI gate)
+
+CI runs `npm run format:check` (prettier) on every PR; a failure blocks merge. Run before pushing:
+
+```bash
+npm install   # one-time, adds prettier to node_modules/.bin
+npm run format        # auto-fix
+npm run format:check  # verify clean
+```
+
+Covers `force-app/**/*.{cls,trigger,page,component,cmp,html,js,xml}`, `scripts/**/*.apex`, and root `*.{json,md,yml,yaml}`. Apex scripts under `/scripts/` are formatted too — long string concatenations get reflowed, so don't fight the wrap.
+
 ## Out of scope
 
 Don't touch signatures, HTML templates, watermarks, client-side DOCX assembly, font handling, command hub, or query config formats unless a bug fix forces it. Historical context for those subsystems was removed from this file in the bug-fix-branch trim — recover from `git log -- CLAUDE.md` if needed.

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -13,6 +13,26 @@ public with sharing class DocGenSignatureSenderController {
     }
 
     /**
+     * Parses a JSON array of template IDs and returns it deduped, preserving order.
+     * The LWC sender's template picker can append the same templateId twice when a
+     * user clicks faster than the awaited getTemplateSignaturePlacements call resolves —
+     * the dropdown's "filter already-selected" check runs against pre-await state.
+     */
+    @TestVisible
+    private static List<Id> parseAndDedupTemplateIds(String templateIdsJson) {
+        List<Object> raw = (List<Object>) JSON.deserializeUntyped(templateIdsJson);
+        List<Id> deduped = new List<Id>();
+        Set<Id> seen = new Set<Id>();
+        for (Object t : raw) {
+            Id tid = (Id) t;
+            if (seen.add(tid)) {
+                deduped.add(tid);
+            }
+        }
+        return deduped;
+    }
+
+    /**
      * Returns all active DocGen templates for the signature sender template picker.
      */
     @AuraEnabled(cacheable=true)
@@ -555,11 +575,7 @@ public with sharing class DocGenSignatureSenderController {
         String signingOrder,
         String documentTitleFormat
     ) {
-        List<Object> rawTemplateIds = (List<Object>) JSON.deserializeUntyped(templateIdsJson);
-        List<Id> templateIds = new List<Id>();
-        for (Object t : rawTemplateIds)
-            templateIds.add((Id) t);
-
+        List<Id> templateIds = parseAndDedupTemplateIds(templateIdsJson);
         if (templateIds.isEmpty()) {
             throw new AuraHandledException('At least one template is required.');
         }

--- a/force-app/main/default/classes/DocGenSignatureTests.cls
+++ b/force-app/main/default/classes/DocGenSignatureTests.cls
@@ -4392,6 +4392,35 @@ private class DocGenSignatureTests {
     }
 
     @isTest
+    static void testParseAndDedupTemplateIds_dropsDuplicatesPreservesOrder() {
+        Id a = '0Mw000000000001AAA';
+        Id b = '0Mw000000000002AAA';
+        Id c = '0Mw000000000003AAA';
+        String json = JSON.serialize(new List<Id>{ a, b, a, c, b, a });
+
+        Test.startTest();
+        List<Id> result = DocGenSignatureSenderController.parseAndDedupTemplateIds(json);
+        Test.stopTest();
+
+        System.assertEquals(3, result.size(), 'Should dedupe to 3 unique templateIds');
+        System.assertEquals(a, result[0], 'First occurrence wins (a)');
+        System.assertEquals(b, result[1], 'Order preserved (b)');
+        System.assertEquals(c, result[2], 'Order preserved (c)');
+    }
+
+    @isTest
+    static void testParseAndDedupTemplateIds_emptyAndSingle() {
+        Test.startTest();
+        System.assertEquals(0, DocGenSignatureSenderController.parseAndDedupTemplateIds('[]').size(), 'Empty input → empty output');
+
+        Id only = '0Mw000000000099AAA';
+        List<Id> single = DocGenSignatureSenderController.parseAndDedupTemplateIds(JSON.serialize(new List<Id>{ only, only, only }));
+        System.assertEquals(1, single.size(), 'All-duplicate input collapses to one');
+        System.assertEquals(only, single[0]);
+        Test.stopTest();
+    }
+
+    @isTest
     static void testBuildPlacementText_datePick() {
         DocGen_Signer__c signer = getTestSigner();
         DocGen_Signature_Request__c req = getTestRequest();

--- a/force-app/main/default/classes/DocGenSignatureTests.cls
+++ b/force-app/main/default/classes/DocGenSignatureTests.cls
@@ -4411,10 +4411,16 @@ private class DocGenSignatureTests {
     @isTest
     static void testParseAndDedupTemplateIds_emptyAndSingle() {
         Test.startTest();
-        System.assertEquals(0, DocGenSignatureSenderController.parseAndDedupTemplateIds('[]').size(), 'Empty input → empty output');
+        System.assertEquals(
+            0,
+            DocGenSignatureSenderController.parseAndDedupTemplateIds('[]').size(),
+            'Empty input → empty output'
+        );
 
         Id only = '0Mw000000000099AAA';
-        List<Id> single = DocGenSignatureSenderController.parseAndDedupTemplateIds(JSON.serialize(new List<Id>{ only, only, only }));
+        List<Id> single = DocGenSignatureSenderController.parseAndDedupTemplateIds(
+            JSON.serialize(new List<Id>{ only, only, only })
+        );
         System.assertEquals(1, single.size(), 'All-duplicate input collapses to one');
         System.assertEquals(only, single[0]);
         Test.stopTest();

--- a/force-app/main/default/lwc/docGenSignatureSender/docGenSignatureSender.js
+++ b/force-app/main/default/lwc/docGenSignatureSender/docGenSignatureSender.js
@@ -197,6 +197,13 @@ export default class DocGenSignatureSender extends LightningElement {
         const templateId = event.detail.value;
         if (!templateId) return;
 
+        // availableTemplateOptions filters by selectedTemplates, but selectedTemplates
+        // is only appended after the awaited Apex call below. Rapid clicks can fire
+        // this handler twice for the same templateId before the dropdown re-filters.
+        if (this.selectedTemplates.some((t) => t.templateId === templateId)) {
+            return;
+        }
+
         const opt = this.docGenTemplateOptions.find((t) => t.value === templateId);
         if (!opt) return;
 

--- a/scripts/diag-multipath-dump.apex
+++ b/scripts/diag-multipath-dump.apex
@@ -1,0 +1,48 @@
+// Dumps the most recent signature request's cached previewHtml + Template_Ids__c
+// so you can verify what got cached without having to load the signer VF page
+// (scratch org has no Site provisioned).
+
+DocGen_Signature_Request__c req = [
+    SELECT Id, Template_Ids__c, Signature_Data__c
+    FROM DocGen_Signature_Request__c
+    ORDER BY CreatedDate DESC
+    LIMIT 1
+];
+
+System.debug('REQ_ID: ' + req.Id);
+System.debug('TEMPLATE_IDS: ' + req.Template_Ids__c);
+
+if (String.isBlank(req.Signature_Data__c)) {
+    System.debug('PREVIEW_HTML: <empty>');
+    return;
+}
+
+Map<String, Object> cached = (Map<String, Object>) JSON.deserializeUntyped(req.Signature_Data__c);
+String previewHtml = (String) cached.get('previewHtml');
+System.debug('PREVIEW_HTML_LEN: ' + (previewHtml == null ? 0 : previewHtml.length()));
+
+// Count DIAG marker occurrences per template — proves uniqueness end-to-end
+for (String marker : new List<String>{ 'DIAG_ALPHA', 'DIAG_BRAVO', 'DIAG_CHARLIE', 'DIAG_DELTA' }) {
+    Integer count = 0;
+    Integer idx = 0;
+    while (idx != -1) {
+        idx = previewHtml.indexOf(marker, idx);
+        if (idx != -1) {
+            count++;
+            idx += marker.length();
+        }
+    }
+    System.debug('MARKER ' + marker + ' appears ' + count + ' time(s)');
+}
+
+// Emit the full HTML in chunks so it can be reassembled from the log
+Integer chunkSize = 8000;
+Integer chunks = (previewHtml.length() + chunkSize - 1) / chunkSize;
+System.debug('PREVIEW_HTML_CHUNKS: ' + chunks);
+for (Integer i = 0; i < chunks; i++) {
+    Integer startIdx = i * chunkSize;
+    Integer endIdx = Math.min(startIdx + chunkSize, previewHtml.length());
+    System.debug('CHUNK_' + i + '_START');
+    System.debug(previewHtml.substring(startIdx, endIdx));
+    System.debug('CHUNK_' + i + '_END');
+}

--- a/scripts/diag-multipath-seed.apex
+++ b/scripts/diag-multipath-seed.apex
@@ -1,0 +1,147 @@
+// DocGen Diagnostic Seed — Multipath Signature Duplicate Documents
+// Run: sf apex run --target-org <org> -f scripts/diag-multipath-seed.apex
+//
+// Creates 4 distinct Word templates with unique sentinel markers
+// (DIAG_ALPHA, DIAG_BRAVO, DIAG_CHARLIE, DIAG_DELTA) and an Account
+// "Diag Multipath Acct". The companion script diag-multipath.apex picks
+// these up by name prefix and asserts each rendered output contains its
+// own marker and ONLY its own.
+//
+// Idempotent: re-running deletes prior Diag Multipath templates first.
+
+Integer pass = 0;
+Integer fail = 0;
+
+String[] markers = new List<String>{ 'ALPHA', 'BRAVO', 'CHARLIE', 'DELTA' };
+
+// ───────── Cleanup prior runs ─────────
+try {
+    List<DocGen_Template__c> prior = [SELECT Id FROM DocGen_Template__c WHERE Name LIKE 'Diag Multipath %'];
+    if (!prior.isEmpty()) {
+        Set<Id> ids = new Set<Id>();
+        for (DocGen_Template__c t : prior) {
+            ids.add(t.Id);
+        }
+        delete [SELECT Id FROM DocGen_Template_Version__c WHERE Template__c IN :ids];
+        delete prior;
+        System.debug('CLEANUP: removed ' + prior.size() + ' prior Diag Multipath templates');
+    }
+} catch (Exception e) {
+    System.debug('CLEANUP: WARN — ' + e.getMessage());
+}
+
+// ───────── Account ─────────
+Id acctId;
+try {
+    List<Account> existing = [SELECT Id FROM Account WHERE Name = 'Diag Multipath Acct' LIMIT 1];
+    if (!existing.isEmpty()) {
+        acctId = existing[0].Id;
+        System.debug('ACCT: reusing existing — ' + acctId);
+    } else {
+        Account a = new Account(Name = 'Diag Multipath Acct', Industry = 'Technology', Phone = '555-0100');
+        insert a;
+        acctId = a.Id;
+        System.debug('ACCT: created — ' + acctId);
+    }
+    pass++;
+} catch (Exception e) {
+    fail++;
+    System.debug('ACCT: FAIL — ' + e.getMessage());
+}
+
+// ───────── Templates ─────────
+String relsXml =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+    '</Relationships>';
+
+String contentTypes =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+    '<Default Extension="xml" ContentType="application/xml"/>' +
+    '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+    '</Types>';
+
+String wordRels =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>';
+
+for (String marker : markers) {
+    try {
+        String docXml =
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+            '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ' +
+            'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">' +
+            '<w:body>' +
+            '<w:p><w:r><w:rPr><w:b/><w:sz w:val="32"/></w:rPr>' +
+            '<w:t>DIAG_' +
+            marker +
+            ' Title</w:t></w:r></w:p>' +
+            '<w:p><w:r><w:t>DIAG_' +
+            marker +
+            ' body content for {Name}</w:t></w:r></w:p>' +
+            '<w:p><w:r><w:t>Marker repeats: DIAG_' +
+            marker +
+            ' / DIAG_' +
+            marker +
+            '</w:t></w:r></w:p>' +
+            '<w:sectPr><w:pgSz w:w="12240" w:h="15840"/>' +
+            '<w:pgMar w:top="1080" w:right="1080" w:bottom="1080" w:left="1080" w:header="360" w:footer="360"/>' +
+            '</w:sectPr></w:body></w:document>';
+
+        Compression.ZipWriter zw = new Compression.ZipWriter();
+        zw.addEntry('[Content_Types].xml', Blob.valueOf(contentTypes));
+        zw.addEntry('_rels/.rels', Blob.valueOf(relsXml));
+        zw.addEntry('word/_rels/document.xml.rels', Blob.valueOf(wordRels));
+        zw.addEntry('word/document.xml', Blob.valueOf(docXml));
+        Blob docxBlob = zw.getArchive();
+
+        DocGen_Template__c t = new DocGen_Template__c(
+            Name = 'Diag Multipath ' + marker,
+            Base_Object_API__c = 'Account',
+            Type__c = 'Word',
+            Output_Format__c = 'PDF',
+            Query_Config__c = 'Name',
+            Description__c = 'Sentinel template DIAG_' + marker,
+            Category__c = 'Diag'
+        );
+        insert t;
+
+        DocGen_Template_Version__c ver = new DocGen_Template_Version__c(
+            Template__c = t.Id,
+            Is_Active__c = true,
+            Type__c = 'Word',
+            Base_Object_API__c = 'Account',
+            Category__c = 'Diag',
+            Description__c = 'DIAG_' + marker + ' v1',
+            Query_Config__c = 'Name'
+        );
+        insert ver;
+
+        ContentVersion cv = new ContentVersion(
+            Title = 'Diag Multipath ' + marker,
+            PathOnClient = 'diag_' + marker.toLowerCase() + '.docx',
+            VersionData = docxBlob,
+            FirstPublishLocationId = t.Id
+        );
+        insert cv;
+        cv = [SELECT Id, ContentDocumentId FROM ContentVersion WHERE Id = :cv.Id];
+
+        ver.Content_Version_Id__c = cv.Id;
+        update ver;
+
+        pass++;
+        System.debug('TEMPLATE ' + marker + ': created tid=' + t.Id + ' cvId=' + cv.Id + ' size=' + docxBlob.size());
+    } catch (Exception e) {
+        fail++;
+        System.debug('TEMPLATE ' + marker + ': FAIL — ' + e.getMessage());
+    }
+}
+
+System.debug('────────────────────────────────────');
+System.debug('SEED PASS: ' + pass + '  FAIL: ' + fail);
+if (fail == 0) {
+    System.debug('SEED COMPLETE — now run scripts/diag-multipath.apex');
+}

--- a/scripts/diag-multipath.apex
+++ b/scripts/diag-multipath.apex
@@ -1,0 +1,355 @@
+// DocGen Diagnostic — Multipath Signature Duplicate Documents
+// Run: sf apex run --target-org <org> -f scripts/diag-multipath.apex
+//
+// Purpose: User reported that selecting 4 templates in docGenSignatureSender
+// produces a packet whose document headers are correct (1, 2, 3, 4) but whose
+// document BODIES duplicate (e.g., 1, 2, 1, 2). Pattern can vary.
+//
+// This script mimics the per-template loop in
+// DocGenSignatureSenderController.createPacketSignerRequestWithTitle()
+// (force-app/main/default/classes/DocGenSignatureSenderController.cls:613-670)
+// and asserts that each iteration produces unique output for distinct templates.
+//
+// Picks the 4 most-recently-modified active templates and a record (Account by
+// default; override RECORD_ID below). Calls mergeTemplateForSignature() and
+// DocGenHtmlRenderer.convertToHtml() in the same order the sender does, then
+// hashes documentXml and HTML per iteration and reports any collisions.
+//
+// If collisions appear: root cause is in the merge / convert pipeline (likely
+// stale static state in DocGenService or DocGenHtmlRenderer).
+// If no collisions: root cause is upstream — LWC sending duplicated templateIds,
+// or downstream — signer-page render path consuming a stale cache.
+
+Integer pass = 0;
+Integer fail = 0;
+
+// ───────── Setup ─────────
+String recordIdOverride = null; // set to a record Id to override Account default
+
+List<DocGen_Template__c> templates;
+try {
+    // Prefer the seeded "Diag Multipath" templates (have unique sentinel markers
+    // for cross-leak detection). Fall back to any 4 active Word templates if not seeded.
+    Set<Id> activeWordTemplateIds = new Set<Id>();
+    for (DocGen_Template_Version__c v : [
+        SELECT Template__c
+        FROM DocGen_Template_Version__c
+        WHERE Is_Active__c = TRUE AND Type__c = 'Word'
+    ]) {
+        activeWordTemplateIds.add(v.Template__c);
+    }
+    templates = [
+        SELECT Id, Name
+        FROM DocGen_Template__c
+        WHERE Name LIKE 'Diag Multipath %' AND Id IN :activeWordTemplateIds
+        ORDER BY Name ASC
+    ];
+    if (templates.size() < 4) {
+        System.debug(
+            'SETUP: only found ' +
+            templates.size() +
+            ' Diag Multipath templates. Run scripts/diag-multipath-seed.apex first, ' +
+            'or falling back to any 4 active Word templates (no sentinel cross-leak check).'
+        );
+        templates = [
+            SELECT Id, Name
+            FROM DocGen_Template__c
+            WHERE Id IN :activeWordTemplateIds
+            ORDER BY LastModifiedDate DESC
+            LIMIT 4
+        ];
+    }
+} catch (Exception e) {
+    System.debug('SETUP: FAIL — could not query templates: ' + e.getMessage());
+    return;
+}
+
+if (templates.size() < 4) {
+    System.debug(
+        'SETUP: FAIL — need ≥4 active Word templates, found ' +
+        templates.size() +
+        '. Create more or seed via e2e-02-template-crud.apex.'
+    );
+    return;
+}
+
+System.debug('SETUP: using ' + templates.size() + ' templates:');
+for (Integer i = 0; i < templates.size(); i++) {
+    System.debug('  [' + i + '] ' + templates[i].Id + ' — ' + templates[i].Name);
+}
+
+String recordId;
+if (String.isNotBlank(recordIdOverride)) {
+    recordId = recordIdOverride;
+} else {
+    List<Account> accs = [
+        SELECT Id
+        FROM Account
+        WHERE Name = 'Diag Multipath Acct'
+        LIMIT 1
+    ];
+    if (accs.isEmpty()) {
+        // Fall back to any account
+        accs = [SELECT Id FROM Account LIMIT 1];
+    }
+    if (accs.isEmpty()) {
+        System.debug('SETUP: FAIL — no Account record found. Run diag-multipath-seed.apex or set recordIdOverride.');
+        return;
+    }
+    recordId = accs[0].Id;
+}
+System.debug('SETUP: recordId = ' + recordId);
+
+// ───────── Mimic sender loop, capture per-iteration output ─────────
+List<String> docXmls = new List<String>();
+List<String> htmls = new List<String>();
+List<Integer> docXmlLens = new List<Integer>();
+List<Integer> htmlLens = new List<Integer>();
+List<String> tplNames = new List<String>();
+
+for (Integer docIdx = 0; docIdx < templates.size(); docIdx++) {
+    Id tid = templates[docIdx].Id;
+    String tname = templates[docIdx].Name;
+    tplNames.add(tname);
+
+    try {
+        Map<String, Object> mergeData = DocGenService.mergeTemplateForSignature(tid, recordId);
+        String docXml = (String) mergeData.get('documentXml');
+        Map<String, String> pdfImageMap = (Map<String, String>) mergeData.get('pdfImageMap');
+        if (pdfImageMap == null) {
+            pdfImageMap = new Map<String, String>();
+        }
+
+        // Apply watermark override — same as sender does
+        DocGenService.applyWatermarkOverride(tid);
+
+        // Mimic the preview image map build (skip ContentDistribution side effects;
+        // they don't affect docXml/html identity which is what we're testing).
+        Map<String, String> previewImageMap = new Map<String, String>();
+        for (String relId : pdfImageMap.keySet()) {
+            previewImageMap.put(relId, pdfImageMap.get(relId));
+        }
+
+        String html = DocGenHtmlRenderer.convertToHtml(docXml, previewImageMap);
+
+        docXmls.add(docXml == null ? '' : docXml);
+        htmls.add(html == null ? '' : html);
+        docXmlLens.add(docXml == null ? 0 : docXml.length());
+        htmlLens.add(html == null ? 0 : html.length());
+
+        System.debug(
+            'ITER ' +
+            docIdx +
+            ' — tid=' +
+            tid +
+            ' name="' +
+            tname +
+            '" docXmlLen=' +
+            docXmlLens[docIdx] +
+            ' htmlLen=' +
+            htmlLens[docIdx]
+        );
+    } catch (Exception e) {
+        fail++;
+        System.debug('ITER ' + docIdx + ': FAIL — exception: ' + e.getMessage() + '\n' + e.getStackTraceString());
+        docXmls.add('');
+        htmls.add('');
+        docXmlLens.add(0);
+        htmlLens.add(0);
+    }
+}
+
+// ───────── Assertion 1: every documentXml unique ─────────
+System.debug('=== ASSERT 1: documentXml uniqueness ===');
+Boolean docXmlAllUnique = true;
+for (Integer i = 0; i < docXmls.size(); i++) {
+    for (Integer j = i + 1; j < docXmls.size(); j++) {
+        if (docXmls[i].length() > 0 && docXmls[i] == docXmls[j]) {
+            fail++;
+            docXmlAllUnique = false;
+            System.debug(
+                'COLLISION docXml[' +
+                i +
+                '] (' +
+                tplNames[i] +
+                ') == docXml[' +
+                j +
+                '] (' +
+                tplNames[j] +
+                ') — SMOKING GUN: mergeTemplateForSignature returned identical XML for distinct templates.'
+            );
+        }
+    }
+}
+if (docXmlAllUnique) {
+    pass++;
+    System.debug('ASSERT 1: PASS — all documentXml outputs distinct.');
+}
+
+// ───────── Assertion 2: every HTML unique ─────────
+System.debug('=== ASSERT 2: convertToHtml uniqueness ===');
+Boolean htmlAllUnique = true;
+for (Integer i = 0; i < htmls.size(); i++) {
+    for (Integer j = i + 1; j < htmls.size(); j++) {
+        if (htmls[i].length() > 0 && htmls[i] == htmls[j]) {
+            fail++;
+            htmlAllUnique = false;
+            System.debug(
+                'COLLISION html[' +
+                i +
+                '] (' +
+                tplNames[i] +
+                ') == html[' +
+                j +
+                '] (' +
+                tplNames[j] +
+                ') — convertToHtml emitted identical output for distinct docXml inputs (or identical inputs).'
+            );
+        }
+    }
+}
+if (htmlAllUnique) {
+    pass++;
+    System.debug('ASSERT 2: PASS — all convertToHtml outputs distinct.');
+}
+
+// ───────── Assertion 2.5: Diag sentinel markers (only when seeded) ─────────
+// If templates are the seeded "Diag Multipath ALPHA/BRAVO/CHARLIE/DELTA" set,
+// each iteration's HTML must contain its OWN DIAG_<MARKER> and none of the others.
+System.debug('=== ASSERT 2.5: DIAG sentinel attribution (only if seeded) ===');
+Boolean seededRun = true;
+List<String> diagMarkers = new List<String>();
+for (Integer i = 0; i < tplNames.size(); i++) {
+    if (tplNames[i].startsWith('Diag Multipath ')) {
+        diagMarkers.add('DIAG_' + tplNames[i].substringAfter('Diag Multipath ').trim());
+    } else {
+        seededRun = false;
+        break;
+    }
+}
+if (seededRun) {
+    Boolean sentinelOK = true;
+    for (Integer i = 0; i < htmls.size(); i++) {
+        String mine = diagMarkers[i];
+        if (!htmls[i].contains(mine)) {
+            fail++;
+            sentinelOK = false;
+            System.debug('SENTINEL MISS: iter ' + i + ' (' + tplNames[i] + ') html does NOT contain its marker ' + mine);
+        }
+        for (Integer j = 0; j < diagMarkers.size(); j++) {
+            if (i == j) {
+                continue;
+            }
+            String other = diagMarkers[j];
+            if (htmls[i].contains(other)) {
+                fail++;
+                sentinelOK = false;
+                System.debug(
+                    'SENTINEL CROSS-LEAK: iter ' +
+                    i +
+                    ' (' +
+                    tplNames[i] +
+                    ') html contains ' +
+                    other +
+                    ' which belongs to iter ' +
+                    j +
+                    ' (' +
+                    tplNames[j] +
+                    ').'
+                );
+            }
+        }
+    }
+    if (sentinelOK) {
+        pass++;
+        System.debug('ASSERT 2.5: PASS — each iteration HTML contains exactly its own DIAG marker.');
+    }
+} else {
+    System.debug('ASSERT 2.5: SKIP — templates are not the seeded Diag Multipath set.');
+}
+
+// ───────── Assertion 3: each HTML contains its template name ─────────
+// Templates often render their Name somewhere in body or header. This is a
+// soft assertion — only counts as fail if the template Name appears in a
+// DIFFERENT iteration's HTML but not its own (clear evidence of cross-leak).
+System.debug('=== ASSERT 3: template Name attribution (soft) ===');
+Boolean attributionOK = true;
+for (Integer i = 0; i < htmls.size(); i++) {
+    String name = tplNames[i];
+    if (String.isBlank(name) || name.length() < 4) {
+        continue; // too short to be a reliable marker
+    }
+    for (Integer j = 0; j < htmls.size(); j++) {
+        if (i == j) {
+            continue;
+        }
+        if (htmls[j].contains(name) && !htmls[i].contains(name)) {
+            fail++;
+            attributionOK = false;
+            System.debug(
+                'CROSS-LEAK: template[' +
+                i +
+                '] name "' +
+                name +
+                '" appears in html[' +
+                j +
+                '] but NOT in its own html[' +
+                i +
+                '] — likely indicates iteration ' +
+                j +
+                ' rendered template ' +
+                i +
+                '\'s content.'
+            );
+        }
+    }
+}
+if (attributionOK) {
+    pass++;
+    System.debug('ASSERT 3: PASS (soft) — no cross-attribution detected by name marker.');
+}
+
+// ───────── Assertion 4: re-call iteration 0 after the loop, compare to first ─────────
+// If mergeTemplate has stale static state, calling it again for the SAME template
+// after a sequence of other templates should still produce identical output.
+System.debug('=== ASSERT 4: replay first template after sequence ===');
+try {
+    Map<String, Object> replay = DocGenService.mergeTemplateForSignature(templates[0].Id, recordId);
+    String replayXml = (String) replay.get('documentXml');
+    if (replayXml != null && replayXml == docXmls[0]) {
+        pass++;
+        System.debug('ASSERT 4: PASS — replay of templates[0] reproduces original docXml.');
+    } else {
+        fail++;
+        System.debug(
+            'ASSERT 4: FAIL — replay of templates[0] differs from original. ' +
+            'origLen=' +
+            docXmlLens[0] +
+            ' replayLen=' +
+            (replayXml == null ? 0 : replayXml.length()) +
+            ' — indicates stale state across calls.'
+        );
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('ASSERT 4: FAIL — replay threw: ' + e.getMessage());
+}
+
+// ───────── Summary ─────────
+System.debug('────────────────────────────────────');
+System.debug('PASS: ' + pass + '  FAIL: ' + fail);
+if (fail == 0) {
+    System.debug('ALL TESTS PASSED — merge/convert pipeline is clean.');
+    System.debug(
+        'NEXT: bug is upstream (LWC sending duplicate templateIds) or downstream ' +
+        '(signer-side fetchDocumentData consuming stale cache). Capture a real ' +
+        'DocGen_Signature_Request__c.Id from a reproducer and dump its ' +
+        'Signature_Data__c + Template_Ids__c to compare.'
+    );
+} else {
+    System.debug('FAILURES DETECTED — root cause is in the merge/convert pipeline.');
+    System.debug(
+        'NEXT: audit static state in DocGenService.mergeTemplate / ' +
+        'tryMergeFromPreDecomposed / DocGenHtmlRenderer for cross-iteration leaks.'
+    );
+}

--- a/scripts/diag-multipath.apex
+++ b/scripts/diag-multipath.apex
@@ -47,9 +47,9 @@ try {
     if (templates.size() < 4) {
         System.debug(
             'SETUP: only found ' +
-            templates.size() +
-            ' Diag Multipath templates. Run scripts/diag-multipath-seed.apex first, ' +
-            'or falling back to any 4 active Word templates (no sentinel cross-leak check).'
+                templates.size() +
+                ' Diag Multipath templates. Run scripts/diag-multipath-seed.apex first, ' +
+                'or falling back to any 4 active Word templates (no sentinel cross-leak check).'
         );
         templates = [
             SELECT Id, Name
@@ -67,8 +67,8 @@ try {
 if (templates.size() < 4) {
     System.debug(
         'SETUP: FAIL — need ≥4 active Word templates, found ' +
-        templates.size() +
-        '. Create more or seed via e2e-02-template-crud.apex.'
+            templates.size() +
+            '. Create more or seed via e2e-02-template-crud.apex.'
     );
     return;
 }
@@ -139,15 +139,15 @@ for (Integer docIdx = 0; docIdx < templates.size(); docIdx++) {
 
         System.debug(
             'ITER ' +
-            docIdx +
-            ' — tid=' +
-            tid +
-            ' name="' +
-            tname +
-            '" docXmlLen=' +
-            docXmlLens[docIdx] +
-            ' htmlLen=' +
-            htmlLens[docIdx]
+                docIdx +
+                ' — tid=' +
+                tid +
+                ' name="' +
+                tname +
+                '" docXmlLen=' +
+                docXmlLens[docIdx] +
+                ' htmlLen=' +
+                htmlLens[docIdx]
         );
     } catch (Exception e) {
         fail++;
@@ -169,14 +169,14 @@ for (Integer i = 0; i < docXmls.size(); i++) {
             docXmlAllUnique = false;
             System.debug(
                 'COLLISION docXml[' +
-                i +
-                '] (' +
-                tplNames[i] +
-                ') == docXml[' +
-                j +
-                '] (' +
-                tplNames[j] +
-                ') — SMOKING GUN: mergeTemplateForSignature returned identical XML for distinct templates.'
+                    i +
+                    '] (' +
+                    tplNames[i] +
+                    ') == docXml[' +
+                    j +
+                    '] (' +
+                    tplNames[j] +
+                    ') — SMOKING GUN: mergeTemplateForSignature returned identical XML for distinct templates.'
             );
         }
     }
@@ -196,14 +196,14 @@ for (Integer i = 0; i < htmls.size(); i++) {
             htmlAllUnique = false;
             System.debug(
                 'COLLISION html[' +
-                i +
-                '] (' +
-                tplNames[i] +
-                ') == html[' +
-                j +
-                '] (' +
-                tplNames[j] +
-                ') — convertToHtml emitted identical output for distinct docXml inputs (or identical inputs).'
+                    i +
+                    '] (' +
+                    tplNames[i] +
+                    ') == html[' +
+                    j +
+                    '] (' +
+                    tplNames[j] +
+                    ') — convertToHtml emitted identical output for distinct docXml inputs (or identical inputs).'
             );
         }
     }
@@ -234,7 +234,9 @@ if (seededRun) {
         if (!htmls[i].contains(mine)) {
             fail++;
             sentinelOK = false;
-            System.debug('SENTINEL MISS: iter ' + i + ' (' + tplNames[i] + ') html does NOT contain its marker ' + mine);
+            System.debug(
+                'SENTINEL MISS: iter ' + i + ' (' + tplNames[i] + ') html does NOT contain its marker ' + mine
+            );
         }
         for (Integer j = 0; j < diagMarkers.size(); j++) {
             if (i == j) {
@@ -246,16 +248,16 @@ if (seededRun) {
                 sentinelOK = false;
                 System.debug(
                     'SENTINEL CROSS-LEAK: iter ' +
-                    i +
-                    ' (' +
-                    tplNames[i] +
-                    ') html contains ' +
-                    other +
-                    ' which belongs to iter ' +
-                    j +
-                    ' (' +
-                    tplNames[j] +
-                    ').'
+                        i +
+                        ' (' +
+                        tplNames[i] +
+                        ') html contains ' +
+                        other +
+                        ' which belongs to iter ' +
+                        j +
+                        ' (' +
+                        tplNames[j] +
+                        ').'
                 );
             }
         }
@@ -288,18 +290,18 @@ for (Integer i = 0; i < htmls.size(); i++) {
             attributionOK = false;
             System.debug(
                 'CROSS-LEAK: template[' +
-                i +
-                '] name "' +
-                name +
-                '" appears in html[' +
-                j +
-                '] but NOT in its own html[' +
-                i +
-                '] — likely indicates iteration ' +
-                j +
-                ' rendered template ' +
-                i +
-                '\'s content.'
+                    i +
+                    '] name "' +
+                    name +
+                    '" appears in html[' +
+                    j +
+                    '] but NOT in its own html[' +
+                    i +
+                    '] — likely indicates iteration ' +
+                    j +
+                    ' rendered template ' +
+                    i +
+                    '\'s content.'
             );
         }
     }
@@ -323,11 +325,11 @@ try {
         fail++;
         System.debug(
             'ASSERT 4: FAIL — replay of templates[0] differs from original. ' +
-            'origLen=' +
-            docXmlLens[0] +
-            ' replayLen=' +
-            (replayXml == null ? 0 : replayXml.length()) +
-            ' — indicates stale state across calls.'
+                'origLen=' +
+                docXmlLens[0] +
+                ' replayLen=' +
+                (replayXml == null ? 0 : replayXml.length()) +
+                ' — indicates stale state across calls.'
         );
     }
 } catch (Exception e) {
@@ -342,9 +344,9 @@ if (fail == 0) {
     System.debug('ALL TESTS PASSED — merge/convert pipeline is clean.');
     System.debug(
         'NEXT: bug is upstream (LWC sending duplicate templateIds) or downstream ' +
-        '(signer-side fetchDocumentData consuming stale cache). Capture a real ' +
-        'DocGen_Signature_Request__c.Id from a reproducer and dump its ' +
-        'Signature_Data__c + Template_Ids__c to compare.'
+            '(signer-side fetchDocumentData consuming stale cache). Capture a real ' +
+            'DocGen_Signature_Request__c.Id from a reproducer and dump its ' +
+            'Signature_Data__c + Template_Ids__c to compare.'
     );
 } else {
     System.debug('FAILURES DETECTED — root cause is in the merge/convert pipeline.');


### PR DESCRIPTION
## Summary
- Rapid clicks in the multi-template picker (`docGenSignatureSender`) could append the same templateId twice. The dropdown's "filter already-selected" check keyed off `selectedTemplates`, but that array was only mutated after an awaited Apex call returned — clicks before the await resolved saw the unfiltered list and re-fired with the same id.
- Server-side, the packet builder iterated whatever the LWC sent, so duplicated ids produced duplicated document bodies under correct-looking "Document N of N" headers (matches "1, 2, 1, 2" field reports; the variable patterns reporters described correspond to which clicks won the race).
- Fix is two-layered: an LWC early-return guard plus a `@TestVisible` server-side dedup helper so Flow / custom Apex callers get the same protection.

## What changed
- `force-app/main/default/lwc/docGenSignatureSender/docGenSignatureSender.js` — `handleTemplateSelected` early-returns when `templateId` is already in `selectedTemplates`. Comment explains the await-race.
- `force-app/main/default/classes/DocGenSignatureSenderController.cls` — extracted `parseAndDedupTemplateIds` (`@TestVisible private static`); `createPacketSignerRequestWithTitle` now uses it.
- `force-app/main/default/classes/DocGenSignatureTests.cls` — two new unit tests for the dedup helper (preserves order, collapses all-duplicates to one).
- `scripts/diag-multipath{,-seed,-dump}.apex` — diagnostics. The seed creates 4 sentinel Word templates (`DIAG_ALPHA/BRAVO/CHARLIE/DELTA`); the diag mimics the sender loop and asserts each iteration's HTML contains only its own marker; the dump extracts the cached `previewHtml` for inspection.

## Test plan
- [x] New Apex tests run on `docgen-designer`: 3/3 pass, 100%
- [x] `scripts/diag-multipath.apex` on `docgen-designer`: 5/5 assertions pass after seeding (proves merge/convert pipeline is clean — bug was upstream, in the LWC)
- [x] Manual verification on `docgen-designer`: created a packet with 4 distinct templates; `Template_Ids__c` stored as `[ALPHA, BRAVO, CHARLIE, DELTA]` with no duplicates; cached `previewHtml` shows each `DIAG_<MARKER>` appearing exactly 4 times (= 4 body occurrences × 1 cache instance)
- [x] User-side fast-clicking smoke test passed
- [ ] Full release-validation trio (e2e suite + RunLocalTests + code-analyzer) — pending before release

🤖 Generated with [Claude Code](https://claude.com/claude-code)