### PR TITLE
fix(runner): exempt guests from mobile=save-only restriction

### DIFF
--- a/force-app/main/default/lwc/docGenRunner/docGenRunner.js
+++ b/force-app/main/default/lwc/docGenRunner/docGenRunner.js
@@ -148,7 +148,16 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
     }
 
     get allowedOutputModes() {
-        if (this._isMobile) {
+        // Authenticated mobile path historically had Blob.toPdf base64 +
+        // blob-URL download issues (iOS Safari especially), so we restricted
+        // mobile to save-to-record only. The guest Experience Cloud path
+        // is different: it routes through DocGen_Guest_Render__e and
+        // downloads via a real shepherd URL link (no base64, no blob URL),
+        // which mobile browsers handle natively. Guests on community pages
+        // typically don't have save-to-record either, so blocking download
+        // would leave them with no output mode at all and a greyed-out
+        // generate button. Exempt guests from the mobile restriction.
+        if (this._isMobile && !this._isGuest) {
             return this.canSaveToRecord ? ['save'] : [];
         }
         // Combine PDFs (mergeOnly) and Document Packet are download-only.


### PR DESCRIPTION
## Summary

On a public Experience Cloud community page rendered on mobile, the runner's generate button greys out and the user has no way to download the document.

## Root cause

`allowedOutputModes()` in `docGenRunner.js` had a hardcoded mobile=save-only rule:

```javascript
if (this._isMobile) {
    return this.canSaveToRecord ? ['save'] : [];
}
```

That rule was originally added because iOS Safari has known bugs around base64 + blob-URL downloads — which is what the authenticated `Blob.toPdf` path produces. Save-to-record sidesteps the blob URL and was the safe fallback for mobile.

But on Experience Cloud public guest pages, `showSaveToRecordOption` defaults to `false`. So a mobile guest hits `canSaveToRecord === false`, the function returns `[]`, `modernOutputOptions` is empty, `isGenerateDisabled` is true, and the button is greyed out with no available output mode.

## Fix

Exempt guests from the mobile restriction. Guests go through `DocGen_Guest_Render__e` → `DocGenGuestRenderQueueable` → CV + shepherd URL link, which mobile browsers handle natively. No base64, no blob URL, no iOS Safari concern.

```diff
-if (this._isMobile) {
+if (this._isMobile && !this._isGuest) {
     return this.canSaveToRecord ? ['save'] : [];
}
```

Authenticated mobile users keep the original save-only behaviour because they still hit the Blob.toPdf path with the iOS Safari concern.

## Severity

P0 / silent-corruption — output looks fine (button just greys out) but the runner is unusable for the most common Experience Cloud mobile use case.

## Test plan

- [x] LWC bundle deploys cleanly to docgen-designer
- [x] Prettier clean
- [ ] Manual UI verification on DemoBox after v1.88.0 install — mobile community page should now show the Download button and generate successfully

Must merge before v1.88.0 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)