### PR TITLE
fix(signatures): close in-flight race in template picker dedup

### DIFF
--- a/force-app/main/default/lwc/docGenSignatureSender/docGenSignatureSender.js
+++ b/force-app/main/default/lwc/docGenSignatureSender/docGenSignatureSender.js
@@ -193,53 +193,76 @@ export default class DocGenSignatureSender extends LightningElement {
 
     // --- Template Selection ---
 
+    // Synchronous in-flight tracker. selectedTemplates is only appended AFTER an
+    // awaited Apex call resolves, so a synchronous .some() check on it can't catch
+    // multiple pending picks for the same templateId. This Set is mutated before
+    // the await and cleared in finally, giving us a single source of truth for
+    // "is this id already being processed".
+    _pendingTemplateIds = new Set();
+
     async handleTemplateSelected(event) {
         const templateId = event.detail.value;
         if (!templateId) return;
 
-        // availableTemplateOptions filters by selectedTemplates, but selectedTemplates
-        // is only appended after the awaited Apex call below. Rapid clicks can fire
-        // this handler twice for the same templateId before the dropdown re-filters.
-        if (this.selectedTemplates.some((t) => t.templateId === templateId)) {
+        // Guard against three races:
+        //   1. Same id already confirmed in selectedTemplates.
+        //   2. Same id with an in-flight getTemplateSignaturePlacements await.
+        //   3. Two rapid clicks on different ids — handled because each gets its
+        //      own pending entry and runs through independently.
+        if (
+            this._pendingTemplateIds.has(templateId) ||
+            this.selectedTemplates.some((t) => t.templateId === templateId)
+        ) {
             return;
         }
+        this._pendingTemplateIds.add(templateId);
 
-        const opt = this.docGenTemplateOptions.find((t) => t.value === templateId);
-        if (!opt) return;
-
-        // Scan template for placements
-        let placements = [];
         try {
-            placements = await getTemplateSignaturePlacements({ templateId });
-        } catch (_err) {
-            // Template may not have signature tags
-        }
+            const opt = this.docGenTemplateOptions.find((t) => t.value === templateId);
+            if (!opt) return;
 
-        // Build placement summary string
-        const counts = { Full: 0, Initials: 0, Date: 0, DatePick: 0 };
-        for (const p of placements || []) {
-            counts[p.placementType] = (counts[p.placementType] || 0) + 1;
-        }
-        const parts = [];
-        if (counts.Full > 0) parts.push(counts.Full + ' signature' + (counts.Full > 1 ? 's' : ''));
-        if (counts.Initials > 0) parts.push(counts.Initials + ' initial' + (counts.Initials > 1 ? 's' : ''));
-        if (counts.Date > 0) parts.push(counts.Date + ' date' + (counts.Date > 1 ? 's' : ''));
-        if (counts.DatePick > 0) parts.push(counts.DatePick + ' date picker' + (counts.DatePick > 1 ? 's' : ''));
-        const placementSummary = parts.length > 0 ? parts.join(', ') : 'No signature placements detected';
-
-        this.selectedTemplates = [
-            ...this.selectedTemplates,
-            {
-                id: ++templateIdCounter,
-                templateId,
-                name: opt.label,
-                placements: placements || [],
-                placementSummary,
-                docNumber: this.selectedTemplates.length + 1
+            // Scan template for placements
+            let placements = [];
+            try {
+                placements = await getTemplateSignaturePlacements({ templateId });
+            } catch (_err) {
+                // Template may not have signature tags
             }
-        ];
 
-        this._refreshAggregatedPlacements();
+            // Build placement summary string
+            const counts = { Full: 0, Initials: 0, Date: 0, DatePick: 0 };
+            for (const p of placements || []) {
+                counts[p.placementType] = (counts[p.placementType] || 0) + 1;
+            }
+            const parts = [];
+            if (counts.Full > 0) parts.push(counts.Full + ' signature' + (counts.Full > 1 ? 's' : ''));
+            if (counts.Initials > 0) parts.push(counts.Initials + ' initial' + (counts.Initials > 1 ? 's' : ''));
+            if (counts.Date > 0) parts.push(counts.Date + ' date' + (counts.Date > 1 ? 's' : ''));
+            if (counts.DatePick > 0) parts.push(counts.DatePick + ' date picker' + (counts.DatePick > 1 ? 's' : ''));
+            const placementSummary = parts.length > 0 ? parts.join(', ') : 'No signature placements detected';
+
+            // Re-check selectedTemplates after the await — defense-in-depth in case
+            // some other code path appended this id while we were awaiting.
+            if (this.selectedTemplates.some((t) => t.templateId === templateId)) {
+                return;
+            }
+
+            this.selectedTemplates = [
+                ...this.selectedTemplates,
+                {
+                    id: ++templateIdCounter,
+                    templateId,
+                    name: opt.label,
+                    placements: placements || [],
+                    placementSummary,
+                    docNumber: this.selectedTemplates.length + 1
+                }
+            ];
+
+            this._refreshAggregatedPlacements();
+        } finally {
+            this._pendingTemplateIds.delete(templateId);
+        }
     }
 
     handleRemoveTemplate(event) {

--- a/scripts/diag-multipath-seed.apex
+++ b/scripts/diag-multipath-seed.apex
@@ -12,7 +12,7 @@
 Integer pass = 0;
 Integer fail = 0;
 
-String[] markers = new List<String>{ 'ALPHA', 'BRAVO', 'CHARLIE', 'DELTA' };
+String[] markers = new List<String>{ 'ALPHA', 'BRAVO', 'CHARLIE', 'DELTA', 'ECHO' };
 
 // ───────── Cleanup prior runs ─────────
 try {


### PR DESCRIPTION
## Summary
Follow-up to #61. Dustin tested a 5-template packet and reported `Doc1=T1, Doc2=T4, Doc3=T1, Doc5=T4` — distinct templates duplicated under correct-looking "Doc N of N" headers. The N=5 \`diag-multipath\` script still passes (merge/convert pipeline produces unique XML/HTML per call, sentinel attribution clean) so the server is fine. The root cause is a hole in the original LWC fix.

## Root cause
The original \`handleTemplateSelected\` dedup checked \`selectedTemplates.some(t => t.templateId === id)\` synchronously, but \`selectedTemplates\` is only mutated *after* the awaited \`getTemplateSignaturePlacements\` call resolves. Multiple rapid clicks all see an empty list before any await resolves, all pass the dedup, and all push.

The downstream behavior matches Dustin's pattern:
- LWC sends e.g. \`[T1, T4, T1, Tx, T4]\` to the server.
- \`parseAndDedupTemplateIds\` (the server defense added in #61) collapses to \`[T1, T4, Tx]\` *preserving first occurrence* — but with rapid clicks happening to land in any order, the resulting first-occurrence ordering may not match what the user intended.
- Headers say "Doc 1 of N: …", "Doc 2 of N: …" using the order the server actually iterated, which is what the signer sees.

If the user clicks more than \`N\` distinct templates with some same-id repeats fast enough, the rendered packet shows fewer documents than they intended, in an unexpected order, with apparent duplicates.

## Fix
- New \`_pendingTemplateIds\` Set on the LWC instance, mutated synchronously *before* the await and cleared in \`finally\`.
- \`handleTemplateSelected\` now rejects if the id is in-flight OR already confirmed.
- Defense-in-depth re-check post-await before append, in case any other code path appends concurrently.

## Test plan
- [x] N=5 \`diag-multipath\` still passes on \`docgen-designer\` — merge pipeline confirmed clean.
- [x] Manual smoke test: rapid-click 4 templates ALPHA/BRAVO/CHARLIE/DELTA in arbitrary order with deliberate repeats; \`Template_Ids__c\` on the resulting request comes back as 4 distinct ids in click order.
- [ ] Dustin retests his original 5-template flow on \`docgen-designer\`.
- [ ] Server unit tests already cover \`parseAndDedupTemplateIds\` (added in #61); no new Apex test needed since the change is purely client-side and LWC unit tests aren't currently part of the project.

## Related
- Builds on #61 (multipath signature dedup).
- Seed script extended to 5 markers (added ECHO) so future diagnostics can match Dustin's reproduction shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)