### PR TITLE
fix(export-import): preserve all scalar template fields across orgs

### DIFF
--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -5370,8 +5370,19 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                     Query_Config__c,
                     Document_Title_Format__c,
                     Is_Default__c,
+                    Is_Active__c,
                     Header_Html__c,
                     Footer_Html__c,
+                    Test_Record_Id__c,
+                    Sort_Order__c,
+                    Lock_Output_Format__c,
+                    Specific_Record_Ids__c,
+                    Required_Permission_Sets__c,
+                    Record_Filter__c,
+                    Page_Orientation__c,
+                    Page_Size__c,
+                    Page_Margins__c,
+                    Custom_Margins__c,
                     (
                         SELECT
                             Id,
@@ -5381,7 +5392,11 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                             Category__c,
                             Description__c,
                             Type__c,
-                            Base_Object_API__c
+                            Base_Object_API__c,
+                            Page_Orientation__c,
+                            Page_Size__c,
+                            Page_Margins__c,
+                            Custom_Margins__c
                         FROM Versions__r
                         WHERE Is_Active__c = TRUE
                         LIMIT 1
@@ -5412,8 +5427,19 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             tmplData.put('Query_Config__c', tmpl.Query_Config__c);
             tmplData.put('Document_Title_Format__c', tmpl.Document_Title_Format__c);
             tmplData.put('Is_Default__c', tmpl.Is_Default__c);
+            tmplData.put('Is_Active__c', tmpl.Is_Active__c);
             tmplData.put('Header_Html__c', tmpl.Header_Html__c);
             tmplData.put('Footer_Html__c', tmpl.Footer_Html__c);
+            tmplData.put('Test_Record_Id__c', tmpl.Test_Record_Id__c);
+            tmplData.put('Sort_Order__c', tmpl.Sort_Order__c);
+            tmplData.put('Lock_Output_Format__c', tmpl.Lock_Output_Format__c);
+            tmplData.put('Specific_Record_Ids__c', tmpl.Specific_Record_Ids__c);
+            tmplData.put('Required_Permission_Sets__c', tmpl.Required_Permission_Sets__c);
+            tmplData.put('Record_Filter__c', tmpl.Record_Filter__c);
+            tmplData.put('Page_Orientation__c', tmpl.Page_Orientation__c);
+            tmplData.put('Page_Size__c', tmpl.Page_Size__c);
+            tmplData.put('Page_Margins__c', tmpl.Page_Margins__c);
+            tmplData.put('Custom_Margins__c', tmpl.Custom_Margins__c);
             bundle.put('template', tmplData);
 
             // Active version's template file
@@ -5491,8 +5517,25 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             tmpl.Query_Config__c = (String) tmplData.get('Query_Config__c');
             tmpl.Document_Title_Format__c = (String) tmplData.get('Document_Title_Format__c');
             tmpl.Is_Default__c = tmplData.get('Is_Default__c') == true;
+            // Default to true if the export bundle predates the Is_Active__c field (older
+            // exports won't include the key, and silently flipping the new template inactive
+            // would surprise the importing user).
+            tmpl.Is_Active__c = tmplData.containsKey('Is_Active__c') ? tmplData.get('Is_Active__c') == true : true;
             tmpl.Header_Html__c = (String) tmplData.get('Header_Html__c');
             tmpl.Footer_Html__c = (String) tmplData.get('Footer_Html__c');
+            tmpl.Test_Record_Id__c = (String) tmplData.get('Test_Record_Id__c');
+            Object sortOrderObj = tmplData.get('Sort_Order__c');
+            if (sortOrderObj != null) {
+                tmpl.Sort_Order__c = Decimal.valueOf(String.valueOf(sortOrderObj));
+            }
+            tmpl.Lock_Output_Format__c = tmplData.get('Lock_Output_Format__c') == true;
+            tmpl.Specific_Record_Ids__c = (String) tmplData.get('Specific_Record_Ids__c');
+            tmpl.Required_Permission_Sets__c = (String) tmplData.get('Required_Permission_Sets__c');
+            tmpl.Record_Filter__c = (String) tmplData.get('Record_Filter__c');
+            tmpl.Page_Orientation__c = (String) tmplData.get('Page_Orientation__c');
+            tmpl.Page_Size__c = (String) tmplData.get('Page_Size__c');
+            tmpl.Page_Margins__c = (String) tmplData.get('Page_Margins__c');
+            tmpl.Custom_Margins__c = (String) tmplData.get('Custom_Margins__c');
             /* code-analyzer-suppress ApexFlsViolation */
             insert tmpl; // NOPMD ApexCRUDViolation - package-internal custom object; CRUD controlled by DocGen permission sets
 
@@ -5533,6 +5576,12 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             ver.Description__c = (String) tmplData.get('Description__c');
             ver.Type__c = (String) tmplData.get('Type__c');
             ver.Base_Object_API__c = (String) tmplData.get('Base_Object_API__c');
+            // Snapshot page-setup onto the version so the renderer reads the imported
+            // settings instead of the org-default field values (the A4 → Letter bug).
+            ver.Page_Orientation__c = (String) tmplData.get('Page_Orientation__c');
+            ver.Page_Size__c = (String) tmplData.get('Page_Size__c');
+            ver.Page_Margins__c = (String) tmplData.get('Page_Margins__c');
+            ver.Custom_Margins__c = (String) tmplData.get('Custom_Margins__c');
             /* code-analyzer-suppress ApexFlsViolation */
             insert ver; // NOPMD ApexCRUDViolation - package-internal custom object; CRUD controlled by DocGen permission sets
 

--- a/force-app/main/default/classes/DocGenControllerTests.cls
+++ b/force-app/main/default/classes/DocGenControllerTests.cls
@@ -4043,6 +4043,121 @@ private class DocGenControllerTests {
         }
     }
 
