### PR TITLE
fix(apex-provider): expose base SObject in wizard + find namespaced providers

### DIFF
--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -2557,7 +2557,11 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
     @AuraEnabled(cacheable=true)
     public static List<String> searchDataProviders(String searchTerm) {
         List<String> providers = new List<String>();
-        String query = 'SELECT Name FROM ApexClass WHERE NamespacePrefix = null';
+        // Match the runtime resolution in DocGenDataRetriever.getRecordDataV4:
+        // unqualified classes (subscriber-org case) AND portwoodglobal-namespaced
+        // classes (dev-org / namespaced-scratch case, also future packaged samples).
+        // See issue #63.
+        String query = 'SELECT Name FROM ApexClass WHERE NamespacePrefix IN (null, \'portwoodglobal\')';
         if (String.isNotBlank(searchTerm)) {
             query += ' AND Name LIKE \'%' + String.escapeSingleQuotes(searchTerm) + '%\'';
         }

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -228,6 +228,17 @@
                                                         >
                                                         </lightning-button>
                                                     </div>
+                                                    <div class="slds-var-m-top_small">
+                                                        <lightning-input
+                                                            label="Base Object (optional)"
+                                                            value={apexProviderBaseObject}
+                                                            onchange={handleApexProviderBaseObjectChange}
+                                                            placeholder="Account, Opportunity, Custom_Object__c"
+                                                            field-level-help="Leave blank for record-agnostic providers. Set an SObject API name when this provider returns data about a specific record type — needed for cross-object aggregation and record-context filtering."
+                                                            autocomplete="off"
+                                                        >
+                                                        </lightning-input>
+                                                    </div>
                                                 </div>
                                             </template>
                                         </div>

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -271,6 +271,10 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     @track selectedProviderClassName = '';
     @track providerFields = [];
     @track isValidatingProvider = false;
+    // Optional base SObject API name for v4 Apex Provider templates. When set,
+    // overrides the 'ApexProvider' sentinel in Base_Object_API__c so the template
+    // is filterable by record context (cross-object aggregation use case).
+    @track apexProviderBaseObject = '';
 
     // Edit modal manual query toggle (for backward compat with existing V3 configs)
     @track isManualQuery = false;
@@ -794,10 +798,12 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                     this.showToast('Error', 'Please select an Apex Data Provider class first.', 'error');
                     return;
                 }
-                // Set a sentinel base object — the engine ignores it for v4 configs
-                // but the field is non-nullable downstream. 'ApexProvider' is what
-                // docGenColumnBuilder also emits for this path.
-                this.newTemplateObject = 'ApexProvider';
+                // Base_Object_API__c is non-nullable downstream. If the user supplied
+                // an SObject API name (cross-object aggregation: provider returns data
+                // about a specific record type), use it; otherwise fall back to the
+                // 'ApexProvider' sentinel that docGenColumnBuilder also emits.
+                const apexBase = (this.apexProviderBaseObject || '').trim();
+                this.newTemplateObject = apexBase || 'ApexProvider';
                 this.useApexProvider = true;
                 this.useVisualBuilder = false;
                 this.newTemplateQuery = JSON.stringify({ v: 4, provider: this.selectedProviderClassName });
@@ -877,7 +883,15 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     }
 
     handleConfigChange(event) {
-        this.newTemplateObject = event.detail.objectName;
+        // The column builder emits 'ApexProvider' as a sentinel object name when in
+        // Apex Provider mode. Don't let it clobber a real SObject API name that the
+        // user already set in Step 1's "Base Object (optional)" input — needed for
+        // cross-object aggregation use cases (issue #62).
+        const incoming = event.detail.objectName;
+        const haveRealBase = this.newTemplateObject && this.newTemplateObject !== 'ApexProvider';
+        if (!(incoming === 'ApexProvider' && haveRealBase)) {
+            this.newTemplateObject = incoming;
+        }
         this.newTemplateQuery = event.detail.queryConfig;
         this._updateQueryTree();
     }
@@ -891,7 +905,12 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     }
 
     handleEditConfigChange(event) {
-        this.editTemplateObject = event.detail.objectName;
+        // Mirror handleConfigChange's sentinel guard — see comment there.
+        const incoming = event.detail.objectName;
+        const haveRealBase = this.editTemplateObject && this.editTemplateObject !== 'ApexProvider';
+        if (!(incoming === 'ApexProvider' && haveRealBase)) {
+            this.editTemplateObject = incoming;
+        }
         this.editTemplateQuery = event.detail.queryConfig;
     }
 
