### PR TITLE
docs(userguide): document Lightning RTE image-sizing limitation (#71)

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -892,6 +892,7 @@ A few caveats:
 - The **Generate Sample** button in the template builder doesn't render inline rich-text images — they show as broken placeholders. Test the real output via the runner instead.
 - For pixel-perfect images, use the `{%Image:N}` tag with an attached File rather than inline rich text — DOCX image quality is slightly lossy when sourced from rich-text inline images.
 - Inline-image rotation isn't preserved. Rotate the source before pasting.
+- **Pre-size images before pasting.** Lightning's rich text editor doesn't write `width=`/`height=`/`style=` to the HTML it stores — even when you drag-resize the image in the editor, the displayed size never makes it into the saved markup. (In Chrome, drag-resize is disabled outright; Firefox lets you drag but the resize still doesn't persist.) DocGen falls back to a 4-inch default for DOCX output and to natural pixel dimensions for PDF output, so a phone photo pasted at 4000×3000 will render correctly in DOCX but bleed off the page in PDF. The reliable fix is to **resize the image to your intended dimensions in an editor BEFORE pasting** — once it's in the rich text field, the size is locked to whatever the source pixels were. For pixel-precise sizing across both formats, prefer `{%Image:N}` with `:WxH` (§7.6).
 
 Plain multiline (long text, textarea) fields work too — newlines in the field value render as proper line breaks in the output. No manual `<br>` needed.
 


### PR DESCRIPTION
## Summary

Closes #71 as wontfix in favor of documentation. The root cause is a Salesforce platform limitation — Lightning's rich text editor doesn't persist drag-resize dimensions to the saved HTML. Chrome disables drag-resize outright; Firefox lets you drag but the size doesn't make it into the markup. With no size info to work with, DocGen has no honest way to recover the user's intended dimensions.

The PDF default (natural pixel dimensions, by way of the \`DOCGEN_AUTOSIZE\` marker) is materially worse than the DOCX default (fixed 4-inch fallback), but trying to "fix" it by changing the default would just trade one wrong default for another — the real fix lives outside DocGen.

## What this PR does

Adds a §7.9 caveat to the UserGuide:
- Explains the Lightning RTE constraint (Chrome / Firefox specifics)
- Documents the DOCX vs PDF default behavior so users know what to expect
- Recommends the reliable workarounds: pre-resize before pasting, or use \`{%Image:N}\` with explicit \`:WxH\` for pixel-precise control across both formats

## Test plan

- [x] Prettier clean

## Follow-up

Closing #71 as wontfix once this merges. The TRIAGE.md \`priority:P1\` label was applied before we understood the platform constraint — leaving it on the closed issue serves as a record of the original triage decision. If a future Salesforce platform update changes drag-resize behavior, we can revisit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)