### PR TITLE
fix(parser): track section depth when finding {:else} (#68)

### DIFF
--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -2770,10 +2770,13 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
                         cursor = closeTagEnd + 1;
                     }
 
-                    // Split on {:else} if present
+                    // Split on {:else} if present. Issue #68: scan must
+                    // ignore {:else} inside any nested section opener so
+                    // an inner {#IF}{:else}{/IF} does not get split open
+                    // by the outer scope.
                     String trueBranch = innerXml;
                     String elseBranch = null;
-                    Integer elsePos = innerXml.indexOf('{:else}');
+                    Integer elsePos = findElseAtDepthZero(innerXml);
                     if (elsePos != -1) {
                         trueBranch = innerXml.substring(0, elsePos);
                         elseBranch = innerXml.substring(elsePos + 7); // 7 = '{:else}'.length()
@@ -2896,10 +2899,11 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
                     Integer contentEnd = sectionEnd;
                     String innerXml = xml.substring(contentStart, contentEnd);
                     Integer closeTagEnd = xml.indexOf('}', sectionEnd);
-                    // Split on {:else} if present
+                    // Split on {:else} if present. Same depth-aware scan
+                    // as the truthy path (issue #68).
                     String inverseTrueBranch = innerXml;
                     String inverseElseBranch = null;
-                    Integer inverseElsePos = innerXml.indexOf('{:else}');
+                    Integer inverseElsePos = findElseAtDepthZero(innerXml);
                     if (inverseElsePos != -1) {
                         inverseTrueBranch = innerXml.substring(0, inverseElsePos);
                         inverseElseBranch = innerXml.substring(inverseElsePos + 7);
@@ -3125,6 +3129,38 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
                 if (depth == 0) {
                     return nextStart;
                 }
+            }
+            cursor = nextClose + 1;
+        }
+        return -1;
+    }
+
+    // Find the {:else} that belongs to the *current* section, ignoring any
+    // {:else} that belongs to a nested {#X}/{^X}/{#IF}/{^IF} block. Without
+    // this, an outer loop body containing a nested {#IF}{:else}{/IF} would
+    // mis-split on the inner {:else} (issue #68) — the engine would later
+    // throw "Malformed loop tag" because the recursed trueBranch ended up
+    // with an unclosed opener.
+    private static Integer findElseAtDepthZero(String xml) {
+        Integer depth = 0;
+        Integer cursor = 0;
+        while (cursor < xml.length()) {
+            Integer nextOpen = xml.indexOf('{', cursor);
+            if (nextOpen == -1) {
+                return -1;
+            }
+            Integer nextClose = xml.indexOf('}', nextOpen);
+            if (nextClose == -1) {
+                return -1;
+            }
+            String content = xml.substring(nextOpen + 1, nextClose).trim();
+            if (depth == 0 && content == ':else') {
+                return nextOpen;
+            }
+            if (content.startsWith('#') || content.startsWith('^')) {
+                depth++;
+            } else if (content.startsWith('/')) {
+                depth--;
             }
             cursor = nextClose + 1;
         }

--- a/scripts/e2e-07-syntax3.apex
+++ b/scripts/e2e-07-syntax3.apex
@@ -332,6 +332,69 @@ try {
     System.debug('IF DBLQUOTE LITERAL (#69): FAIL — ' + e.getMessage());
 }
 
+// ===== Nested IF/else ownership across outer section (issue #68) =====
+// Pre-fix: outer section's split-on-{:else} grabbed the inner IF's
+// {:else} as its own split point; recursing into trueBranch (now with
+// an unclosed {#IF} opener) threw "Malformed loop tag". Post-fix:
+// findElseAtDepthZero ignores nested {:else}s. Verifies all three
+// section types: regular loop, regular loop with its own outer
+// {:else}, and inverse {^X}.
+try {
+    // Case 1 — Joe's repro: non-IF loop with nested IF/else, multi-iter.
+    String t1 = '<w:t>{#Steps}{#IF S = \'Started\'}A{:else}B{/IF}|{/Steps}</w:t>';
+    Map<String, Object> d1 = new Map<String, Object>{
+        'Steps' => new List<Object>{
+            new Map<String, Object>{ 'S' => 'Started' },
+            new Map<String, Object>{ 'S' => 'Pending' },
+            new Map<String, Object>{ 'S' => 'Started' }
+        }
+    };
+    String r1 = DocGenService.processXmlForTest(t1, d1);
+
+    // Case 2 — outer {:else} must still be found AFTER a nested IF/else.
+    // The depth-aware scan must walk past inner {#IF}, {:else}, {/IF}
+    // and identify the OUTER {:else} that comes after {/IF}.
+    String t2 = '<w:t>{#Recs}{#IF X = \'a\'}Y{:else}N{/IF}{:else}EMPTY{/Recs}</w:t>';
+    String r2empty = DocGenService.processXmlForTest(t2, new Map<String, Object>{ 'Recs' => new List<Object>() });
+    String r2match = DocGenService.processXmlForTest(
+        t2,
+        new Map<String, Object>{ 'Recs' => new List<Object>{ new Map<String, Object>{ 'X' => 'a' } } }
+    );
+
+    // Case 3 — inverse section {^X} with nested IF/else.
+    String t3 = '<w:t>{^Empty}{#IF X = \'a\'}YES{:else}NO{/IF}{/Empty}</w:t>';
+    String r3 = DocGenService.processXmlForTest(t3, new Map<String, Object>{ 'Empty' => null, 'X' => 'a' });
+
+    Boolean ok1 = (r1 == '<w:t>A|B|A|</w:t>');
+    Boolean ok2 = (r2empty == '<w:t>EMPTY</w:t>' && r2match == '<w:t>Y</w:t>');
+    Boolean ok3 = (r3 == '<w:t>YES</w:t>');
+    if (ok1 && ok2 && ok3) {
+        pass++;
+        System.debug('NESTED IF/ELSE OWNERSHIP (#68): PASS');
+    } else {
+        fail++;
+        System.debug(
+            'NESTED IF/ELSE OWNERSHIP (#68): FAIL ok1=' +
+                ok1 +
+                ' ok2=' +
+                ok2 +
+                ' ok3=' +
+                ok3 +
+                ' r1=' +
+                r1 +
+                ' r2empty=' +
+                r2empty +
+                ' r2match=' +
+                r2match +
+                ' r3=' +
+                r3
+        );
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('NESTED IF/ELSE OWNERSHIP (#68): FAIL — ' + e.getMessage());
+}
+
 System.debug('========================================');
 System.debug(
     'E2E-07-SYNTAX3 — PASS: ' + pass + '  FAIL: ' + fail + (fail == 0 ? '  ALL TESTS PASSED' : '  FAILURES DETECTED')


### PR DESCRIPTION
## Summary

Fixes #68 — when a non-IF outer loop body contained a nested `{#IF}{:else}{/IF}`, the outer scan's `indexOf('{:else}')` grabbed the **inner** `{:else}` as its own split point. The recursed `trueBranch` then carried an unclosed `{#IF}` opener, and the engine threw `Malformed loop tag: missing closing "{/}" for "{#}"` with empty quote payloads.

This was both a hard error AND silent: the misleading error message made it hard for users to figure out what was wrong, and the error fired on a perfectly reasonable template pattern. Tagged `priority:P0` / `severity:silent-corruption` because (a) any nested IF/else inside a loop trips it and (b) the surfaced error doesn't point at the real problem.

## Fix

- New `findElseAtDepthZero` helper alongside `findBalancedEnd`. Walks `{` tag content while tracking depth from `#X` / `^X` openers and `/X` closers; returns the first `{:else}` at depth 0.
- Both `{:else}` split sites in `processXml` now route through it: the truthy/IF path (line ~2776) and the inverse-section path (line ~2902).
- Helper inherits the same simplifications as `findBalancedEnd` (naive `indexOf('}')`, run-merge precondition).

## Credit

Reporter [@josephedwards-png](https://github.com/josephedwards-png) filed an RCA with the depth-tracking patch and algorithm-level verification across 5 cases (current wrong on 2/5, fix correct on 5/5). This PR is essentially their patch.

## Test plan

- [x] New `e2e-07-syntax3` assertion covering three cases:
  - non-IF loop with nested IF/else, multi-iteration (Joe's exact repro)
  - outer `{:else}` on a non-IF loop must still be found **after** a nested IF/else
  - inverse section `{^X}` with nested IF/else
- [x] `e2e-07-syntax1` (35/35), `e2e-07-syntax2` (31/31), `e2e-07-syntax3` (13/13) all pass against `docgen-designer`
- [x] Joe's exact repro template (`{#Steps}{#IF StepStatus = 'Started'}…{:else}…{/IF}{/Steps}`) renders correctly per iteration — pre-fix this threw the malformed-loop-tag error
- [x] Prettier clean
- [ ] Apex test suite at v1.88.0 release-validation time

🤖 Generated with [Claude Code](https://claude.com/claude-code)