@@ -954,6 +973,11 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         this.providerFields = [];
         this.showProviderPicker = false;
         this.isValidatingProvider = false;
+        this.apexProviderBaseObject = '';
+    }
+
+    handleApexProviderBaseObjectChange(event) {
+        this.apexProviderBaseObject = (event.detail ? event.detail.value : event.target.value) || '';
     }
 
     handleApexProviderSearch(event) {
@@ -1532,7 +1556,12 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     }
 
     handleEditConfigChange(event) {
-        this.editTemplateObject = event.detail.objectName;
+        // Mirror handleConfigChange's sentinel guard — see comment there.
+        const incoming = event.detail.objectName;
+        const haveRealBase = this.editTemplateObject && this.editTemplateObject !== 'ApexProvider';
+        if (!(incoming === 'ApexProvider' && haveRealBase)) {
+            this.editTemplateObject = incoming;
+        }
         this.editTemplateQuery = event.detail.queryConfig;
     }
 


### PR DESCRIPTION
## Summary
Closes #62 and #63 — both surfaced from Konrad's testing of the v1.84 Apex Data Provider feature.

- **#62**: Apex Provider wizard hardcoded `Base_Object_API__c = 'ApexProvider'` when a provider class was picked. Cross-object aggregation use cases (provider returns data *about* a specific record type) need a real SObject API name on the template. Konrad confirmed the export/import JSON round-trip already accepted it — only the UI was missing.
- **#63**: `DocGenController.searchDataProviders` filtered `WHERE NamespacePrefix = null`, so providers deployed to namespaced scratches (every `dev-only-deploy/` class in `docgen-designer`) were invisible. Blocked dev-org testing of the entire feature, including #62. Subscriber orgs aren't affected (no namespace), but a packaged sample provider would also be invisible if we ever shipped one.

## What changed
- `force-app/main/default/lwc/docGenAdmin/docGenAdmin.html` — new **Base Object (optional)** `lightning-input` inside the connected-provider chip in Step 1 of the create wizard, with field-level help explaining when to set it.
- `force-app/main/default/lwc/docGenAdmin/docGenAdmin.js`:
  - New `@track apexProviderBaseObject` state + `handleApexProviderBaseObjectChange` handler.
  - `handleNextStep` writes the user's value to `newTemplateObject`; falls back to the `'ApexProvider'` sentinel if blank (existing behavior preserved).
  - `_clearApexProviderState` resets the new field.
  - `handleConfigChange` / `handleEditConfigChange`: sentinel guard so the column builder's downstream `objectName: 'ApexProvider'` emit can't clobber the real SObject the user set in Step 1 / the edit modal.
- `force-app/main/default/classes/DocGenController.cls:2557` — `searchDataProviders` SOQL widened to `WHERE NamespacePrefix IN (null, 'portwoodglobal')` to match the runtime resolution in `DocGenDataRetriever.getRecordDataV4`.

## Test plan
- [x] Picker now finds namespaced providers in `docgen-designer`: `searchDataProviders('Provider')` returns `(DocGenSampleAccountProvider, ProjectStatusDemoProvider)`.
- [x] Manual wizard test: picked `DocGenSampleAccountProvider`, typed `Account` in the new Base Object input. Advanced through wizard. (Screenshot in user-confirmed verification.)
- [ ] Subscriber-org sanity check (NamespacePrefix = null branch) — covered by existing release-validation runs on a non-namespaced staging.
- [ ] Edit modal: open an existing v4 template, populate Base Object, confirm round-trip survives save/reload — pending.
- [ ] Full release-validation trio (e2e + RunLocalTests + code-analyzer) — pending before v1.85 release.

## Out of scope (follow-ups)
- The edit modal currently doesn't render the Base Object input next to its connected-provider chip (only the wizard does). The sentinel guard in `handleEditConfigChange` is in place so future field addition won't get clobbered, but the UI element itself is wizard-only in this PR. Filing a follow-up if Konrad needs it.
- `docGenColumnBuilder` still emits `objectName: 'ApexProvider'` on its own — the parent's guard absorbs this. Refactoring the builder to forward the user's chosen base would be cleaner long-term but is a bigger surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)