### PR TITLE
fix(parser): accept double-quoted IF literals (#69)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,10 +51,11 @@ sf apex run --target-org <org> -f scripts/e2e-05-generate-bulk.apex
 sf apex run --target-org <org> -f scripts/e2e-06-signatures.apex
 sf apex run --target-org <org> -f scripts/e2e-07-syntax1.apex
 sf apex run --target-org <org> -f scripts/e2e-07-syntax2.apex
+sf apex run --target-org <org> -f scripts/e2e-07-syntax3.apex
 sf apex run --target-org <org> -f scripts/e2e-08-cleanup.apex
 ```
 
-Each script must print `PASS: N  FAIL: 0  ALL TESTS PASSED`. Sequence: 01 standalone, 02 creates test data, 03–06 depend on 02, 07-syntax1/2 standalone (use `processXmlForTest`), 08 cleans up.
+Each script must print `PASS: N  FAIL: 0  ALL TESTS PASSED`. Sequence: 01 standalone, 02 creates test data, 03–06 depend on 02, 07-syntax1/2/3 standalone (use `processXmlForTest`), 08 cleans up.
 
 When fixing a parser-level bug, add a regression assertion in `e2e-07-syntax1` or `e2e-07-syntax2` that exercises the offending pattern via `processXmlForTest`. Each script must stay under 18,000 chars (Anonymous Apex limit is 20,000).
 

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -3422,8 +3422,14 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         Object fieldVal = resolveValue(data, fieldPart);
         String fieldStr = fieldVal != null ? String.valueOf(fieldVal) : '';
 
-        // Strip quotes from value if present
-        if (valuePart.startsWith('\'') && valuePart.endsWith('\'')) {
+        // Strip surrounding quotes from value literal — accept both single
+        // and double quotes. Issue #69: double-quoted form silently failed
+        // because only single quotes were stripped, so `"X"` was compared
+        // against the unquoted field value verbatim and never matched.
+        if (
+            (valuePart.startsWith('\'') && valuePart.endsWith('\'')) ||
+            (valuePart.startsWith('"') && valuePart.endsWith('"'))
+        ) {
             valuePart = valuePart.substring(1, valuePart.length() - 1);
         }
 

--- a/scripts/e2e-07-syntax3.apex
+++ b/scripts/e2e-07-syntax3.apex
@@ -311,6 +311,27 @@ try {
     System.debug('IF-IN-ROW (issue #53): FAIL — ' + e.getMessage());
 }
 
+// ===== IF double-quoted literal (issue #69) =====
+// Pre-fix: only single quotes were stripped from the value side, so the
+// double-quoted form compared `Won` against `"Won"` (10 chars) and never
+// matched. Asserts symmetry with single-quote form for both = and !=.
+try {
+    String t =
+        '<w:t>{#IF S = "Won"}M{/IF}|{#IF S != "Won"}N{/IF}|' + '{#IF S = \'Won\'}m{/IF}|{#IF S != \'Won\'}n{/IF}</w:t>';
+    String hit = DocGenService.processXmlForTest(t, new Map<String, Object>{ 'S' => 'Won' });
+    String miss = DocGenService.processXmlForTest(t, new Map<String, Object>{ 'S' => 'Lost' });
+    if (hit == '<w:t>M||m|</w:t>' && miss == '<w:t>|N||n</w:t>') {
+        pass++;
+        System.debug('IF DBLQUOTE LITERAL (#69): PASS');
+    } else {
+        fail++;
+        System.debug('IF DBLQUOTE LITERAL (#69): FAIL hit=' + hit + ' miss=' + miss);
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('IF DBLQUOTE LITERAL (#69): FAIL — ' + e.getMessage());
+}
+
 System.debug('========================================');
 System.debug(
     'E2E-07-SYNTAX3 — PASS: ' + pass + '  FAIL: ' + fail + (fail == 0 ? '  ALL TESTS PASSED' : '  FAILURES DETECTED')


### PR DESCRIPTION
## Summary

- Fixes #69 — `{#IF Field = "literal"}` (double-quoted form) silently always evaluated false because `evaluateSingleComparison` only stripped single quotes from the value side. The double-quote characters survived as part of the comparand, so a 6-char `Started` was compared against a 10-char `"Started"` and never matched.
- Single-quote form (`{#IF Field = 'literal'}`) was unaffected, which made the asymmetry invisible to anyone whose templates already used single quotes.
- Output looked plausible — the IF just never fired — which is the worst class of bug (silent corruption / `severity:silent-corruption` / `priority:P0`).

## Fix

One block in `DocGenService.evaluateSingleComparison`: broaden the strip-surrounding-quotes step to accept both `'…'` and `"…"`. Same-quote-on-both-sides invariant preserved (mixed-quote inputs like `"abc'` still don't get stripped, matching prior behavior).

## Credit

Reporter [@josephedwards-png](https://github.com/josephedwards-png) filed a clean RCA with the proposed one-line fix and an algorithm-level verification across 7 cases (current behavior wrong on 2/7, fix correct on 7/7). This PR is essentially their patch.

## Test plan

- [x] New `e2e-07-syntax3` assertion exercising both quote styles on `=` and `!=` against matching and non-matching field values
- [x] `e2e-07-syntax1` (35/35), `e2e-07-syntax2` (31/31), `e2e-07-syntax3` (13/13) all pass against `docgen-designer`
- [x] Prettier clean (`npm run format:check`)
- [x] CLAUDE.md release-validation list updated to include `syntax3` (it was missing — orthogonal cleanup)
- [ ] Apex test suite run at release-validation time (v1.88.0 milestone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)