+    @IsTest
+    static void testExportImportRoundTripPreservesAllScalarFields() {
+        // Regression: export → import must preserve every settable scalar field on
+        // the template + page-setup snapshot on the version. Previously the export
+        // SELECT lagged behind saveTemplate and silently dropped page-setup, sort
+        // order, lock-output, specific records, required permsets, record filter,
+        // is_active, and test record id. Customer-visible symptom: A4 templates
+        // import as Letter.
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            DocGen_Template__c src = new DocGen_Template__c(
+                Name = 'RoundTrip Source',
+                Base_Object_API__c = 'Account',
+                Type__c = 'Word',
+                Output_Format__c = 'PDF',
+                Category__c = 'Test',
+                Description__c = 'Round-trip src',
+                Query_Config__c = 'Name',
+                Document_Title_Format__c = '{Name}',
+                Is_Default__c = false,
+                Is_Active__c = true,
+                Page_Size__c = 'A4',
+                Page_Orientation__c = 'Landscape',
+                Page_Margins__c = 'Custom',
+                Custom_Margins__c = '0.5,0.75,1.0,1.25',
+                Test_Record_Id__c = '001000000000001',
+                Sort_Order__c = 42,
+                Lock_Output_Format__c = true,
+                Specific_Record_Ids__c = '001000000000001,001000000000002',
+                Required_Permission_Sets__c = 'DocGen_Admin',
+                Record_Filter__c = 'Industry = \'Tech\''
+            );
+            insert src;
+            insert new DocGen_Template_Version__c(
+                Template__c = src.Id,
+                Is_Active__c = true,
+                Query_Config__c = 'Name',
+                Type__c = 'Word',
+                Base_Object_API__c = 'Account',
+                Page_Size__c = 'A4',
+                Page_Orientation__c = 'Landscape',
+                Page_Margins__c = 'Custom',
+                Custom_Margins__c = '0.5,0.75,1.0,1.25'
+            );
+
+            Test.startTest();
+            String json = DocGenController.exportTemplate(src.Id);
+            Map<String, Object> bundle = (Map<String, Object>) System.JSON.deserializeUntyped(json);
+            // Rename so the import doesn't collide
+            ((Map<String, Object>) bundle.get('template')).put('Name', 'RoundTrip Imported');
+            Id importedId = DocGenController.importTemplate(System.JSON.serialize(bundle));
+            Test.stopTest();
+
+            DocGen_Template__c imp = [
+                SELECT
+                    Page_Size__c,
+                    Page_Orientation__c,
+                    Page_Margins__c,
+                    Custom_Margins__c,
+                    Test_Record_Id__c,
+                    Sort_Order__c,
+                    Lock_Output_Format__c,
+                    Specific_Record_Ids__c,
+                    Required_Permission_Sets__c,
+                    Record_Filter__c,
+                    Is_Active__c
+                FROM DocGen_Template__c
+                WHERE Id = :importedId
+                LIMIT 1
+            ];
+            System.assertEquals(
+                'A4',
+                imp.Page_Size__c,
+                'Page_Size__c must survive round-trip (A4 → Letter is the reported bug)'
+            );
+            System.assertEquals('Landscape', imp.Page_Orientation__c, 'Page_Orientation__c must survive');
+            System.assertEquals('Custom', imp.Page_Margins__c, 'Page_Margins__c must survive');
+            System.assertEquals('0.5,0.75,1.0,1.25', imp.Custom_Margins__c, 'Custom_Margins__c must survive');
+            System.assertEquals('001000000000001', imp.Test_Record_Id__c, 'Test_Record_Id__c must survive');
+            System.assertEquals(42, imp.Sort_Order__c, 'Sort_Order__c must survive');
+            System.assertEquals(true, imp.Lock_Output_Format__c, 'Lock_Output_Format__c must survive');
+            System.assertEquals(
+                '001000000000001,001000000000002',
+                imp.Specific_Record_Ids__c,
+                'Specific_Record_Ids__c must survive'
+            );
+            System.assertEquals(
+                'DocGen_Admin',
+                imp.Required_Permission_Sets__c,
+                'Required_Permission_Sets__c must survive'
+            );
+            System.assertEquals('Industry = \'Tech\'', imp.Record_Filter__c, 'Record_Filter__c must survive');
+            System.assertEquals(true, imp.Is_Active__c, 'Is_Active__c must survive');
+
+            DocGen_Template_Version__c impVer = [
+                SELECT Page_Size__c, Page_Orientation__c, Page_Margins__c, Custom_Margins__c
+                FROM DocGen_Template_Version__c
+                WHERE Template__c = :importedId AND Is_Active__c = TRUE
+                LIMIT 1
+            ];
+            System.assertEquals(
+                'A4',
+                impVer.Page_Size__c,
+                'Version Page_Size__c snapshot must survive (renderer reads from version)'
+            );
+            System.assertEquals('Landscape', impVer.Page_Orientation__c, 'Version Page_Orientation__c must survive');
+            System.assertEquals('Custom', impVer.Page_Margins__c, 'Version Page_Margins__c must survive');
+            System.assertEquals(
+                '0.5,0.75,1.0,1.25',
+                impVer.Custom_Margins__c,
+                'Version Custom_Margins__c must survive'
+            );
+        }
+    }
+
     // =======================================================================
     // NEW COVERAGE TESTS — importTemplate
     // =======================================================================


