### PR TITLE
fix(retriever): route ProcessInstance grandchildren via parent subquery (#67)

### DIFF
--- a/force-app/main/default/classes/DocGenDataRetriever.cls
+++ b/force-app/main/default/classes/DocGenDataRetriever.cls
@@ -862,31 +862,70 @@ public with sharing class DocGenDataRetriever {
             // Allowlist validation: get field map for ORDER BY field validation
             Map<String, Schema.SObjectField> childNodeFieldMap = childObjType.getDescribe().fields.getMap();
 
-            String childQuery =
-                'SELECT ' +
-                String.join(selectFields, ', ') +
-                ' FROM ' +
-                String.escapeSingleQuotes(child.objectApiName) +
-                ' WHERE ' +
-                String.escapeSingleQuotes(child.lookupField) +
-                ' IN :parentIds';
-            List<SObject> childResults;
-            try {
-                if (String.isNotBlank(child.whereClause)) {
-                    childQuery += ' AND ' + sanitizeClause(child.whereClause, 'WHERE');
-                }
-                // Allowlist validation: ORDER BY fields verified against Schema.describeSObjects() field map
-                if (String.isNotBlank(child.orderByClause)) {
-                    childQuery += ' ORDER BY ' + sanitizeClause(child.orderByClause, 'ORDER BY', childNodeFieldMap);
-                }
-                if (String.isNotBlank(child.limitClause)) {
-                    childQuery += ' LIMIT ' + sanitizeClause(child.limitClause, 'LIMIT');
-                }
+            // Issue #67: ProcessInstanceHistory and ProcessInstanceWorkitem
+            // are NOT standalone-queryable. Route through a parent subquery
+            // from ProcessInstance and unwrap.
+            Boolean isProcessInstanceChild =
+                child.objectApiName == 'ProcessInstanceHistory' ||
+                child.objectApiName == 'ProcessInstanceWorkitem';
 
-                childResults = Database.query(childQuery, AccessLevel.USER_MODE); // NOPMD ApexSOQLInjection — all dynamic elements allowlist-validated against Schema.describeSObjects() field map; USER_MODE enforced
-            } catch (Exception e) {
-                // Child query failed — skip this child relationship
-                continue;
+            List<SObject> childResults;
+            if (isProcessInstanceChild) {
+                String piQuery =
+                    'SELECT Id, (SELECT ' +
+                    String.join(selectFields, ', ') +
+                    ' FROM ' +
+                    String.escapeSingleQuotes(child.relationshipName);
+                try {
+                    if (String.isNotBlank(child.whereClause)) {
+                        piQuery += ' WHERE ' + sanitizeClause(child.whereClause, 'WHERE');
+                    }
+                    if (String.isNotBlank(child.orderByClause)) {
+                        piQuery += ' ORDER BY ' + sanitizeClause(child.orderByClause, 'ORDER BY', childNodeFieldMap);
+                    }
+                    if (String.isNotBlank(child.limitClause)) {
+                        piQuery += ' LIMIT ' + sanitizeClause(child.limitClause, 'LIMIT');
+                    }
+                    piQuery += ') FROM ProcessInstance WHERE Id IN :parentIds';
+
+                    List<SObject> piResults = Database.query(piQuery, AccessLevel.USER_MODE); // NOPMD ApexSOQLInjection — all dynamic elements allowlist-validated against Schema.describeSObjects() field map; USER_MODE enforced
+                    childResults = new List<SObject>();
+                    for (SObject pi : piResults) {
+                        SObject[] piChildren = pi.getSObjects(child.relationshipName);
+                        if (piChildren != null) {
+                            childResults.addAll(piChildren);
+                        }
+                    }
+                } catch (Exception e) {
+                    // ProcessInstance subquery failed — skip this child relationship
+                    continue;
+                }
+            } else {
+                String childQuery =
+                    'SELECT ' +
+                    String.join(selectFields, ', ') +
+                    ' FROM ' +
+                    String.escapeSingleQuotes(child.objectApiName) +
+                    ' WHERE ' +
+                    String.escapeSingleQuotes(child.lookupField) +
+                    ' IN :parentIds';
+                try {
+                    if (String.isNotBlank(child.whereClause)) {
+                        childQuery += ' AND ' + sanitizeClause(child.whereClause, 'WHERE');
+                    }
+                    // Allowlist validation: ORDER BY fields verified against Schema.describeSObjects() field map
+                    if (String.isNotBlank(child.orderByClause)) {
+                        childQuery += ' ORDER BY ' + sanitizeClause(child.orderByClause, 'ORDER BY', childNodeFieldMap);
+                    }
+                    if (String.isNotBlank(child.limitClause)) {
+                        childQuery += ' LIMIT ' + sanitizeClause(child.limitClause, 'LIMIT');
+                    }
+
+                    childResults = Database.query(childQuery, AccessLevel.USER_MODE); // NOPMD ApexSOQLInjection — all dynamic elements allowlist-validated against Schema.describeSObjects() field map; USER_MODE enforced
+                } catch (Exception e) {
+                    // Child query failed — skip this child relationship
+                    continue;
+                }
             }
 
             // Group by parent lookup field
@@ -996,33 +1035,72 @@ public with sharing class DocGenDataRetriever {
             // Allowlist validation: get field map for ORDER BY field validation
             Map<String, Schema.SObjectField> bulkChildFieldMap = bulkChildObjType.getDescribe().fields.getMap();
 
-            // Single query for ALL parents
-            String childQuery =
-                'SELECT ' +
-                String.join(selectFields, ', ') +
-                ' FROM ' +
-                String.escapeSingleQuotes(child.objectApiName) +
-                ' WHERE ' +
-                String.escapeSingleQuotes(child.lookupField) +
-                ' IN :parentIds';
+            // Issue #67: ProcessInstanceHistory and ProcessInstanceWorkitem
+            // are NOT standalone-queryable. Route through a parent subquery
+            // from ProcessInstance and unwrap.
+            Boolean isProcessInstanceChild =
+                child.objectApiName == 'ProcessInstanceHistory' ||
+                child.objectApiName == 'ProcessInstanceWorkitem';
 
             List<SObject> childResults;
-            try {
-                if (String.isNotBlank(child.whereClause)) {
-                    childQuery += ' AND ' + sanitizeClause(child.whereClause, 'WHERE');
-                }
-                // Allowlist validation: ORDER BY fields verified against Schema.describeSObjects() field map
-                if (String.isNotBlank(child.orderByClause)) {
-                    childQuery += ' ORDER BY ' + sanitizeClause(child.orderByClause, 'ORDER BY', bulkChildFieldMap);
-                }
-                if (String.isNotBlank(child.limitClause)) {
-                    childQuery += ' LIMIT ' + sanitizeClause(child.limitClause, 'LIMIT');
-                }
+            if (isProcessInstanceChild) {
+                String piQuery =
+                    'SELECT Id, (SELECT ' +
+                    String.join(selectFields, ', ') +
+                    ' FROM ' +
+                    String.escapeSingleQuotes(child.relationshipName);
+                try {
+                    if (String.isNotBlank(child.whereClause)) {
+                        piQuery += ' WHERE ' + sanitizeClause(child.whereClause, 'WHERE');
+                    }
+                    if (String.isNotBlank(child.orderByClause)) {
+                        piQuery += ' ORDER BY ' + sanitizeClause(child.orderByClause, 'ORDER BY', bulkChildFieldMap);
+                    }
+                    if (String.isNotBlank(child.limitClause)) {
+                        piQuery += ' LIMIT ' + sanitizeClause(child.limitClause, 'LIMIT');
+                    }
+                    piQuery += ') FROM ProcessInstance WHERE Id IN :parentIds';
 
-                childResults = Database.query(childQuery, AccessLevel.USER_MODE); // NOPMD ApexSOQLInjection — all dynamic elements allowlist-validated against Schema.describeSObjects() field map; USER_MODE enforced
-            } catch (Exception e) {
-                // Bulk child query failed — skip this child relationship
-                continue;
+                    List<SObject> piResults = Database.query(piQuery, AccessLevel.USER_MODE); // NOPMD ApexSOQLInjection — all dynamic elements allowlist-validated against Schema.describeSObjects() field map; USER_MODE enforced
+                    childResults = new List<SObject>();
+                    for (SObject pi : piResults) {
+                        SObject[] piChildren = pi.getSObjects(child.relationshipName);
+                        if (piChildren != null) {
+                            childResults.addAll(piChildren);
+                        }
+                    }
+                } catch (Exception e) {
+                    // ProcessInstance bulk subquery failed — skip this child relationship
+                    continue;
+                }
+            } else {
+                // Single query for ALL parents
+                String childQuery =
+                    'SELECT ' +
+                    String.join(selectFields, ', ') +
+                    ' FROM ' +
+                    String.escapeSingleQuotes(child.objectApiName) +
+                    ' WHERE ' +
+                    String.escapeSingleQuotes(child.lookupField) +
+                    ' IN :parentIds';
+
+                try {
+                    if (String.isNotBlank(child.whereClause)) {
+                        childQuery += ' AND ' + sanitizeClause(child.whereClause, 'WHERE');
+                    }
+                    // Allowlist validation: ORDER BY fields verified against Schema.describeSObjects() field map
+                    if (String.isNotBlank(child.orderByClause)) {
+                        childQuery += ' ORDER BY ' + sanitizeClause(child.orderByClause, 'ORDER BY', bulkChildFieldMap);
+                    }
+                    if (String.isNotBlank(child.limitClause)) {
+                        childQuery += ' LIMIT ' + sanitizeClause(child.limitClause, 'LIMIT');
+                    }
+
+                    childResults = Database.query(childQuery, AccessLevel.USER_MODE); // NOPMD ApexSOQLInjection — all dynamic elements allowlist-validated against Schema.describeSObjects() field map; USER_MODE enforced
+                } catch (Exception e) {
+                    // Bulk child query failed — skip this child relationship
+                    continue;
+                }
             }
 
             // Group by parent lookup field
@@ -1562,31 +1640,73 @@ public with sharing class DocGenDataRetriever {
                 gcValidatedFields.add(String.escapeSingleQuotes(grandchildSpec.parentIdField));
             }
 
-            String gcQuery =
-                'SELECT ' +
-                String.join(gcValidatedFields, ', ') +
-                ' FROM ' +
-                String.escapeSingleQuotes(grandchildSpec.childObjectApiName) +
-                ' WHERE ' +
-                String.escapeSingleQuotes(grandchildSpec.parentIdField) +
-                ' IN :parentIds';
-            if (String.isNotBlank(grandchildSpec.whereClause)) {
-                gcQuery += ' AND ' + sanitizeClause(grandchildSpec.whereClause, 'WHERE');
-            }
-            // Allowlist validation: ORDER BY fields verified against Schema.describeSObjects() field map
-            if (String.isNotBlank(grandchildSpec.orderByClause)) {
-                gcQuery += ' ORDER BY ' + sanitizeClause(grandchildSpec.orderByClause, 'ORDER BY', gcFieldMap);
-            }
-            if (String.isNotBlank(grandchildSpec.limitClause)) {
-                gcQuery += ' LIMIT ' + sanitizeClause(grandchildSpec.limitClause, 'LIMIT');
-            }
+            // Issue #67: ProcessInstanceHistory and ProcessInstanceWorkitem
+            // are NOT standalone-queryable. Route through a parent subquery
+            // from ProcessInstance and unwrap. Other objects use the regular
+            // standalone-query path.
+            Boolean isProcessInstanceChild =
+                grandchildSpec.childObjectApiName == 'ProcessInstanceHistory' ||
+                grandchildSpec.childObjectApiName == 'ProcessInstanceWorkitem';
 
             List<SObject> gcResults;
-            try {
-                gcResults = Database.query(gcQuery, AccessLevel.USER_MODE); // NOPMD ApexSOQLInjection — all dynamic elements allowlist-validated against Schema.describeSObjects() field map; USER_MODE enforced
-            } catch (Exception e) {
-                // Grandchild query failed — skip this relationship
-                continue;
+            if (isProcessInstanceChild) {
+                String piQuery =
+                    'SELECT Id, (SELECT ' +
+                    String.join(gcValidatedFields, ', ') +
+                    ' FROM ' +
+                    String.escapeSingleQuotes(grandchildSpec.relationshipName);
+                if (String.isNotBlank(grandchildSpec.whereClause)) {
+                    piQuery += ' WHERE ' + sanitizeClause(grandchildSpec.whereClause, 'WHERE');
+                }
+                if (String.isNotBlank(grandchildSpec.orderByClause)) {
+                    piQuery += ' ORDER BY ' + sanitizeClause(grandchildSpec.orderByClause, 'ORDER BY', gcFieldMap);
+                }
+                if (String.isNotBlank(grandchildSpec.limitClause)) {
+                    piQuery += ' LIMIT ' + sanitizeClause(grandchildSpec.limitClause, 'LIMIT');
+                }
+                piQuery += ') FROM ProcessInstance WHERE Id IN :parentIds';
+
+                List<SObject> piResults;
+                try {
+                    piResults = Database.query(piQuery, AccessLevel.USER_MODE); // NOPMD ApexSOQLInjection — all dynamic elements allowlist-validated against Schema.describeSObjects() field map; USER_MODE enforced
+                } catch (Exception e) {
+                    // ProcessInstance subquery failed — skip this relationship
+                    continue;
+                }
+
+                gcResults = new List<SObject>();
+                for (SObject pi : piResults) {
+                    SObject[] children = pi.getSObjects(grandchildSpec.relationshipName);
+                    if (children != null) {
+                        gcResults.addAll(children);
+                    }
+                }
+            } else {
+                String gcQuery =
+                    'SELECT ' +
+                    String.join(gcValidatedFields, ', ') +
+                    ' FROM ' +
+                    String.escapeSingleQuotes(grandchildSpec.childObjectApiName) +
+                    ' WHERE ' +
+                    String.escapeSingleQuotes(grandchildSpec.parentIdField) +
+                    ' IN :parentIds';
+                if (String.isNotBlank(grandchildSpec.whereClause)) {
+                    gcQuery += ' AND ' + sanitizeClause(grandchildSpec.whereClause, 'WHERE');
+                }
+                // Allowlist validation: ORDER BY fields verified against Schema.describeSObjects() field map
+                if (String.isNotBlank(grandchildSpec.orderByClause)) {
+                    gcQuery += ' ORDER BY ' + sanitizeClause(grandchildSpec.orderByClause, 'ORDER BY', gcFieldMap);
+                }
+                if (String.isNotBlank(grandchildSpec.limitClause)) {
+                    gcQuery += ' LIMIT ' + sanitizeClause(grandchildSpec.limitClause, 'LIMIT');
+                }
+
+                try {
+                    gcResults = Database.query(gcQuery, AccessLevel.USER_MODE); // NOPMD ApexSOQLInjection — all dynamic elements allowlist-validated against Schema.describeSObjects() field map; USER_MODE enforced
+                } catch (Exception e) {
+                    // Grandchild query failed — skip this relationship
+                    continue;
+                }
             }
 
             // Group grandchild records by parent ID


### PR DESCRIPTION
## Summary

Fixes #67 — `ProcessInstanceHistory` and `ProcessInstanceWorkitem` are not standalone-queryable. The grandchild stitcher built a synthetic standalone query, Salesforce rejected it with `entity type ProcessInstanceHistory does not support query`, the catch block silently swallowed the exception, and the relationship dropped out of the data map. Templates trying to reproduce the standard Approval History related list rendered empty rows with no error surfaced — silent corruption.

## Fix

Three sites all built the same standalone-query pattern. All three now special-case ProcessInstance children and route through a parent subquery (`SELECT Id, (SELECT ... FROM StepsAndWorkitems) FROM ProcessInstance WHERE Id IN :parentIds`), unwrap via `pi.getSObjects(relationshipName)`, and feed the existing groupBy stitching loop unchanged:

- `DocGenDataRetriever.stitchGrandchildren` (V1 flat-string config)
- `DocGenDataRetriever.processChildNodes` (V3 single-record)
- `DocGenDataRetriever.processChildNodesBulk` (V3 bulk)

Per CLAUDE.md's subsystem-caution note: V1 and V3 reproduce similar query patterns, so bug fixes here often need to land in both.

## Empirical confirmation

Verified in this branch against 3 real `ProcessInstance` records:

```
PRE-FIX SOQL: threw as expected — entity type ProcessInstanceHistory does not support query
POST-FIX SOQL: 3 PIs, 3 children unwrapped
  child[0] Id=04i… StepStatus=Pending ProcessInstanceId=04g3h000001uzgyAAA
  child[1] Id=04i… StepStatus=Pending ProcessInstanceId=04g3h000001uzh0AAA
  child[2] Id=04i… StepStatus=Pending ProcessInstanceId=04g3h000001v3YuAAI
```

`ProcessInstanceId` is populated on the unwrapped children, so the downstream `gc.get(parentIdField)` / `rec.get(lookupField)` grouping runs unchanged.

## No Apex unit test (intentional)

Exercising this path meaningfully requires an approval process configured in metadata, which can't be set up from Apex test code. Compile-check via deploy serves as smoke test; the empirical SOQL verification above covers the runtime behavior. Full integration validation will run on `portwood-staging` once an approval process is set up there (it has zero `ProcessInstance` records today).

## Credit

Reporter [@josephedwards-png](https://github.com/josephedwards-png) filed an RCA with structurally-sound patches and a SOQL-shape verification against their own org. This PR is the same routing logic.

## Test plan

- [x] `DocGenDataRetriever` deploys cleanly to `docgen-designer`
- [x] Pre-fix SOQL throws the expected error against real \`ProcessInstance\` data on \`DaveMoudy OG\`
- [x] Post-fix SOQL returns unwrapped children with \`ProcessInstanceId\` correctly populated
- [x] Prettier clean
- [ ] Apex test suite (run at v1.88.0 release-validation time)
- [ ] Real-world template render against approval history (deferred to release-validation when staging org has approvals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)