### PR TITLE
fix(giant-query): use class selectors instead of :nth-child for per-column CSS

### DIFF
--- a/force-app/main/default/classes/DocGenGiantQueryBatch.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryBatch.cls
@@ -317,7 +317,9 @@ public with sharing class DocGenGiantQueryBatch implements Database.Batchable<St
 
     /**
      * Lightweight DOCX XML → HTML row converter. Extracts text from <w:t> tags.
-     * No inline formatting — column styles applied via nth-child CSS in the assembler.
+     * No inline formatting — column styles applied via td.gqcN class CSS in the
+     * assembler. (Flying Saucer's Blob.toPdf silently ignores :nth-child(), so
+     * class selectors are required to land per-column styling on the PDF path.)
      * Barcode markers stripped to plain text values.
      */
     private static String xmlRowsToHtmlRows(String xml) {
@@ -378,7 +380,7 @@ public with sharing class DocGenGiantQueryBatch implements Database.Batchable<St
                     }
                 }
 
-                row += '<td>' + txt + '</td>';
+                row += '<td class="gqc' + colNum + '">' + txt + '</td>';
             }
             result += row + '</tr>';
         }
@@ -406,8 +408,9 @@ public with sharing class DocGenGiantQueryBatch implements Database.Batchable<St
     /**
      * Extracts per-column CSS from the template's loop row XML. Reads bold, italic,
      * font-size from <w:rPr> and alignment from <w:pPr> for each cell, returns
-     * nth-child CSS rules. Called once during config extraction, injected into
-     * the assembler's HTML <style> block.
+     * td.gqcN class CSS rules. Called once during config extraction, injected into
+     * the assembler's HTML <style> block. Class selectors (not :nth-child) because
+     * Flying Saucer's Blob.toPdf silently drops :nth-child().
      */
     public static String extractColumnCss(String loopRowXml) {
         String css = '';
@@ -469,7 +472,7 @@ public with sharing class DocGenGiantQueryBatch implements Database.Batchable<St
             }
 
             if (!styles.isEmpty()) {
-                css += 'td:nth-child(' + colNum + '){' + String.join(styles, ';') + '} ';
+                css += 'td.gqc' + colNum + '{' + String.join(styles, ';') + '} ';
             }
         }
         return css;

--- a/force-app/main/default/classes/DocGenGiantQueryTest.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryTest.cls
@@ -160,6 +160,34 @@ private class DocGenGiantQueryTest {
     }
 
     @IsTest
+    static void testExtractColumnCssEmitsClassSelectors() {
+        // Regression: per-column styles must use td.gqcN class selectors, not
+        // td:nth-child(N) — Flying Saucer (Blob.toPdf) silently drops :nth-child,
+        // making the entire giant-query column-CSS scheme dead. Customer-visible
+        // symptom: right-aligned cells render left-aligned in the PDF.
+        String loopRowXml =
+            '<w:tr>' +
+            '<w:tc><w:p><w:pPr><w:jc w:val="right"/></w:pPr><w:r><w:t>A</w:t></w:r></w:p></w:tc>' +
+            '<w:tc><w:p><w:pPr><w:jc w:val="center"/></w:pPr><w:r><w:rPr><w:b/></w:rPr><w:t>B</w:t></w:r></w:p></w:tc>' +
+            '<w:tc><w:p><w:r><w:t>C</w:t></w:r></w:p></w:tc>' +
+            '</w:tr>';
+
+        Test.startTest();
+        String css = DocGenGiantQueryBatch.extractColumnCss(loopRowXml);
+        Test.stopTest();
+
+        System.assert(css.contains('td.gqc1{'), 'Col 1 must use class selector. Got: ' + css);
+        System.assert(css.contains('td.gqc2{'), 'Col 2 must use class selector. Got: ' + css);
+        System.assert(css.contains('text-align:right'), 'Col 1 right-align must be emitted. Got: ' + css);
+        System.assert(css.contains('text-align:center'), 'Col 2 center-align must be emitted. Got: ' + css);
+        System.assert(css.contains('font-weight:bold'), 'Col 2 bold must be emitted. Got: ' + css);
+        System.assert(
+            !css.contains(':nth-child('),
+            ':nth-child must NEVER be emitted — Flying Saucer ignores it. Got: ' + css
+        );
+    }
+
+    @IsTest
     static void testRenderLoopBodyForRecords() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {


### PR DESCRIPTION
## Summary

- Per-column CSS in giant-query PDFs (`text-align`, `font-weight`, `font-style`, `font-size`) was silently dropped because the rules used `td:nth-child(N){...}` selectors, which Flying Saucer (Salesforce's `Blob.toPdf`) does not support.
- `extractColumnCss` now emits `td.gqcN{...}` rules; `xmlRowsToHtmlRows` tags each cell with `class="gqcN"`. Class selectors are CSS 1 — Flying Saucer honors them.
- Customer-reported symptom: right-aligned data cells in a >2000-row template render as left-aligned in the PDF. Same fix also restores per-column bold/italic/font-size that have been dead behind the same selector.

## Root cause walk-through

The giant-query path doesn't go through `DocGenHtmlRenderer`. To stay heap-light at >2000 rows, `DocGenGiantQueryBatch.xmlRowsToHtmlRows()` strips all inline formatting from each data row and emits bare `<td>plain text</td>`. Per-column styling is meant to come from `extractColumnCss()` reading the template's loop-row `<w:tc>` properties and emitting a small CSS rule block injected once into the assembled HTML's `<style>` block.

That `extractColumnCss` produces correct output — `td:nth-child(N){text-align:right}` etc. — verified against the customer's actual loop-row XML. The break is downstream: Flying Saucer silently ignores `:nth-child()`. Three back-to-back Blob.toPdf test cases proved it (`td:nth-child(N)` → ignored; class selectors → applied; inline style → applied).

## Verification

- Mini-test PDFs with three control cases against `Blob.toPdf` directly.
- End-to-end in staging: Account `001cb00000nKNIoAAO` ("Giant Query Test") + 3000 Contacts, with a DOCX template carrying inline `<w:jc w:val="right"/>` on the loop-row cells, routed through the real `DocGenController.generateDocumentGiantQuery` → `DocGenGiantQueryBatch` → `DocGenGiantQueryAssembler` pipeline. Result: 72-page PDF, all three data columns right-aligned, 0 fragment errors.

## Test plan

- [x] `DocGenGiantQueryTest` — 41/41 pass on staging post-fix
- [x] New regression test `testExtractColumnCssEmitsClassSelectors` asserts `:nth-child` is never emitted
- [x] Prettier clean
- [ ] Full `RunLocalTests` on release validation org
- [ ] Code Analyzer clean (0 High)

🤖 Generated with [Claude Code](https://claude.com/claude-code)