### PR TITLE
fix(runner): swap @salesforce/community/basePath static import for Apex call

### DIFF
--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -2447,6 +2447,24 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
     }
 
     /**
+     * Returns the running user's site URL path prefix (e.g. "/PublicFacing").
+     * Empty string outside of a Site context (internal record pages, app pages,
+     * Flow screens). The runner LWC uses this to prepend the prefix to the
+     * shepherd download URL — guest sessions only authenticate against site-
+     * domain paths, so the bare org host returns a 90-byte JSON redirect.
+     *
+     * Replaces a `@salesforce/community/basePath` static import that broke the
+     * LWC on internal lightning__RecordPage targets (the import resolves at
+     * module-load time and fails outside community contexts, which manifested
+     * as an endless spinner that also blocked the rest of the record page).
+     */
+    @AuraEnabled(cacheable=true)
+    public static String getSiteUrlPathPrefix() {
+        String prefix = Site.getPathPrefix();
+        return prefix == null ? '' : prefix;
+    }
+
+    /**
      * Queues guest-context PDF generation via a platform event so the actual
      * render runs as Automated Process (system context) instead of the guest.
      *

--- a/force-app/main/default/lwc/docGenRunner/docGenRunner.js
+++ b/force-app/main/default/lwc/docGenRunner/docGenRunner.js
@@ -10,6 +10,7 @@ import generatePdfAsync from '@salesforce/apex/DocGenController.generatePdfAsync
 import isCurrentUserGuest from '@salesforce/apex/DocGenController.isCurrentUserGuest';
 import queueGuestRender from '@salesforce/apex/DocGenController.queueGuestRender';
 import getGuestRenderStatus from '@salesforce/apex/DocGenController.getGuestRenderStatus';
+import getSiteUrlPathPrefix from '@salesforce/apex/DocGenController.getSiteUrlPathPrefix';
 import scoutAttachedImageSize from '@salesforce/apex/DocGenController.scoutAttachedImageSize';
 import getChildRelationships from '@salesforce/apex/DocGenController.getChildRelationships';
 import getChildRecordPdfs from '@salesforce/apex/DocGenController.getChildRecordPdfs';
@@ -34,7 +35,6 @@ import OUT_FMT_FIELD from '@salesforce/schema/DocGen_Template__c.Output_Format__
 import TYPE_FIELD from '@salesforce/schema/DocGen_Template__c.Type__c';
 import IS_DEFAULT_FIELD from '@salesforce/schema/DocGen_Template__c.Is_Default__c';
 import CATEGORY_FIELD from '@salesforce/schema/DocGen_Template__c.Category__c';
-import COMMUNITY_BASE_PATH from '@salesforce/community/basePath';
 
 export default class DocGenRunner extends NavigationMixin(LightningElement) {
     @api recordId;
@@ -736,10 +736,16 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
         // against the site, not the lightning subdomain, so this fetch succeeds.
         // The site URL path prefix matters: the bare org host returns a JSON error
         // redirect for guests; only paths under the site's base recognize the session.
-        // `@salesforce/community/basePath` returns "/<sitePrefix>/s" (or "/s" if the
-        // site has no prefix) — strip the trailing "/s" to get just the site root.
-        const bp = typeof COMMUNITY_BASE_PATH === 'string' ? COMMUNITY_BASE_PATH : '';
-        const sitePrefix = bp.endsWith('/s') ? bp.slice(0, -2) : bp;
+        // Fetch the prefix from Apex (via Site.getPathPrefix()) instead of importing
+        // `@salesforce/community/basePath` statically — the latter resolves at module-
+        // load time and breaks the LWC on internal lightning__RecordPage targets,
+        // showing an endless spinner that also blocks the rest of the record page.
+        let sitePrefix = '';
+        try {
+            sitePrefix = (await getSiteUrlPathPrefix()) || '';
+        } catch (e) {
+            // Non-Site context — leave prefix empty.
+        }
         const url = sitePrefix + '/sfc/servlet.shepherd/version/download/' + result.cvId;
         const link = document.createElement('a');
         link.href = url;


### PR DESCRIPTION
## Summary

The runner LWC's static `@salesforce/community/basePath` import (added in v1.87.0 to fix the LWR site-prefix shepherd-download bug) breaks the LWC on internal `lightning__RecordPage` placements. The community-scoped module can't resolve outside community contexts, the LWC never finishes initializing, and the user sees an endless spinner that also blocks the rest of the record page from rendering.

User repro: drop the runner on an internal record page in DemoBox → endless spin → record itself doesn't load.

## Why this slipped through

PR #70 added `lightning__RecordPage` as a target alongside `lightningCommunity__Page`, so the same bundle has to load in both contexts. v1.87.0's fix added a static import that's community-only. The two changes were correct individually but incompatible when stacked.

## Fix

Replace the static import with a new cacheable Apex method, `DocGenController.getSiteUrlPathPrefix()`, wrapping `Site.getPathPrefix()`. That call works in both contexts: returns the site URL path prefix when running as a guest on a Site, empty string everywhere else. The LWC now fetches the prefix on demand inside `_generateGuestPdf` rather than at module load, so internal-page placements no longer pull in the community-scoped module.

```diff
-import COMMUNITY_BASE_PATH from '@salesforce/community/basePath';
+import getSiteUrlPathPrefix from '@salesforce/apex/DocGenController.getSiteUrlPathPrefix';
```

Inside `_generateGuestPdf`:

```diff
-const bp = typeof COMMUNITY_BASE_PATH === 'string' ? COMMUNITY_BASE_PATH : '';
-const sitePrefix = bp.endsWith('/s') ? bp.slice(0, -2) : bp;
+let sitePrefix = '';
+try {
+    sitePrefix = (await getSiteUrlPathPrefix()) || '';
+} catch (e) {
+    // Non-Site context — leave prefix empty.
+}
```

## Severity

P0 / silent-corruption — output "looks fine" (the LWC just spins) but the page beneath becomes unusable. Anyone who placed the runner on an internal record page after upgrading to v1.87.0 hit this.

## Test plan

- [x] LWC bundle + DocGenController deploy cleanly to docgen-designer
- [x] `Site.getPathPrefix()` returns empty string in non-Site context (verified via anonymous Apex)
- [x] Permset already grants class-level access on `DocGenController`, so the new method is reachable for both internal and guest users
- [ ] Manual UI verification on DemoBox after v1.88.0 package install — drop runner on internal record page, confirm no spinner, no page-load block. Drop on community page, confirm guest PDF download still works.

This must merge before the v1.88.0 package is created — the bug as-shipped in v1.87.0 makes the runner unusable on the most common deployment target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)