### PR TITLE
v1.93.0 — Flow Save-to-Record (#90), signature decline-leak (#91), status column polish (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## v1.93.0 — Flow Save-to-Record honored (#90), signature decline cache cleared (#91), Template Status column symmetric labels (#92)
+
+Three bug fixes ride this release — two from real customer field reports, one a follow-up polish to the v1.92.0 active/inactive feature. Highlights: the **Generate Document** Flow action now actually honors `Save to Record = false` (today the file was always attached via `ContentVersion.FirstPublishLocationId` regardless of the toggle); declining an e-signature now clears the cached typed-name preview so the signing page can't keep reading as "Electronically signed by …" after the fact; and the Template Library Status column now labels active templates "Active" (green) symmetrically with "Inactive" (gray) instead of leaving active cells blank.
+
+### Flow `Save to Record = false` now actually keeps the file off the record (refs #90)
+
+`DocGenFlowAction`'s `Save to Record` toggle was effectively a no-op: regardless of its value, the service path inserted the generated `ContentVersion` with `FirstPublishLocationId = recordId`, which auto-creates a `ContentDocumentLink` to the source record on insert. Customers who wanted "generate and download — don't leave an artifact on the record" had no clean Flow-side path.
+
+Root cause: `recordId` was overloaded as both the merge-data source **and** the file attachment target.
+
+- **`DocGenService.generateDocument`** — new 5-arg overload `(templateId, recordId, outputFormatOverride, documentTitle, attachmentRecordId)` that separates the two roles. `attachmentRecordId = null` inserts the `ContentVersion` standalone (no `FirstPublishLocationId`, no `ContentDocumentLink`) while still using `recordId` for merge data. Existing 4-arg overload delegates with back-compat behavior.
+- **`DocGenService.generateAndSaveFromData`** — parallel 6-arg overload for the JSON Data path (Flow action's pre-built data-map mode).
+- **`DocGenFlowAction`** — both branches (standard `recordId` and JSON Data) now pass `attachmentRecordId = (req.saveToRecord == true) ? req.recordId : null`. `@InvocableVariable` description updated to match reality. Phase 3 CDL backfill still runs only when `saveToRecord=true` (idempotent, deduped — no-op for the happy path now that `FirstPublishLocationId` does the work).
+- **`DocGenGiantQueryFlowAction`** sync path — same fix applied; removed the now-dead `linkToRecord` helper (`FirstPublishLocationId` handles attach).
+- **`DocGenBulkFlowAction`** is unaffected (bulk jobs always attach by design).
+- **Tests** — `DocGenMiscTests` gets two new regression tests (`testFlowAction_jsonData_withRecordId_saveToRecord_false_doesNotAttach`, `testFlowAction_recordId_saveToRecord_false_doesNotAttach`); the existing `testFlowActionSaveToRecord` was asserting the old buggy behavior and is now flipped to assert `saveToRecord = true` actually creates a CDL. `e2e-04-generate-docx.apex` gets two new assertions covering both toggle states with cleanup.
+
+### Signature decline now clears the cached typed-name preview (refs #91)
+
+When a v3 e-signature signer typed their name on the preview screen and then hit Decline, the verification page correctly reflected "Declined" but the signing-page document preview kept reading as "Electronically signed by …" — confusing for the signer and for anyone re-opening the link.
+
+Cause: the signing UI caches a fully merged preview HTML (including the typed-name signature stamp) into `DocGen_Signature_Request__c.Signature_Data__c` so signers see an instant live preview after typing. The decline endpoint (`DocGenSignatureController.declineSignature`) marked the signer + request `Declined` and wrote an audit row but never cleared the cache. `fetchDocumentData` then re-served the stale stamped preview. No legal/audit impact (verification cert was always accurate; no signed PDF is ever generated post-decline) — but a real UX bug.
+
+- **`DocGenSignatureController.declineSignature`** — now also nulls `signer.Signature_Data__c` and `parentReq.Signature_Data__c` alongside the status update. Mirrors what the Cancel path already did.
+- **`DocGenSignatureController.fetchDocumentData`** — when the request status is `Declined`, returns a clean confirmation card (decline date + reason if captured) instead of attempting a preview render. Survives page refresh independent of cache state.
+- **New `buildDeclinedStateHtml(...)` helper** produces the confirmation HTML.
+- **Tests** — `DocGenSignatureTests.testDeclineSignature` extended to seed `Signature_Data__c` on both records, decline, and assert both fields are nulled. New `testFetchDocumentData_returnsDeclinedCardAfterDecline` asserts the response contains "Signature Request Declined" + reason text and does **not** contain "electronically signed".
+
+### Template Library Status column shows "Active" instead of blank (refs #92)
+
+Follow-up to v1.92.0 #85. The Status column was rendering `'Inactive'` (gray) for inactive templates but `''` for active ones — under a column header reading "Status", an empty cell read as missing data rather than "Active".
+
+- **`lwc/docGenAdmin/docGenAdmin.js`** — symmetric labels: "Active" (green, bold) and "Inactive" (gray, bold).
+- LWC-only change. No Apex, no field, no permission set deltas.
+
+### Test counts
+
+- Apex local tests: **1334 passing**, 100% pass rate, 76% org-wide coverage.
+- e2e suite (e2e-01 through e2e-08) green on `portwood-staging`.
+- Prettier: clean. Code Analyzer: 0 High, 41 Moderate (signature-field `pmd:ProtectSensitiveData` false positives — unchanged from v1.92.0 baseline).
+
 ## v1.92.0 — Active/Inactive template toggle, prune old versions, Classic Approvals merge tag, guest DOCX images closed wontfix with empirical record
 
 Promoted package: `04tVx000000S9I5IAK` · [Install URL](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000S9I5IAK)

--- a/force-app/main/default/classes/DocGenFlowAction.cls
+++ b/force-app/main/default/classes/DocGenFlowAction.cls
@@ -17,7 +17,7 @@ global with sharing class DocGenFlowAction { // NOPMD AvoidGlobalModifier — gl
 
         @InvocableVariable(
             label='Save to Record'
-            description='If true, attach the generated file to the source record via ContentDocumentLink. Default: false'
+            description='If true, attach the generated file to the source record (Files related list). If false (default), the file is inserted as a standalone ContentVersion and can still be downloaded via the returned Content Document ID / Content Version ID — the source record is not touched.'
         )
         global Boolean saveToRecord;
 
@@ -87,14 +87,17 @@ global with sharing class DocGenFlowAction { // NOPMD AvoidGlobalModifier — gl
                     Map<String, Object> dataMap = (Map<String, Object>) parsed;
 
                     if (req.recordId != null) {
-                        // Caller wants the file attached to the supplied record (FirstPublishLocationId).
-                        // saveToRecord=true adds an extra ContentDocumentLink in Phase 3.
+                        // recordId is the title/context anchor. The actual attachment target is null
+                        // when saveToRecord != true — produces a standalone ContentVersion the Flow
+                        // can hand off via the returned ContentDocumentId (issue #90).
+                        Id fileAttachmentTarget = (req.saveToRecord == true) ? req.recordId : null;
                         docId = DocGenService.generateAndSaveFromData(
                             req.templateId,
                             req.recordId,
                             dataMap,
                             req.outputFormatOverride,
-                            req.documentTitle
+                            req.documentTitle,
+                            fileAttachmentTarget
                         );
                     } else {
                         // No record context — render PDF and insert as a standalone ContentVersion.
@@ -128,11 +131,15 @@ global with sharing class DocGenFlowAction { // NOPMD AvoidGlobalModifier — gl
                         res.contentVersionId = saved.Id;
                     }
                 } else {
+                    // attachmentRecordId is null when saveToRecord != true — keeps the file out of the
+                    // record's Files related list while still using recordId for merge data (issue #90).
+                    Id attachmentRecordId = (req.saveToRecord == true) ? req.recordId : null;
                     docId = DocGenService.generateDocument(
                         req.templateId,
                         req.recordId,
                         req.outputFormatOverride,
-                        req.documentTitle
+                        req.documentTitle,
+                        attachmentRecordId
                     );
                 }
                 res.contentDocumentId = docId;

--- a/force-app/main/default/classes/DocGenGiantQueryFlowAction.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryFlowAction.cls
@@ -21,7 +21,7 @@ global with sharing class DocGenGiantQueryFlowAction { // NOPMD AvoidGlobalModif
 
         @InvocableVariable(
             label='Save to Record'
-            description='If true, attach the generated file to the source record. Default: true for sync, always true for async Giant Query.'
+            description='If true, attach the generated file to the source record (Files related list). If false (default), the sync-path file is inserted as a standalone ContentVersion and can still be downloaded via the returned Content Document ID. The async Giant Query path always attaches because the batch writes the final PDF back to the job/record.'
         )
         global Boolean saveToRecord;
     }
@@ -113,8 +113,16 @@ global with sharing class DocGenGiantQueryFlowAction { // NOPMD AvoidGlobalModif
                     res.jobId = launchGiantBatch(req.templateId, req.recordId, giantRelationship, giantNodeConfig);
                     res.success = true;
                 } else {
-                    // Sync path — same as DocGenFlowAction
-                    Id docId = DocGenService.generateDocument(req.templateId, req.recordId);
+                    // Sync path — same as DocGenFlowAction. attachmentRecordId is null when
+                    // saveToRecord != true so the file stays off the record (issue #90).
+                    Id attachmentRecordId = (req.saveToRecord == true) ? req.recordId : null;
+                    Id docId = DocGenService.generateDocument(
+                        req.templateId,
+                        req.recordId,
+                        null,
+                        null,
+                        attachmentRecordId
+                    );
                     res.contentDocumentId = docId;
                     res.success = true;
 
@@ -128,11 +136,6 @@ global with sharing class DocGenGiantQueryFlowAction { // NOPMD AvoidGlobalModif
                     ];
                     if (!cvs.isEmpty()) {
                         res.contentVersionId = cvs[0].Id;
-                    }
-
-                    // Link to record
-                    if (req.saveToRecord == true && docId != null) {
-                        linkToRecord(docId, req.recordId);
                     }
                 }
             } catch (Exception e) {
@@ -211,31 +214,5 @@ global with sharing class DocGenGiantQueryFlowAction { // NOPMD AvoidGlobalModif
         Database.executeBatch(batch, 1);
 
         return job.Id;
-    }
-
-    /**
-     * Links a ContentDocument to a record, avoiding duplicate links.
-     */
-    private static void linkToRecord(Id docId, Id recordId) {
-        List<ContentDocumentLink> existing = [
-            SELECT Id
-            FROM ContentDocumentLink
-            WHERE ContentDocumentId = :docId AND LinkedEntityId = :recordId
-            WITH USER_MODE
-            LIMIT 1
-        ];
-        if (existing.isEmpty()) {
-            ContentDocumentLink cdl = new ContentDocumentLink(
-                ContentDocumentId = docId,
-                LinkedEntityId = recordId,
-                ShareType = 'V',
-                Visibility = 'AllUsers'
-            );
-            SObjectAccessDecision decision = Security.stripInaccessible(
-                AccessType.CREATABLE,
-                new List<ContentDocumentLink>{ cdl }
-            );
-            insert decision.getRecords(); // NOPMD ApexCRUDViolation — FLS enforced via stripInaccessible
-        }
     }
 }

--- a/force-app/main/default/classes/DocGenMiscTests.cls
+++ b/force-app/main/default/classes/DocGenMiscTests.cls
@@ -272,7 +272,7 @@ private class DocGenMiscTests {
     }
 
     @IsTest
-    static void testFlowAction_jsonData_withRecordId_attaches_to_record() {
+    static void testFlowAction_jsonData_withRecordId_saveToRecord_true_attaches() {
         TestDataFactory.attachRealDocxToTestTemplate();
         DocGen_Template__c tpl = TestDataFactory.getTestTemplate();
         Account acc = TestDataFactory.getTestAccount();
@@ -280,6 +280,7 @@ private class DocGenMiscTests {
         DocGenFlowAction.Request req = new DocGenFlowAction.Request();
         req.templateId = tpl.Id;
         req.recordId = acc.Id;
+        req.saveToRecord = true;
         req.jsonData = '{"Name":"Hybrid","Amount":1}';
 
         Test.startTest();
@@ -296,6 +297,70 @@ private class DocGenMiscTests {
             WHERE LinkedEntityId = :acc.Id AND ContentDocumentId = :responses[0].contentDocumentId
         ];
         System.assert(linkCount > 0, 'Document should be linked to the supplied recordId');
+    }
+
+    // Regression: GitHub #90 — Save to Record = false (or omitted) must NOT attach to the
+    // supplied recordId, even when JSON Data + recordId are both provided. recordId stays
+    // as the title/context anchor; the file lands as a standalone ContentVersion.
+    @IsTest
+    static void testFlowAction_jsonData_withRecordId_saveToRecord_false_doesNotAttach() {
+        TestDataFactory.attachRealDocxToTestTemplate();
+        DocGen_Template__c tpl = TestDataFactory.getTestTemplate();
+        Account acc = TestDataFactory.getTestAccount();
+
+        DocGenFlowAction.Request req = new DocGenFlowAction.Request();
+        req.templateId = tpl.Id;
+        req.recordId = acc.Id;
+        req.saveToRecord = false;
+        req.jsonData = '{"Name":"Hybrid","Amount":1}';
+
+        Test.startTest();
+        List<DocGenFlowAction.Response> responses = DocGenFlowAction.generateDocument(
+            new List<DocGenFlowAction.Request>{ req }
+        );
+        Test.stopTest();
+
+        System.assertEquals(true, responses[0].success, 'Should succeed: ' + responses[0].errorMessage);
+        System.assertNotEquals(null, responses[0].contentDocumentId, 'CD id still returned for download');
+        Integer linkCount = [
+            SELECT COUNT()
+            FROM ContentDocumentLink
+            WHERE LinkedEntityId = :acc.Id AND ContentDocumentId = :responses[0].contentDocumentId
+        ];
+        System.assertEquals(0, linkCount, 'Document must NOT be linked when saveToRecord=false');
+    }
+
+    // Regression: GitHub #90 — standard recordId path (no JSON Data) must honor saveToRecord=false.
+    @IsTest
+    static void testFlowAction_recordId_saveToRecord_false_doesNotAttach() {
+        String docXml =
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+            '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' +
+            '<w:body><w:p><w:r><w:t>{Name}</w:t></w:r></w:p></w:body></w:document>';
+        createValidDocxFile(docXml);
+
+        DocGen_Template__c tpl = TestDataFactory.getTestTemplate();
+        Account acc = TestDataFactory.getTestAccount();
+
+        DocGenFlowAction.Request req = new DocGenFlowAction.Request();
+        req.templateId = tpl.Id;
+        req.recordId = acc.Id;
+        req.saveToRecord = false;
+
+        Test.startTest();
+        List<DocGenFlowAction.Response> responses = DocGenFlowAction.generateDocument(
+            new List<DocGenFlowAction.Request>{ req }
+        );
+        Test.stopTest();
+
+        System.assertEquals(true, responses[0].success, 'Should succeed: ' + responses[0].errorMessage);
+        System.assertNotEquals(null, responses[0].contentDocumentId, 'CD id still returned for download');
+        Integer linkCount = [
+            SELECT COUNT()
+            FROM ContentDocumentLink
+            WHERE LinkedEntityId = :acc.Id AND ContentDocumentId = :responses[0].contentDocumentId
+        ];
+        System.assertEquals(0, linkCount, 'Document must NOT be linked when saveToRecord=false');
     }
 
     @IsTest
@@ -6128,7 +6193,7 @@ private class DocGenMiscTests {
             DocGenFlowAction.Request req = new DocGenFlowAction.Request();
             req.templateId = tpl.Id;
             req.recordId = acc.Id;
-            req.saveToRecord = false; // Service already links via FirstPublishLocationId
+            req.saveToRecord = true;
 
             Test.startTest();
             List<DocGenFlowAction.Response> responses = DocGenFlowAction.generateDocument(
@@ -6146,7 +6211,7 @@ private class DocGenMiscTests {
             System.assertNotEquals(null, responses[0].contentVersionId, 'ContentVersionId should be set on success');
             System.assertEquals(null, responses[0].errorMessage, 'ErrorMessage should be null on success');
 
-            // Verify the file is linked to the source record (auto-linked by service)
+            // saveToRecord=true: file must be linked to the source record (FirstPublishLocationId path).
             List<ContentDocumentLink> links = [
                 SELECT Id
                 FROM ContentDocumentLink

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -2019,6 +2019,24 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
      * resolved title format / record Name fallback. Used by Flow callers (Document Title input).
      */
     global static Id generateDocument(Id templateId, Id recordId, String outputFormatOverride, String documentTitle) {
+        return generateDocument(templateId, recordId, outputFormatOverride, documentTitle, recordId);
+    }
+
+    /**
+     * Same as the 4-arg overload but separates the merge-data record from the attachment target.
+     * Pass attachmentRecordId = null to insert the ContentVersion as a standalone file (no
+     * FirstPublishLocationId, no ContentDocumentLink) — the caller still gets the returned
+     * ContentDocumentId so it can hand the user a `/sfc/servlet.shepherd/version/download/...`
+     * URL without leaving an artifact on the source record. Used by Flow callers that opt out
+     * of "Save to Record" (issue #90).
+     */
+    global static Id generateDocument(
+        Id templateId,
+        Id recordId,
+        String outputFormatOverride,
+        String documentTitle,
+        Id attachmentRecordId
+    ) {
         validateOutputFormatOverride(templateId, outputFormatOverride);
         MergeResult mr = mergeTemplate(templateId, recordId, null, outputFormatOverride);
         if (String.isNotBlank(documentTitle)) {
@@ -2027,12 +2045,12 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
 
         if (mr.outputFormat == 'PDF' && (mr.templateType == 'Word' || mr.templateType == 'HTML')) {
             Blob pdfBlob = renderPdf(mr, templateId, recordId);
-            return savePdfFile(pdfBlob, mr.docTitle, recordId);
+            return savePdfFile(pdfBlob, mr.docTitle, attachmentRecordId);
         }
 
         // Native DOCX/PPTX path
         Blob resultBlob = assembleZip(mr);
-        return saveFile(resultBlob, mr.docTitle, recordId, mr.outputFormat, mr.templateType);
+        return saveFile(resultBlob, mr.docTitle, attachmentRecordId, mr.outputFormat, mr.templateType);
     }
 
     /**
@@ -2110,6 +2128,31 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         String outputFormatOverride,
         String documentTitle
     ) {
+        return generateAndSaveFromData(
+            templateId,
+            attachmentRecordId,
+            dataMap,
+            outputFormatOverride,
+            documentTitle,
+            attachmentRecordId
+        );
+    }
+
+    /**
+     * Same as generateAndSaveFromData(templateId, attachmentRecordId, dataMap, outputFormatOverride,
+     * documentTitle) but separates the data-source record from the attachment target. Pass
+     * fileAttachmentTarget = null to insert a standalone ContentVersion (no FirstPublishLocationId,
+     * no ContentDocumentLink). Used by the Flow action when saveToRecord=false and JSON Data is
+     * supplied (issue #90).
+     */
+    global static Id generateAndSaveFromData(
+        Id templateId,
+        Id attachmentRecordId,
+        Map<String, Object> dataMap,
+        String outputFormatOverride,
+        String documentTitle,
+        Id fileAttachmentTarget
+    ) {
         if (dataMap == null) {
             throw new DocGenException('dataMap cannot be null.');
         }
@@ -2119,7 +2162,13 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             );
         }
         preloadedRecordDataOverride = dataMap;
-        return generateDocument(templateId, attachmentRecordId, outputFormatOverride, documentTitle);
+        return generateDocument(
+            templateId,
+            attachmentRecordId,
+            outputFormatOverride,
+            documentTitle,
+            fileAttachmentTarget
+        );
     }
 
     /**

--- a/force-app/main/default/classes/DocGenSignatureController.cls
+++ b/force-app/main/default/classes/DocGenSignatureController.cls
@@ -614,9 +614,12 @@ public without sharing class DocGenSignatureController {
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
         List<DocGen_Signer__c> signers = [
             SELECT
+                Decline_Reason__c,
+                LastModifiedDate,
                 Signature_Request__r.Source_Document_Id__c,
                 Signature_Request__r.Related_Record_Id__c,
-                Signature_Request__r.Template__c
+                Signature_Request__r.Template__c,
+                Signature_Request__r.Status__c
             FROM DocGen_Signer__c
             WHERE Secure_Token__c = :token
             WITH SYSTEM_MODE
@@ -627,18 +630,24 @@ public without sharing class DocGenSignatureController {
         Id templateId;
         Id requestId;
         String recordId;
+        String requestStatus;
+        String declineReason;
+        Datetime declinedAt;
         if (!signers.isEmpty()) {
             sourceDocId = signers[0].Signature_Request__r.Source_Document_Id__c;
             templateId = signers[0].Signature_Request__r.Template__c;
             requestId = signers[0].Signature_Request__r.Id;
             recordId = signers[0].Signature_Request__r.Related_Record_Id__c;
+            requestStatus = signers[0].Signature_Request__r.Status__c;
+            declineReason = signers[0].Decline_Reason__c;
+            declinedAt = signers[0].LastModifiedDate;
             res.recordId = recordId;
         } else {
             // CxSAST: USER_MODE not viable in managed package (namespace resolution breaks unqualified field names); CRUD/FLS enforced by permission sets
             // Legacy fallback
             /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
             List<DocGen_Signature_Request__c> requests = [
-                SELECT Id, Source_Document_Id__c, Related_Record_Id__c, Template__c
+                SELECT Id, Source_Document_Id__c, Related_Record_Id__c, Template__c, Status__c, LastModifiedDate
                 FROM DocGen_Signature_Request__c
                 WHERE Secure_Token__c = :token
                 WITH SYSTEM_MODE
@@ -649,8 +658,19 @@ public without sharing class DocGenSignatureController {
                 templateId = requests[0].Template__c;
                 requestId = requests[0].Id;
                 recordId = requests[0].Related_Record_Id__c;
+                requestStatus = requests[0].Status__c;
+                declinedAt = requests[0].LastModifiedDate;
                 res.recordId = recordId;
             }
+        }
+
+        // Issue #91: when the request is declined, short-circuit with a confirmation card
+        // instead of trying to render a preview. The cached preview HTML was already cleared
+        // in declineSignature, so any fallback to the live render would still show a doc that
+        // reads as unsigned — but we'd rather make the declined state explicit than implicit.
+        if (requestStatus == 'Declined') {
+            res.templateBase64 = buildDeclinedStateHtml(declinedAt, declineReason);
+            return res;
         }
 
         // Template-based: load preview HTML from Signature_Data__c cache on the request,
@@ -745,6 +765,35 @@ public without sharing class DocGenSignatureController {
             );
         }
         return '<html><body><p>Document preview unavailable.</p></body></html>';
+    }
+
+    /**
+     * Issue #91: Renders the confirmation card shown when the signing link is opened after
+     * the request has been declined. Replaces the document preview so the page can't read
+     * as signed regardless of cache state.
+     */
+    private static String buildDeclinedStateHtml(Datetime declinedAt, String reason) {
+        String dateStr = declinedAt != null ? declinedAt.format('MMMM d, yyyy \'at\' h:mm a z') : '';
+        String reasonBlock = '';
+        if (String.isNotBlank(reason)) {
+            reasonBlock =
+                '<p style="margin:12px 0 0 0;color:#3e3e3c;"><strong>Reason:</strong> ' +
+                reason.escapeHtml4() +
+                '</p>';
+        }
+        return '<html><head><style>' +
+            'body{font-family:Arial,Helvetica,sans-serif;background:#f3f3f3;margin:0;padding:48px 16px;}' +
+            '.card{max-width:560px;margin:0 auto;background:#fff;border:1px solid #dddbda;border-radius:6px;' +
+            'padding:32px;text-align:center;}' +
+            '.title{color:#c23934;font-size:20pt;font-weight:600;margin:0 0 8px 0;}' +
+            '.subtitle{color:#3e3e3c;font-size:11pt;margin:0;}' +
+            '</style></head><body><div class="card">' +
+            '<p class="title">Signature Request Declined</p>' +
+            '<p class="subtitle">This signature request was declined' +
+            (String.isNotBlank(dateStr) ? ' on ' + dateStr.escapeHtml4() : '') +
+            '. No further action is required; the document sender has been notified.</p>' +
+            reasonBlock +
+            '</div></body></html>';
     }
 
     /**
@@ -1352,12 +1401,18 @@ public without sharing class DocGenSignatureController {
         // CxSAST: FLS enforced by DocGen permission sets; package-internal custom objects
         signer.Status__c = 'Declined';
         signer.Decline_Reason__c = String.isNotBlank(reason) ? reason.left(1000) : null;
+        // Issue #91: clear the typed-name cache so a refresh of the signing link doesn't
+        // re-stamp the preview with what the signer typed before declining.
+        signer.Signature_Data__c = null;
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
         Database.update(signer, false, AccessLevel.SYSTEM_MODE);
 
-        // Mark parent request as declined
+        // Mark parent request as declined. Null out the cached preview HTML — the JSON blob
+        // in Signature_Data__c carries the live preview with names already stamped, and
+        // fetchDocumentData would otherwise re-serve it (issue #91).
         DocGen_Signature_Request__c parentReq = new DocGen_Signature_Request__c(Id = signer.Signature_Request__c);
         parentReq.Status__c = 'Declined';
+        parentReq.Signature_Data__c = null;
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
         Database.update(parentReq, false, AccessLevel.SYSTEM_MODE);
 

--- a/force-app/main/default/classes/DocGenSignatureTests.cls
+++ b/force-app/main/default/classes/DocGenSignatureTests.cls
@@ -615,6 +615,35 @@ private class DocGenSignatureTests {
         System.assertNotEquals(null, res);
     }
 
+    // Issue #91: when the request is declined, fetchDocumentData must return the
+    // declined-state confirmation card instead of rendering a document preview —
+    // even if a stale cached preview were still present, the response should not
+    // contain "electronically signed" text or document body.
+    @isTest
+    static void testFetchDocumentData_returnsDeclinedCardAfterDecline() {
+        DocGen_Signer__c signer = getTestSigner();
+        String signerToken = [SELECT Secure_Token__c FROM DocGen_Signer__c WHERE Id = :signer.Id].Secure_Token__c;
+
+        // Decline the signer first.
+        DocGenSignatureController.declineSignature(signerToken, 'Wrong document', null, null);
+
+        Test.startTest();
+        DocGenSignatureController.SignatureInitResponse res = DocGenSignatureController.fetchDocumentData(signerToken);
+        Test.stopTest();
+
+        System.assertNotEquals(null, res);
+        System.assertNotEquals(null, res.templateBase64, 'Declined card HTML should be returned');
+        System.assert(
+            res.templateBase64.contains('Signature Request Declined'),
+            'Expected declined-state card, got: ' + res.templateBase64.left(200)
+        );
+        System.assert(res.templateBase64.contains('Wrong document'), 'Decline reason should be surfaced in the card');
+        System.assert(
+            !res.templateBase64.containsIgnoreCase('electronically signed'),
+            'Declined response must not contain signed-state text'
+        );
+    }
+
     // =========================================================================
     // Stamp and return source
     // =========================================================================
@@ -4094,6 +4123,17 @@ private class DocGenSignatureTests {
         DocGen_Signer__c signer = getTestSigner();
         String signerToken = [SELECT Secure_Token__c FROM DocGen_Signer__c WHERE Id = :signer.Id].Secure_Token__c;
 
+        // Issue #91: seed Signature_Data__c on both signer and request so we can confirm
+        // the decline handler clears them — otherwise the cached preview leaks the typed
+        // name back to anyone refreshing the signing link after decline.
+        signer.Signature_Data__c = 'Pre-decline typed name';
+        update signer;
+        DocGen_Signature_Request__c parentReqSeed = new DocGen_Signature_Request__c(
+            Id = signer.Signature_Request__c,
+            Signature_Data__c = '{"previewHtml":"<html>Electronically signed by ...</html>"}'
+        );
+        update parentReqSeed;
+
         Test.startTest();
         Map<String, Object> result = DocGenSignatureController.declineSignature(
             signerToken,
@@ -4104,9 +4144,29 @@ private class DocGenSignatureTests {
         Test.stopTest();
 
         System.assertEquals(true, result.get('success'));
-        DocGen_Signer__c updated = [SELECT Status__c, Decline_Reason__c FROM DocGen_Signer__c WHERE Id = :signer.Id];
+        DocGen_Signer__c updated = [
+            SELECT Status__c, Decline_Reason__c, Signature_Data__c
+            FROM DocGen_Signer__c
+            WHERE Id = :signer.Id
+        ];
         System.assertEquals('Declined', updated.Status__c);
         System.assertEquals('Not agreed with terms', updated.Decline_Reason__c);
+        System.assertEquals(
+            null,
+            updated.Signature_Data__c,
+            'Issue #91: signer typed-name cache must be cleared on decline'
+        );
+
+        DocGen_Signature_Request__c declinedReq = [
+            SELECT Signature_Data__c
+            FROM DocGen_Signature_Request__c
+            WHERE Id = :signer.Signature_Request__c
+        ];
+        System.assertEquals(
+            null,
+            declinedReq.Signature_Data__c,
+            'Issue #91: cached preview HTML on request must be cleared on decline'
+        );
 
         // Verify the supplied IP + UA actually landed on the audit row.
         // resolveClientIp() should have accepted '203.0.113.7' as valid IPv4.

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -698,8 +698,10 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                     ...t,
                     defaultLabel: t[F.IsDefault] ? '★' : '',
                     defaultClass: t[F.IsDefault] ? 'slds-text-color_success slds-text-title_bold' : '',
-                    activeLabel: isActive ? '' : 'Inactive',
-                    activeClass: isActive ? '' : 'slds-text-color_weak slds-text-title_bold'
+                    activeLabel: isActive ? 'Active' : 'Inactive',
+                    activeClass: isActive
+                        ? 'slds-text-color_success slds-text-title_bold'
+                        : 'slds-text-color_weak slds-text-title_bold'
                 };
             });
             this._samplesChecked = true;

--- a/scripts/e2e-04-generate-docx.apex
+++ b/scripts/e2e-04-generate-docx.apex
@@ -238,6 +238,70 @@ try {
     System.debug('TEMPLATE RESET TO PDF: FAIL — ' + e.getMessage());
 }
 
+// ===== Issue #90: Flow action must honor Save to Record toggle =====
+// Runs against the PDF-mode template (after reset) so we exercise the same path
+// real customers use. saveToRecord=false must NOT attach the file to the source
+// record even though recordId is supplied as the merge-data source.
+try {
+    DocGenFlowAction.Request reqOff = new DocGenFlowAction.Request();
+    reqOff.templateId = tmplId;
+    reqOff.recordId = acctId;
+    reqOff.saveToRecord = false;
+    List<DocGenFlowAction.Response> resOff = DocGenFlowAction.generateDocument(
+        new List<DocGenFlowAction.Request>{ reqOff }
+    );
+    if (resOff[0].success == true && resOff[0].contentDocumentId != null) {
+        Integer linkCount = [
+            SELECT COUNT()
+            FROM ContentDocumentLink
+            WHERE LinkedEntityId = :acctId AND ContentDocumentId = :resOff[0].contentDocumentId
+        ];
+        if (linkCount == 0) {
+            pass++;
+            System.debug('FLOW ACTION saveToRecord=false: PASS — no CDL to source record');
+        } else {
+            fail++;
+            System.debug('FLOW ACTION saveToRecord=false: FAIL — file attached anyway (' + linkCount + ' CDL)');
+        }
+    } else {
+        fail++;
+        System.debug('FLOW ACTION saveToRecord=false: FAIL — generation failed: ' + resOff[0].errorMessage);
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('FLOW ACTION saveToRecord=false: FAIL — ' + e.getMessage());
+}
+
+try {
+    DocGenFlowAction.Request reqOn = new DocGenFlowAction.Request();
+    reqOn.templateId = tmplId;
+    reqOn.recordId = acctId;
+    reqOn.saveToRecord = true;
+    List<DocGenFlowAction.Response> resOn = DocGenFlowAction.generateDocument(
+        new List<DocGenFlowAction.Request>{ reqOn }
+    );
+    if (resOn[0].success == true && resOn[0].contentDocumentId != null) {
+        Integer linkCount = [
+            SELECT COUNT()
+            FROM ContentDocumentLink
+            WHERE LinkedEntityId = :acctId AND ContentDocumentId = :resOn[0].contentDocumentId
+        ];
+        if (linkCount > 0) {
+            pass++;
+            System.debug('FLOW ACTION saveToRecord=true: PASS — CDL exists');
+        } else {
+            fail++;
+            System.debug('FLOW ACTION saveToRecord=true: FAIL — no CDL created');
+        }
+    } else {
+        fail++;
+        System.debug('FLOW ACTION saveToRecord=true: FAIL — generation failed: ' + resOn[0].errorMessage);
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('FLOW ACTION saveToRecord=true: FAIL — ' + e.getMessage());
+}
+
 System.debug('========================================');
 System.debug(
     'E2E-04 GENERATE DOCX — PASS: ' +

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,9 +1,9 @@
 {
   "packageDirectories": [
     {
-      "versionName": "1.92.0 — {#Approvals} tag, active/inactive templates, delete versions",
-      "versionNumber": "1.92.0.NEXT",
-      "ancestorId": "04tVx000000RvbhIAC",
+      "versionName": "1.93.0 — Flow Save-to-Record fix (#90), signature decline-leak fix (#91), template status column polish (#92)",
+      "versionNumber": "1.93.0.NEXT",
+      "ancestorId": "04tVx000000S9I5IAK",
       "path": "force-app",
       "default": true,
       "package": "Portwood DocGen Managed",


### PR DESCRIPTION
## Summary

Three customer-reported bug fixes for the v1.93.0 release:

- **#90 (P1)** — `Generate Document` Flow action now honors `Save to Record = false`. Previously the file was always attached to the source record via `ContentVersion.FirstPublishLocationId` regardless of the toggle.
- **#91 (P1)** — Signature decline clears the cached typed-name preview so the signing page stops reading as "Electronically signed by …" after the signer declines. Verification cert was always accurate; this is the UX leak.
- **#92 (P2)** — Template Library Status column shows "Active" symmetrically with "Inactive" instead of leaving active cells blank under the "Status" header (follow-up polish to v1.92.0 #85).

## Key changes

### Issue #90
- `DocGenService.cls` — new 5-arg `generateDocument` overload + 6-arg `generateAndSaveFromData` overload that separate data-source `recordId` from `attachmentRecordId`. `attachmentRecordId = null` inserts a standalone `ContentVersion` (no `FirstPublishLocationId`, no `ContentDocumentLink`). Existing overloads delegate with back-compat behavior.
- `DocGenFlowAction.cls` — both branches (standard `recordId` and JSON Data) pass `attachmentRecordId = (req.saveToRecord == true) ? req.recordId : null`. `@InvocableVariable` description updated.
- `DocGenGiantQueryFlowAction.cls` — sync path wired the same way; removed now-dead `linkToRecord` helper.
- `DocGenBulkFlowAction` is unaffected (bulk jobs always attach by design).

### Issue #91
- `DocGenSignatureController.declineSignature` — nulls `signer.Signature_Data__c` and `parentReq.Signature_Data__c` alongside status update.
- `DocGenSignatureController.fetchDocumentData` — returns a declined-state confirmation card (with date + reason if captured) when the request status is `Declined`, instead of attempting a preview render.
- New private `buildDeclinedStateHtml(...)` helper.

### Issue #92
- `lwc/docGenAdmin/docGenAdmin.js:701-702` — symmetric "Active" (green, bold) / "Inactive" (gray, bold) labels.

## Test plan

- [x] `npm run format:check` clean
- [x] Apex local tests: 1334 pass, 0 fail, 76% org-wide coverage
- [x] e2e-01 through e2e-08 green on `portwood-staging` (221 assertions)
- [x] Code Analyzer: 0 High, 41 Moderate (signature-field `ProtectSensitiveData` false positives — baseline, unchanged from v1.92.0)
- [x] Two new e2e-04 assertions added covering `saveToRecord=false` (no CDL) and `saveToRecord=true` (CDL exists)

## Issue links

Closes #90
Closes #91
Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)