### PR DESCRIPTION
## Summary

- `exportTemplate` / `importTemplate` had drifted behind `saveTemplate`: the export SELECT and bundle only carried a partial set of fields, so every exported template silently reset to the target org's field defaults on import.
- Customer-reported symptom: A4 page-size template exported from production imports as Letter in sandbox.
- This fixes the silent field drop for 11 template fields + 4 version-snapshot fields. Same scoping in export and import.

## Fields added

| Category | Fields |
|---|---|
| Page setup | `Page_Size__c`, `Page_Orientation__c`, `Page_Margins__c`, `Custom_Margins__c` (template AND version snapshot — the renderer reads page setup off the version) |
| Runner | `Sort_Order__c`, `Lock_Output_Format__c`, `Is_Active__c` |
| Filtering | `Specific_Record_Ids__c`, `Required_Permission_Sets__c`, `Record_Filter__c` |
| Misc | `Test_Record_Id__c` |

`Is_Active__c` defaults to `true` on import when the export bundle predates the field, so re-importing an older export doesn't silently flip the new template inactive.

## Verification

Round-trip test in staging with distinctive non-default values for every previously-dropped field:

- Set: `A4` / `Landscape` / `Custom` margins / `0.5,0.75,1.0,1.25` / `Sort_Order=42` / `Lock=true` / record-filter / permset gating
- Export → JSON bundle → delete-style cleanup → import as new template → SOQL re-read
- All 11 template fields + 4 version snapshot fields round-trip cleanly. `===== ROUND-TRIP: PASS =====`

## Out of scope (filed separately)

HTML body inline image URLs and `Watermark_Image_CV_Id__c` still don't carry over because the export doesn't include the referenced ContentVersion binaries. Tracked in #100 — it's a bundle-format change deserving its own PR.

## Test plan

- [x] New regression test `testExportImportRoundTripPreservesAllScalarFields` asserts every field survives
- [x] Existing `DocGenControllerTests` export/import tests pass
- [x] Prettier clean
- [ ] Full `RunLocalTests` on release validation org
- [ ] Code Analyzer clean (0 High)

🤖 Generated with [Claude Code](https://claude.com/claude-code)