### PR TITLE
feat: add JSON Data (from Flow) template data source (#110)

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -1004,6 +1004,12 @@ Id contentDocId = portwoodglobal.DocGenService.generateDocument(templateId, acco
 
 If you don't want template-side binding at all — the data is already in a Flow variable or an Apex wrapper — use **runtime data injection** instead: the **Generate Document** Flow action accepts a `JSON Data` invocable variable, and `DocGenService.generatePdfBlobFromData(templateId, dataMap)` accepts an Apex Map directly. Same merge engine, same tags, no class to write.
 
+#### 6.6.1 JSON Data (from Flow) — template authoring mode
+
+When a template will _only_ ever receive its data from a Flow via `DocGenFlowAction.jsonData`, pick **JSON Data (from Flow)** as the Data Source in Step 1. The wizard then skips the Base Object picker, the SOQL query builder, and the Apex Provider class picker — there's nothing to configure between naming the template and uploading the document.
+
+Behind the scenes the template stores `Base_Object_API__c = 'FlowJsonData'` (a sentinel value) and `Query_Config__c = {"v":4,"source":"flowJsonData"}`. The sentinel keeps the template invisible to the standard record-page Generate-Document launcher (whose query is `WHERE Base_Object_API__c = :objectApiName`) — JSON Data templates are intentionally Flow-only. To invoke one, pass `jsonData` into the **Generate Document** Flow action; the merge engine resolves `{Field}`, `{Parent.Field}`, and `{#Loop.records}` against your JSON shape just like any other template.
+
 ---
 
 ## 7. Merge tag reference

--- a/force-app/main/default/classes/DocGenControllerTests.cls
+++ b/force-app/main/default/classes/DocGenControllerTests.cls
@@ -660,6 +660,47 @@ private class DocGenControllerTests {
         }
     }
 
+    // FlowJsonData sentinel templates are Flow-only (invoked via DocGenFlowAction.jsonData)
+    // and MUST NOT surface in the record-page launcher's templates-for-object selector.
+    @IsTest
+    static void testGetTemplatesForObjectExcludesFlowJsonData() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            DocGen_Template__c flowTpl = new DocGen_Template__c(
+                Name = 'JSON Flow Only Template',
+                Base_Object_API__c = 'FlowJsonData',
+                Type__c = 'Word',
+                Query_Config__c = '{"v":4,"source":"flowJsonData"}',
+                Is_Active__c = true
+            );
+            insert flowTpl;
+
+            Test.startTest();
+            List<DocGen_Template__c> accountTpls = DocGenController.getTemplatesForObject('Account');
+            List<DocGen_Template__c> flowTpls = DocGenController.getTemplatesForObject('FlowJsonData');
+            Test.stopTest();
+
+            for (DocGen_Template__c t : accountTpls) {
+                System.assertNotEquals(
+                    'FlowJsonData',
+                    t.Base_Object_API__c,
+                    'FlowJsonData template must not appear in Account launcher results'
+                );
+            }
+            Boolean found = false;
+            for (DocGen_Template__c t : flowTpls) {
+                if (t.Id == flowTpl.Id) {
+                    found = true;
+                    break;
+                }
+            }
+            System.assert(
+                found,
+                'Querying for FlowJsonData directly should still return the template (admin/import paths)'
+            );
+        }
+    }
+
     // -----------------------------------------------------------------------
     // processAndReturnDocument — success path with valid DOCX
     // -----------------------------------------------------------------------

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -124,6 +124,29 @@
                                         </div>
                                     </template>
 
+                                    <!-- JSON Data (from Flow) path: nothing to configure here.
+                                         The template receives its data at runtime from a Flow that
+                                         supplies DocGenFlowAction.jsonData — no Base Object, no SOQL,
+                                         no merge-field picker required. -->
+                                    <template if:true={isFlowDataSource}>
+                                        <div
+                                            class="slds-box slds-theme_default slds-var-m-top_medium"
+                                            style="border-radius: 8px"
+                                        >
+                                            <p class="slds-text-body_small">
+                                                <lightning-icon
+                                                    icon-name="utility:flow"
+                                                    size="x-small"
+                                                    class="slds-var-m-right_x-small"
+                                                ></lightning-icon>
+                                                This template receives its data from a Flow at runtime via
+                                                <code>DocGenFlowAction.jsonData</code>. No Base Object or SOQL config
+                                                needed — build the JSON payload in your Flow before invoking Generate
+                                                Document. Next step: upload the template document.
+                                            </p>
+                                        </div>
+                                    </template>
+
                                     <!-- Apex Data Provider path: class picker right here on Step 1 -->
                                     <template if:true={isApexDataSource}>
                                         <div class="slds-var-m-top_medium">
@@ -901,20 +924,32 @@
                             <div class="slds-box slds-theme_shade" style="border-radius: 8px">
                                 <h3 class="slds-text-heading_medium slds-var-m-bottom_medium">Review Template</h3>
                                 <p class="slds-var-m-bottom_small"><strong>Name:</strong> {newTemplateName}</p>
-                                <p class="slds-var-m-bottom_small"><strong>Object:</strong> {newTemplateObject}</p>
-                                <p class="slds-var-m-bottom_small"><strong>Query:</strong></p>
-                                <pre
-                                    style="
-                                        font-size: 0.8125rem;
-                                        background: #f3f2f2;
-                                        padding: 0.75rem;
-                                        border-radius: 6px;
-                                        white-space: pre-wrap;
-                                        margin: 0 0 0.5rem 0;
-                                    "
-                                >
+                                <template if:true={isFlowDataSource}>
+                                    <p class="slds-var-m-bottom_small">
+                                        <strong>Data Source:</strong> JSON Data (from Flow)
+                                    </p>
+                                    <p class="slds-var-m-bottom_small slds-text-body_small slds-text-color_weak">
+                                        Data is supplied at runtime via
+                                        <code>DocGenFlowAction.jsonData</code>. No SOQL or Apex Provider class is bound
+                                        to this template.
+                                    </p>
+                                </template>
+                                <template if:false={isFlowDataSource}>
+                                    <p class="slds-var-m-bottom_small"><strong>Object:</strong> {newTemplateObject}</p>
+                                    <p class="slds-var-m-bottom_small"><strong>Query:</strong></p>
+                                    <pre
+                                        style="
+                                            font-size: 0.8125rem;
+                                            background: #f3f2f2;
+                                            padding: 0.75rem;
+                                            border-radius: 6px;
+                                            white-space: pre-wrap;
+                                            margin: 0 0 0.5rem 0;
+                                        "
+                                    >
 {readableQueryConfig}</pre
-                                >
+                                    >
+                                </template>
                                 <p class="slds-var-m-top_large">Click "Create Template" to save.</p>
                             </div>
                         </template>
@@ -1443,13 +1478,39 @@
                                 >
                                     <div style="display: flex; align-items: center; gap: 8px">
                                         <lightning-icon icon-name="standard:account" size="x-small"></lightning-icon>
-                                        <span style="font-weight: 700">{editTemplateObject}</span>
+                                        <span style="font-weight: 700">{editBaseObjectDisplay}</span>
                                     </div>
-                                    <div style="display: flex; align-items: center; gap: 16px">
-                                        <template if:false={editUseApexProvider}>
+                                    <template if:false={isEditFlowDataSource}>
+                                        <div style="display: flex; align-items: center; gap: 16px">
+                                            <template if:false={editUseApexProvider}>
+                                                <a
+                                                    href="javascript:void(0)"
+                                                    onclick={toggleEditVisualBuilder}
+                                                    style="
+                                                        font-size: 0.82rem;
+                                                        color: #7c3aed;
+                                                        text-decoration: none;
+                                                        display: flex;
+                                                        align-items: center;
+                                                        gap: 4px;
+                                                    "
+                                                >
+                                                    <lightning-icon
+                                                        icon-name={editVisualBuilderToggleIcon}
+                                                        size="xx-small"
+                                                        style="--sds-c-icon-color-foreground-default: #7c3aed"
+                                                    ></lightning-icon>
+                                                    <template if:false={editUseVisualBuilder}
+                                                        >Try our visual builder</template
+                                                    >
+                                                    <template if:true={editUseVisualBuilder}
+                                                        >Switch to manual query</template
+                                                    >
+                                                </a>
+                                            </template>
                                             <a
                                                 href="javascript:void(0)"
-                                                onclick={toggleEditVisualBuilder}
+                                                onclick={toggleEditApexProvider}
                                                 style="
                                                     font-size: 0.82rem;
                                                     color: #7c3aed;
@@ -1460,449 +1521,247 @@
                                                 "
                                             >
                                                 <lightning-icon
-                                                    icon-name={editVisualBuilderToggleIcon}
+                                                    icon-name="utility:apex"
                                                     size="xx-small"
                                                     style="--sds-c-icon-color-foreground-default: #7c3aed"
                                                 ></lightning-icon>
-                                                <template if:false={editUseVisualBuilder}
-                                                    >Try our visual builder</template
-                                                >
-                                                <template if:true={editUseVisualBuilder}
-                                                    >Switch to manual query</template
-                                                >
+                                                {editApexProviderToggleLabel}
                                             </a>
-                                        </template>
-                                        <a
-                                            href="javascript:void(0)"
-                                            onclick={toggleEditApexProvider}
-                                            style="
-                                                font-size: 0.82rem;
-                                                color: #7c3aed;
-                                                text-decoration: none;
-                                                display: flex;
-                                                align-items: center;
-                                                gap: 4px;
-                                            "
-                                        >
-                                            <lightning-icon
-                                                icon-name="utility:apex"
-                                                size="xx-small"
-                                                style="--sds-c-icon-color-foreground-default: #7c3aed"
-                                            ></lightning-icon>
-                                            {editApexProviderToggleLabel}
-                                        </a>
-                                    </div>
+                                        </div>
+                                    </template>
                                 </div>
 
-                                <!-- Apex Data Provider mode (V4) -->
-                                <template if:true={editUseApexProvider}>
+                                <!-- JSON Data (from Flow) mode: no SOQL/Apex config -->
+                                <template if:true={isEditFlowDataSource}>
                                     <div class="slds-box slds-theme_default" style="border-radius: 8px">
-                                        <p class="slds-text-body_small slds-text-color_weak slds-var-m-bottom_small">
-                                            This template is bound to an Apex class implementing
-                                            <code>portwoodglobal.DocGenDataProvider</code>. The class supplies merge
-                                            data at render time — no SOQL config needed.
+                                        <p class="slds-text-body_small">
+                                            <lightning-icon
+                                                icon-name="utility:flow"
+                                                size="x-small"
+                                                class="slds-var-m-right_x-small"
+                                            ></lightning-icon>
+                                            This template receives its data from a Flow at runtime via
+                                            <code>DocGenFlowAction.jsonData</code>. Merge tags resolve against the JSON
+                                            payload your Flow builds before invoking Generate Document — no SOQL or Apex
+                                            Data Provider class to configure here.
                                         </p>
-                                        <template if:false={isProviderConnected}>
-                                            <div style="position: relative">
-                                                <lightning-input
-                                                    type="search"
-                                                    label="Search for a Data Provider class"
-                                                    placeholder="Type at least 2 characters..."
-                                                    value={providerSearchTerm}
-                                                    onchange={handleApexProviderSearch}
-                                                >
-                                                </lightning-input>
-                                                <template if:true={showProviderPicker}>
-                                                    <div
-                                                        class="slds-dropdown slds-dropdown_length-5 slds-dropdown_fluid"
-                                                        style="position: absolute; z-index: 100"
+                                    </div>
+                                </template>
+
+                                <!-- Apex / SOQL config bodies — hidden entirely for JSON Flow templates -->
+                                <template if:false={isEditFlowDataSource}>
+                                    <template if:true={editUseApexProvider}>
+                                        <div class="slds-box slds-theme_default" style="border-radius: 8px">
+                                            <p
+                                                class="slds-text-body_small slds-text-color_weak slds-var-m-bottom_small"
+                                            >
+                                                This template is bound to an Apex class implementing
+                                                <code>portwoodglobal.DocGenDataProvider</code>. The class supplies merge
+                                                data at render time — no SOQL config needed.
+                                            </p>
+                                            <template if:false={isProviderConnected}>
+                                                <div style="position: relative">
+                                                    <lightning-input
+                                                        type="search"
+                                                        label="Search for a Data Provider class"
+                                                        placeholder="Type at least 2 characters..."
+                                                        value={providerSearchTerm}
+                                                        onchange={handleApexProviderSearch}
                                                     >
-                                                        <ul class="slds-listbox slds-listbox_vertical">
-                                                            <template if:true={providerOptions.length}>
-                                                                <template for:each={providerOptions} for:item="cls">
-                                                                    <li key={cls} class="slds-listbox__item">
+                                                    </lightning-input>
+                                                    <template if:true={showProviderPicker}>
+                                                        <div
+                                                            class="slds-dropdown slds-dropdown_length-5 slds-dropdown_fluid"
+                                                            style="position: absolute; z-index: 100"
+                                                        >
+                                                            <ul class="slds-listbox slds-listbox_vertical">
+                                                                <template if:true={providerOptions.length}>
+                                                                    <template for:each={providerOptions} for:item="cls">
+                                                                        <li key={cls} class="slds-listbox__item">
+                                                                            <div
+                                                                                class="slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
+                                                                                data-value={cls}
+                                                                                onclick={handleApexProviderSelect}
+                                                                            >
+                                                                                <span class="slds-truncate"
+                                                                                    ><lightning-icon
+                                                                                        icon-name="utility:apex"
+                                                                                        size="x-small"
+                                                                                        class="slds-var-m-right_x-small"
+                                                                                    ></lightning-icon
+                                                                                    >{cls}</span
+                                                                                >
+                                                                            </div>
+                                                                        </li>
+                                                                    </template>
+                                                                </template>
+                                                                <template if:false={providerOptions.length}>
+                                                                    <li class="slds-listbox__item">
                                                                         <div
                                                                             class="slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
-                                                                            data-value={cls}
-                                                                            onclick={handleApexProviderSelect}
                                                                         >
-                                                                            <span class="slds-truncate"
-                                                                                ><lightning-icon
-                                                                                    icon-name="utility:apex"
-                                                                                    size="x-small"
-                                                                                    class="slds-var-m-right_x-small"
-                                                                                ></lightning-icon
-                                                                                >{cls}</span
+                                                                            <span class="slds-text-color_weak"
+                                                                                >No classes implementing
+                                                                                DocGenDataProvider found</span
                                                                             >
                                                                         </div>
                                                                     </li>
                                                                 </template>
-                                                            </template>
-                                                            <template if:false={providerOptions.length}>
-                                                                <li class="slds-listbox__item">
-                                                                    <div
-                                                                        class="slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
-                                                                    >
-                                                                        <span class="slds-text-color_weak"
-                                                                            >No classes implementing DocGenDataProvider
-                                                                            found</span
-                                                                        >
-                                                                    </div>
-                                                                </li>
-                                                            </template>
-                                                        </ul>
+                                                            </ul>
+                                                        </div>
+                                                    </template>
+                                                </div>
+                                                <template if:true={isValidatingProvider}>
+                                                    <div
+                                                        class="slds-var-m-top_small slds-is-relative"
+                                                        style="height: 30px"
+                                                    >
+                                                        <lightning-spinner
+                                                            alternative-text="Validating..."
+                                                            size="small"
+                                                        ></lightning-spinner>
                                                     </div>
                                                 </template>
-                                            </div>
-                                            <template if:true={isValidatingProvider}>
-                                                <div class="slds-var-m-top_small slds-is-relative" style="height: 30px">
-                                                    <lightning-spinner
-                                                        alternative-text="Validating..."
-                                                        size="small"
-                                                    ></lightning-spinner>
-                                                </div>
                                             </template>
-                                        </template>
 
-                                        <template if:true={isProviderConnected}>
-                                            <div
-                                                style="
-                                                    display: flex;
-                                                    align-items: center;
-                                                    justify-content: space-between;
-                                                    margin-bottom: 8px;
-                                                "
-                                            >
-                                                <div style="display: flex; align-items: center; gap: 8px">
-                                                    <lightning-icon
-                                                        icon-name="utility:apex"
-                                                        size="x-small"
-                                                    ></lightning-icon>
-                                                    <span style="font-weight: 700">{selectedProviderClassName}</span>
-                                                    <span class="slds-badge slds-badge_lightest"
-                                                        >{providerFields.length} fields</span
-                                                    >
-                                                </div>
-                                                <lightning-button
-                                                    label="Change class"
-                                                    variant="base"
-                                                    icon-name="utility:close"
-                                                    onclick={handleClearApexProvider}
-                                                >
-                                                </lightning-button>
-                                            </div>
-                                            <p class="slds-text-body_small slds-text-color_weak">
-                                                Available merge tags from this provider:
-                                            </p>
-                                            <div style="display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px">
-                                                <template for:each={providerTagPills} for:item="p">
-                                                    <span
-                                                        key={p.raw}
-                                                        style="
-                                                            background: #f3e8ff;
-                                                            border: 1px solid #d8c4f0;
-                                                            color: #7c3aed;
-                                                            padding: 2px 8px;
-                                                            border-radius: 4px;
-                                                            font-size: 0.78rem;
-                                                            font-family: monospace;
-                                                        "
-                                                        >{p.tag}</span
-                                                    >
-                                                </template>
-                                            </div>
-                                        </template>
-                                    </div>
-                                </template>
-
-                                <!-- Visual Builder -->
-                                <template if:true={editUseVisualBuilder}>
-                                    <c-doc-gen-tree-builder
-                                        selected-object={editTemplateObject}
-                                        query-config={editTemplateQuery}
-                                        onconfigchange={handleEditConfigChange}
-                                    >
-                                    </c-doc-gen-tree-builder>
-                                </template>
-
-                                <!-- Manual Query Textarea (hidden when visual builder OR Apex Provider is on) -->
-                                <template if:false={editUseVisualBuilder}>
-                                    <template if:false={editUseApexProvider}>
-                                        <div style="position: relative">
-                                            <textarea
-                                                class="slds-textarea edit-query-textarea"
-                                                value={editTemplateQuery}
-                                                oninput={handleEditDirectQueryEdit}
-                                                onkeydown={handleQueryKeyDown}
-                                                placeholder="Paste a SOQL query or type field names — suggestions will appear.&#10;&#10;Examples:&#10;  SELECT Name, Industry, (SELECT FirstName FROM Contacts) FROM Account&#10;  Name, Industry, Phone&#10;  Owner.Name, CreatedBy.Email&#10;  (SELECT FirstName, LastName FROM Contacts)"
-                                                style="
-                                                    width: 100%;
-                                                    min-height: 240px;
-                                                    font-family: 'SF Mono', Monaco, Consolas, monospace;
-                                                    font-size: 0.9rem;
-                                                    line-height: 1.8;
-                                                    padding: 14px;
-                                                    border: 1px solid #d8dde6;
-                                                    border-radius: 8px;
-                                                    resize: vertical;
-                                                "
-                                            >
-                                            </textarea>
-                                            <template if:true={showSuggestions}>
+                                            <template if:true={isProviderConnected}>
                                                 <div
                                                     style="
-                                                        position: absolute;
-                                                        z-index: 20;
-                                                        left: 14px;
-                                                        right: 14px;
-                                                        max-height: 200px;
-                                                        overflow-y: auto;
-                                                        background: #fff;
-                                                        border: 1px solid #d8dde6;
-                                                        border-radius: 6px;
-                                                        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
-                                                        padding: 4px 0;
+                                                        display: flex;
+                                                        align-items: center;
+                                                        justify-content: space-between;
+                                                        margin-bottom: 8px;
                                                     "
-                                                    onmousedown={handleSuggestionMouseDown}
                                                 >
-                                                    <template for:each={suggestions} for:item="s">
-                                                        <div
-                                                            key={s.value}
-                                                            class="slash-item"
-                                                            data-value={s.value}
-                                                            onclick={handleSuggestionClick}
-                                                            style="
-                                                                padding: 6px 12px;
-                                                                cursor: pointer;
-                                                                display: flex;
-                                                                align-items: baseline;
-                                                                gap: 8px;
-                                                            "
+                                                    <div style="display: flex; align-items: center; gap: 8px">
+                                                        <lightning-icon
+                                                            icon-name="utility:apex"
+                                                            size="x-small"
+                                                        ></lightning-icon>
+                                                        <span style="font-weight: 700"
+                                                            >{selectedProviderClassName}</span
                                                         >
-                                                            <span
-                                                                style="
-                                                                    font-family: monospace;
-                                                                    font-size: 0.85rem;
-                                                                    color: #7c3aed;
-                                                                    font-weight: 600;
-                                                                "
-                                                                >{s.value}</span
-                                                            >
-                                                            <span style="font-size: 0.78rem; color: #706e6b"
-                                                                >{s.label}</span
-                                                            >
-                                                            <template if:true={s.extra}>
-                                                                <span
-                                                                    style="
-                                                                        font-size: 0.68rem;
-                                                                        color: #999;
-                                                                        margin-left: auto;
-                                                                    "
-                                                                    >{s.extra}</span
-                                                                >
-                                                            </template>
-                                                        </div>
+                                                        <span class="slds-badge slds-badge_lightest"
+                                                            >{providerFields.length} fields</span
+                                                        >
+                                                    </div>
+                                                    <lightning-button
+                                                        label="Change class"
+                                                        variant="base"
+                                                        icon-name="utility:close"
+                                                        onclick={handleClearApexProvider}
+                                                    >
+                                                    </lightning-button>
+                                                </div>
+                                                <p class="slds-text-body_small slds-text-color_weak">
+                                                    Available merge tags from this provider:
+                                                </p>
+                                                <div style="display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px">
+                                                    <template for:each={providerTagPills} for:item="p">
+                                                        <span
+                                                            key={p.raw}
+                                                            style="
+                                                                background: #f3e8ff;
+                                                                border: 1px solid #d8c4f0;
+                                                                color: #7c3aed;
+                                                                padding: 2px 8px;
+                                                                border-radius: 4px;
+                                                                font-size: 0.78rem;
+                                                                font-family: monospace;
+                                                            "
+                                                            >{p.tag}</span
+                                                        >
                                                     </template>
                                                 </div>
                                             </template>
                                         </div>
                                     </template>
-                                </template>
 
-                                <!-- Manual-only: Query warnings, tree preview, quick reference -->
-                                <template if:false={editUseVisualBuilder}>
-                                    <template if:false={editUseApexProvider}>
-                                        <template if:true={queryWarnings}>
-                                            <template for:each={queryWarnings} for:item="warn">
-                                                <div
-                                                    key={warn}
+                                    <!-- Visual Builder -->
+                                    <template if:true={editUseVisualBuilder}>
+                                        <c-doc-gen-tree-builder
+                                            selected-object={editTemplateObject}
+                                            query-config={editTemplateQuery}
+                                            onconfigchange={handleEditConfigChange}
+                                        >
+                                        </c-doc-gen-tree-builder>
+                                    </template>
+
+                                    <!-- Manual Query Textarea (hidden when visual builder OR Apex Provider is on) -->
+                                    <template if:false={editUseVisualBuilder}>
+                                        <template if:false={editUseApexProvider}>
+                                            <div style="position: relative">
+                                                <textarea
+                                                    class="slds-textarea edit-query-textarea"
+                                                    value={editTemplateQuery}
+                                                    oninput={handleEditDirectQueryEdit}
+                                                    onkeydown={handleQueryKeyDown}
+                                                    placeholder="Paste a SOQL query or type field names — suggestions will appear.&#10;&#10;Examples:&#10;  SELECT Name, Industry, (SELECT FirstName FROM Contacts) FROM Account&#10;  Name, Industry, Phone&#10;  Owner.Name, CreatedBy.Email&#10;  (SELECT FirstName, LastName FROM Contacts)"
                                                     style="
-                                                        margin-top: 8px;
-                                                        padding: 8px 12px;
-                                                        background: #fff8e1;
-                                                        border: 1px solid #f9a825;
-                                                        border-radius: 6px;
-                                                        font-size: 0.8rem;
-                                                        color: #5d4037;
-                                                        display: flex;
-                                                        align-items: center;
-                                                        gap: 6px;
+                                                        width: 100%;
+                                                        min-height: 240px;
+                                                        font-family: 'SF Mono', Monaco, Consolas, monospace;
+                                                        font-size: 0.9rem;
+                                                        line-height: 1.8;
+                                                        padding: 14px;
+                                                        border: 1px solid #d8dde6;
+                                                        border-radius: 8px;
+                                                        resize: vertical;
                                                     "
                                                 >
-                                                    <lightning-icon
-                                                        icon-name="utility:warning"
-                                                        size="xx-small"
-                                                        variant="warning"
-                                                    ></lightning-icon>
-                                                    {warn}
-                                                </div>
-                                            </template>
-                                        </template>
-
-                                        <template if:true={queryTreeNodes.length}>
-                                            <div
-                                                style="
-                                                    margin-top: 12px;
-                                                    border: 1px solid #e5e5e5;
-                                                    border-radius: 8px;
-                                                    padding: 10px 14px;
-                                                    background: #fafaf9;
-                                                "
-                                            >
-                                                <template for:each={queryTreeNodes} for:item="node">
-                                                    <div key={node.id}>
-                                                        <div
-                                                            style="
-                                                                display: flex;
-                                                                align-items: center;
-                                                                gap: 4px;
-                                                                margin-bottom: 6px;
-                                                            "
-                                                        >
-                                                            <lightning-icon
-                                                                icon-name="standard:account"
-                                                                size="xx-small"
-                                                            ></lightning-icon>
-                                                            <span style="font-weight: 700; font-size: 0.85rem"
-                                                                >{node.label}</span
-                                                            >
-                                                        </div>
-                                                        <template if:true={node.hasFields}>
+                                                </textarea>
+                                                <template if:true={showSuggestions}>
+                                                    <div
+                                                        style="
+                                                            position: absolute;
+                                                            z-index: 20;
+                                                            left: 14px;
+                                                            right: 14px;
+                                                            max-height: 200px;
+                                                            overflow-y: auto;
+                                                            background: #fff;
+                                                            border: 1px solid #d8dde6;
+                                                            border-radius: 6px;
+                                                            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+                                                            padding: 4px 0;
+                                                        "
+                                                        onmousedown={handleSuggestionMouseDown}
+                                                    >
+                                                        <template for:each={suggestions} for:item="s">
                                                             <div
+                                                                key={s.value}
+                                                                class="slash-item"
+                                                                data-value={s.value}
+                                                                onclick={handleSuggestionClick}
                                                                 style="
-                                                                    margin-left: 22px;
+                                                                    padding: 6px 12px;
+                                                                    cursor: pointer;
                                                                     display: flex;
-                                                                    flex-wrap: wrap;
-                                                                    gap: 4px;
-                                                                    margin-bottom: 6px;
+                                                                    align-items: baseline;
+                                                                    gap: 8px;
                                                                 "
                                                             >
-                                                                <template for:each={node.fieldPills} for:item="fp">
+                                                                <span
+                                                                    style="
+                                                                        font-family: monospace;
+                                                                        font-size: 0.85rem;
+                                                                        color: #7c3aed;
+                                                                        font-weight: 600;
+                                                                    "
+                                                                    >{s.value}</span
+                                                                >
+                                                                <span style="font-size: 0.78rem; color: #706e6b"
+                                                                    >{s.label}</span
+                                                                >
+                                                                <template if:true={s.extra}>
                                                                     <span
-                                                                        key={fp.key}
                                                                         style="
-                                                                            background: #eef4ff;
-                                                                            border: 1px solid #c7d7f5;
-                                                                            padding: 2px 8px;
-                                                                            border-radius: 4px;
-                                                                            font-size: 0.75rem;
-                                                                            font-family: monospace;
-                                                                            display: inline-flex;
-                                                                            align-items: baseline;
-                                                                            gap: 4px;
+                                                                            font-size: 0.68rem;
+                                                                            color: #999;
+                                                                            margin-left: auto;
                                                                         "
+                                                                        >{s.extra}</span
                                                                     >
-                                                                        <span style="color: #1a56db">{fp.name}</span>
-                                                                    </span>
-                                                                </template>
-                                                            </div>
-                                                        </template>
-                                                        <template if:true={node.hasParentFields}>
-                                                            <div
-                                                                style="
-                                                                    margin-left: 22px;
-                                                                    display: flex;
-                                                                    flex-wrap: wrap;
-                                                                    gap: 4px;
-                                                                    margin-bottom: 6px;
-                                                                "
-                                                            >
-                                                                <template for:each={node.parentPills} for:item="pp">
-                                                                    <span
-                                                                        key={pp.key}
-                                                                        style="
-                                                                            background: #f3e8ff;
-                                                                            border: 1px solid #d8c4f0;
-                                                                            padding: 2px 8px;
-                                                                            border-radius: 4px;
-                                                                            font-size: 0.75rem;
-                                                                            font-family: monospace;
-                                                                        "
-                                                                    >
-                                                                        <span style="color: #7c3aed">{pp.name}</span>
-                                                                    </span>
-                                                                </template>
-                                                            </div>
-                                                        </template>
-                                                        <template if:true={node.hasFlatChildren}>
-                                                            <div style="margin-left: 22px">
-                                                                <template for:each={node.flatChildren} for:item="child">
-                                                                    <div key={child.id} style={child.indentStyle}>
-                                                                        <div
-                                                                            style="
-                                                                                display: flex;
-                                                                                align-items: center;
-                                                                                gap: 4px;
-                                                                                margin-bottom: 4px;
-                                                                            "
-                                                                        >
-                                                                            <lightning-icon
-                                                                                icon-name="standard:related_list"
-                                                                                size="xx-small"
-                                                                            ></lightning-icon>
-                                                                            <span
-                                                                                style="
-                                                                                    font-weight: 600;
-                                                                                    font-size: 0.82rem;
-                                                                                "
-                                                                                >{child.label}</span
-                                                                            >
-                                                                            <span
-                                                                                style="
-                                                                                    font-size: 0.72rem;
-                                                                                    color: #706e6b;
-                                                                                    margin-left: 4px;
-                                                                                "
-                                                                                >({child.fieldCount} fields)</span
-                                                                            >
-                                                                        </div>
-                                                                        <div
-                                                                            style="
-                                                                                margin-left: 20px;
-                                                                                display: flex;
-                                                                                flex-wrap: wrap;
-                                                                                gap: 3px;
-                                                                            "
-                                                                        >
-                                                                            <template
-                                                                                for:each={child.fields}
-                                                                                for:item="cf"
-                                                                            >
-                                                                                <span
-                                                                                    key={cf}
-                                                                                    style="
-                                                                                        background: #ecfdf5;
-                                                                                        color: #065f46;
-                                                                                        padding: 2px 8px;
-                                                                                        border-radius: 4px;
-                                                                                        font-size: 0.75rem;
-                                                                                        font-family: monospace;
-                                                                                    "
-                                                                                    >{cf}</span
-                                                                                >
-                                                                            </template>
-                                                                            <template if:true={child.hasParentFields}>
-                                                                                <template
-                                                                                    for:each={child.parentFields}
-                                                                                    for:item="pf"
-                                                                                >
-                                                                                    <span
-                                                                                        key={pf}
-                                                                                        style="
-                                                                                            background: #f3e8ff;
-                                                                                            color: #7c3aed;
-                                                                                            border: 1px solid #d8c4f0;
-                                                                                            padding: 2px 8px;
-                                                                                            border-radius: 4px;
-                                                                                            font-size: 0.75rem;
-                                                                                            font-family: monospace;
-                                                                                        "
-                                                                                        >{pf}</span
-                                                                                    >
-                                                                                </template>
-                                                                            </template>
-                                                                        </div>
-                                                                    </div>
                                                                 </template>
                                                             </div>
                                                         </template>
@@ -1910,61 +1769,308 @@
                                                 </template>
                                             </div>
                                         </template>
+                                    </template>
 
-                                        <div
-                                            style="
-                                                margin-top: 14px;
-                                                background: #f8fafc;
-                                                border: 1px solid #e5e5e5;
-                                                border-radius: 8px;
-                                                padding: 12px 16px;
-                                                font-size: 0.8rem;
-                                                color: #444;
-                                                line-height: 1.7;
-                                            "
-                                        >
-                                            <div style="font-weight: 700; color: #181818; margin-bottom: 6px">
-                                                Quick Reference
+                                    <!-- Manual-only: Query warnings, tree preview, quick reference -->
+                                    <template if:false={editUseVisualBuilder}>
+                                        <template if:false={editUseApexProvider}>
+                                            <template if:true={queryWarnings}>
+                                                <template for:each={queryWarnings} for:item="warn">
+                                                    <div
+                                                        key={warn}
+                                                        style="
+                                                            margin-top: 8px;
+                                                            padding: 8px 12px;
+                                                            background: #fff8e1;
+                                                            border: 1px solid #f9a825;
+                                                            border-radius: 6px;
+                                                            font-size: 0.8rem;
+                                                            color: #5d4037;
+                                                            display: flex;
+                                                            align-items: center;
+                                                            gap: 6px;
+                                                        "
+                                                    >
+                                                        <lightning-icon
+                                                            icon-name="utility:warning"
+                                                            size="xx-small"
+                                                            variant="warning"
+                                                        ></lightning-icon>
+                                                        {warn}
+                                                    </div>
+                                                </template>
+                                            </template>
+
+                                            <template if:true={queryTreeNodes.length}>
+                                                <div
+                                                    style="
+                                                        margin-top: 12px;
+                                                        border: 1px solid #e5e5e5;
+                                                        border-radius: 8px;
+                                                        padding: 10px 14px;
+                                                        background: #fafaf9;
+                                                    "
+                                                >
+                                                    <template for:each={queryTreeNodes} for:item="node">
+                                                        <div key={node.id}>
+                                                            <div
+                                                                style="
+                                                                    display: flex;
+                                                                    align-items: center;
+                                                                    gap: 4px;
+                                                                    margin-bottom: 6px;
+                                                                "
+                                                            >
+                                                                <lightning-icon
+                                                                    icon-name="standard:account"
+                                                                    size="xx-small"
+                                                                ></lightning-icon>
+                                                                <span style="font-weight: 700; font-size: 0.85rem"
+                                                                    >{node.label}</span
+                                                                >
+                                                            </div>
+                                                            <template if:true={node.hasFields}>
+                                                                <div
+                                                                    style="
+                                                                        margin-left: 22px;
+                                                                        display: flex;
+                                                                        flex-wrap: wrap;
+                                                                        gap: 4px;
+                                                                        margin-bottom: 6px;
+                                                                    "
+                                                                >
+                                                                    <template for:each={node.fieldPills} for:item="fp">
+                                                                        <span
+                                                                            key={fp.key}
+                                                                            style="
+                                                                                background: #eef4ff;
+                                                                                border: 1px solid #c7d7f5;
+                                                                                padding: 2px 8px;
+                                                                                border-radius: 4px;
+                                                                                font-size: 0.75rem;
+                                                                                font-family: monospace;
+                                                                                display: inline-flex;
+                                                                                align-items: baseline;
+                                                                                gap: 4px;
+                                                                            "
+                                                                        >
+                                                                            <span style="color: #1a56db"
+                                                                                >{fp.name}</span
+                                                                            >
+                                                                        </span>
+                                                                    </template>
+                                                                </div>
+                                                            </template>
+                                                            <template if:true={node.hasParentFields}>
+                                                                <div
+                                                                    style="
+                                                                        margin-left: 22px;
+                                                                        display: flex;
+                                                                        flex-wrap: wrap;
+                                                                        gap: 4px;
+                                                                        margin-bottom: 6px;
+                                                                    "
+                                                                >
+                                                                    <template for:each={node.parentPills} for:item="pp">
+                                                                        <span
+                                                                            key={pp.key}
+                                                                            style="
+                                                                                background: #f3e8ff;
+                                                                                border: 1px solid #d8c4f0;
+                                                                                padding: 2px 8px;
+                                                                                border-radius: 4px;
+                                                                                font-size: 0.75rem;
+                                                                                font-family: monospace;
+                                                                            "
+                                                                        >
+                                                                            <span style="color: #7c3aed"
+                                                                                >{pp.name}</span
+                                                                            >
+                                                                        </span>
+                                                                    </template>
+                                                                </div>
+                                                            </template>
+                                                            <template if:true={node.hasFlatChildren}>
+                                                                <div style="margin-left: 22px">
+                                                                    <template
+                                                                        for:each={node.flatChildren}
+                                                                        for:item="child"
+                                                                    >
+                                                                        <div key={child.id} style={child.indentStyle}>
+                                                                            <div
+                                                                                style="
+                                                                                    display: flex;
+                                                                                    align-items: center;
+                                                                                    gap: 4px;
+                                                                                    margin-bottom: 4px;
+                                                                                "
+                                                                            >
+                                                                                <lightning-icon
+                                                                                    icon-name="standard:related_list"
+                                                                                    size="xx-small"
+                                                                                ></lightning-icon>
+                                                                                <span
+                                                                                    style="
+                                                                                        font-weight: 600;
+                                                                                        font-size: 0.82rem;
+                                                                                    "
+                                                                                    >{child.label}</span
+                                                                                >
+                                                                                <span
+                                                                                    style="
+                                                                                        font-size: 0.72rem;
+                                                                                        color: #706e6b;
+                                                                                        margin-left: 4px;
+                                                                                    "
+                                                                                    >({child.fieldCount} fields)</span
+                                                                                >
+                                                                            </div>
+                                                                            <div
+                                                                                style="
+                                                                                    margin-left: 20px;
+                                                                                    display: flex;
+                                                                                    flex-wrap: wrap;
+                                                                                    gap: 3px;
+                                                                                "
+                                                                            >
+                                                                                <template
+                                                                                    for:each={child.fields}
+                                                                                    for:item="cf"
+                                                                                >
+                                                                                    <span
+                                                                                        key={cf}
+                                                                                        style="
+                                                                                            background: #ecfdf5;
+                                                                                            color: #065f46;
+                                                                                            padding: 2px 8px;
+                                                                                            border-radius: 4px;
+                                                                                            font-size: 0.75rem;
+                                                                                            font-family: monospace;
+                                                                                        "
+                                                                                        >{cf}</span
+                                                                                    >
+                                                                                </template>
+                                                                                <template
+                                                                                    if:true={child.hasParentFields}
+                                                                                >
+                                                                                    <template
+                                                                                        for:each={child.parentFields}
+                                                                                        for:item="pf"
+                                                                                    >
+                                                                                        <span
+                                                                                            key={pf}
+                                                                                            style="
+                                                                                                background: #f3e8ff;
+                                                                                                color: #7c3aed;
+                                                                                                border: 1px solid
+                                                                                                    #d8c4f0;
+                                                                                                padding: 2px 8px;
+                                                                                                border-radius: 4px;
+                                                                                                font-size: 0.75rem;
+                                                                                                font-family: monospace;
+                                                                                            "
+                                                                                            >{pf}</span
+                                                                                        >
+                                                                                    </template>
+                                                                                </template>
+                                                                            </div>
+                                                                        </div>
+                                                                    </template>
+                                                                </div>
+                                                            </template>
+                                                        </div>
+                                                    </template>
+                                                </div>
+                                            </template>
+
+                                            <div
+                                                style="
+                                                    margin-top: 14px;
+                                                    background: #f8fafc;
+                                                    border: 1px solid #e5e5e5;
+                                                    border-radius: 8px;
+                                                    padding: 12px 16px;
+                                                    font-size: 0.8rem;
+                                                    color: #444;
+                                                    line-height: 1.7;
+                                                "
+                                            >
+                                                <div style="font-weight: 700; color: #181818; margin-bottom: 6px">
+                                                    Quick Reference
+                                                </div>
+                                                <div
+                                                    style="display: grid; grid-template-columns: 1fr 1fr; gap: 4px 24px"
+                                                >
+                                                    <div>
+                                                        <strong>Fields:</strong>
+                                                        <code
+                                                            style="
+                                                                background: #eee;
+                                                                padding: 1px 4px;
+                                                                border-radius: 3px;
+                                                            "
+                                                            >Name, Industry, Phone</code
+                                                        >
+                                                    </div>
+                                                    <div>
+                                                        <strong>Parent lookup:</strong>
+                                                        <code
+                                                            style="
+                                                                background: #eee;
+                                                                padding: 1px 4px;
+                                                                border-radius: 3px;
+                                                            "
+                                                            >Owner.Name, Account.Industry</code
+                                                        >
+                                                    </div>
+                                                    <div>
+                                                        <strong>Related list:</strong>
+                                                        <code
+                                                            style="
+                                                                background: #eee;
+                                                                padding: 1px 4px;
+                                                                border-radius: 3px;
+                                                            "
+                                                            >(SELECT FirstName FROM Contacts)</code
+                                                        >
+                                                    </div>
+                                                    <div>
+                                                        <strong>With filter:</strong>
+                                                        <code
+                                                            style="
+                                                                background: #eee;
+                                                                padding: 1px 4px;
+                                                                border-radius: 3px;
+                                                            "
+                                                            >(SELECT Name FROM Opps WHERE StageName = 'Closed
+                                                            Won')</code
+                                                        >
+                                                    </div>
+                                                    <div>
+                                                        <strong>With sort:</strong>
+                                                        <code
+                                                            style="
+                                                                background: #eee;
+                                                                padding: 1px 4px;
+                                                                border-radius: 3px;
+                                                            "
+                                                            >(SELECT Name FROM Contacts ORDER BY LastName)</code
+                                                        >
+                                                    </div>
+                                                    <div>
+                                                        <strong>With limit:</strong>
+                                                        <code
+                                                            style="
+                                                                background: #eee;
+                                                                padding: 1px 4px;
+                                                                border-radius: 3px;
+                                                            "
+                                                            >(SELECT Name FROM Cases LIMIT 10)</code
+                                                        >
+                                                    </div>
+                                                </div>
                                             </div>
-                                            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 4px 24px">
-                                                <div>
-                                                    <strong>Fields:</strong>
-                                                    <code style="background: #eee; padding: 1px 4px; border-radius: 3px"
-                                                        >Name, Industry, Phone</code
-                                                    >
-                                                </div>
-                                                <div>
-                                                    <strong>Parent lookup:</strong>
-                                                    <code style="background: #eee; padding: 1px 4px; border-radius: 3px"
-                                                        >Owner.Name, Account.Industry</code
-                                                    >
-                                                </div>
-                                                <div>
-                                                    <strong>Related list:</strong>
-                                                    <code style="background: #eee; padding: 1px 4px; border-radius: 3px"
-                                                        >(SELECT FirstName FROM Contacts)</code
-                                                    >
-                                                </div>
-                                                <div>
-                                                    <strong>With filter:</strong>
-                                                    <code style="background: #eee; padding: 1px 4px; border-radius: 3px"
-                                                        >(SELECT Name FROM Opps WHERE StageName = 'Closed Won')</code
-                                                    >
-                                                </div>
-                                                <div>
-                                                    <strong>With sort:</strong>
-                                                    <code style="background: #eee; padding: 1px 4px; border-radius: 3px"
-                                                        >(SELECT Name FROM Contacts ORDER BY LastName)</code
-                                                    >
-                                                </div>
-                                                <div>
-                                                    <strong>With limit:</strong>
-                                                    <code style="background: #eee; padding: 1px 4px; border-radius: 3px"
-                                                        >(SELECT Name FROM Cases LIMIT 10)</code
-                                                    >
-                                                </div>
-                                            </div>
-                                        </div>
+                                        </template>
                                     </template>
                                 </template>
                             </div>

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -114,7 +114,7 @@ const COLUMNS = [
     { label: 'Name', fieldName: 'Name' },
     { label: 'Type', fieldName: F.Type, initialWidth: 100 },
     { label: 'Output Format', fieldName: F.OutputFormat, initialWidth: 120 },
-    { label: 'Base Object', fieldName: F.BaseObject },
+    { label: 'Base Object', fieldName: 'displayBaseObject' },
     {
         label: 'Status',
         fieldName: 'activeLabel',
@@ -694,8 +694,16 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 // shipped — treat null/undefined as Active to match the server
                 // OR-NULL filter in getTemplatesForObjectInternal.
                 const isActive = t[F.IsActive] !== false;
+                const rawBase = t[F.BaseObject];
+                const displayBaseObject =
+                    rawBase === 'FlowJsonData'
+                        ? 'JSON Data (from Flow)'
+                        : rawBase === 'ApexProvider'
+                          ? 'Apex Data Provider'
+                          : rawBase;
                 return {
                     ...t,
+                    displayBaseObject,
                     defaultLabel: t[F.IsDefault] ? '★' : '',
                     defaultClass: t[F.IsDefault] ? 'slds-text-color_success slds-text-title_bold' : '',
                     activeLabel: isActive ? 'Active' : 'Inactive',
@@ -718,6 +726,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 (t.Name && t.Name.toLowerCase().includes(lowerKey)) ||
                 (t[F.Category] && t[F.Category].toLowerCase().includes(lowerKey)) ||
                 (t[F.BaseObject] && t[F.BaseObject].toLowerCase().includes(lowerKey)) ||
+                (t.displayBaseObject && t.displayBaseObject.toLowerCase().includes(lowerKey)) ||
                 (t[F.Type] && t[F.Type].toLowerCase().includes(lowerKey)) ||
                 (t[F.OutputFormat] && t[F.OutputFormat].toLowerCase().includes(lowerKey)) ||
                 (t[F.Desc] && t[F.Desc].toLowerCase().includes(lowerKey)) ||
@@ -828,6 +837,16 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 this.showToast('Error', 'Please fill in the template name and type.', 'error');
                 return;
             }
+            // JSON Data (from Flow) data source: no SOQL, no provider class.
+            // Skip Step 2 entirely — there's nothing to configure between name
+            // and template upload. The FlowJsonData sentinel and v4 marker were
+            // stamped at handleDataSourceModeChange time; just advance to upload.
+            if (this.dataSourceMode === 'flow') {
+                this.useApexProvider = false;
+                this.useVisualBuilder = false;
+                this.currentWizardStep = '3';
+                return;
+            }
             // Apex Data Provider data source bypasses the base-object requirement —
             // the provider class supplies its own data shape. We require a class to
             // be selected and validated before advancing, and stamp the v4 config
@@ -875,8 +894,13 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     }
 
     handlePrevStep() {
-        if (this.currentWizardStep === '3') this.currentWizardStep = '2';
-        else if (this.currentWizardStep === '2') this.currentWizardStep = '1';
+        if (this.currentWizardStep === '3') {
+            // JSON-flow templates skip Step 2 going forward; mirror that going back
+            // so the user lands on Step 1 (where they can re-pick the data source).
+            this.currentWizardStep = this.dataSourceMode === 'flow' ? '1' : '2';
+        } else if (this.currentWizardStep === '2') {
+            this.currentWizardStep = '1';
+        }
     }
 
     handleWizardTabActive() {
@@ -1130,12 +1154,24 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             // Pre-flip Apex Provider mode so Step 2 lands on the right pane.
             this.useApexProvider = true;
             this.useVisualBuilder = false;
+        } else if (mode === 'flow') {
+            // JSON-from-Flow: no SOQL, no provider class. Stamp the FlowJsonData
+            // sentinel into Base_Object_API__c so the record-page launcher's
+            // WHERE Base_Object_API__c = :objectApiName filter naturally excludes
+            // these — they're only invokable via DocGenFlowAction.jsonData.
+            this.useApexProvider = false;
+            this._clearApexProviderState();
+            this.newTemplateObject = 'FlowJsonData';
+            this.newTemplateSampleRecordId = '';
+            this.sampleRecordData = null;
+            this.newTemplateQuery = JSON.stringify({ v: 4, source: 'flowJsonData' });
         } else {
             this.useApexProvider = false;
             this._clearApexProviderState();
             // Restore default object so the next "advance to Step 2" doesn't error
-            // out before the user re-picks one.
-            if (!this.newTemplateObject) {
+            // out before the user re-picks one. Don't carry the FlowJsonData
+            // sentinel forward if the user switches back to Record mode.
+            if (!this.newTemplateObject || this.newTemplateObject === 'FlowJsonData') {
                 this.newTemplateObject = 'Account';
             }
         }
@@ -1144,7 +1180,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     get dataSourceModeOptions() {
         return [
             { label: 'Salesforce Record (SOQL)', value: 'record' },
-            { label: 'Apex Class (Data Provider)', value: 'apex' }
+            { label: 'Apex Class (Data Provider)', value: 'apex' },
+            { label: 'JSON Data (from Flow)', value: 'flow' }
         ];
     }
 
@@ -1153,6 +1190,21 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     }
     get isApexDataSource() {
         return this.dataSourceMode === 'apex';
+    }
+    get isFlowDataSource() {
+        return this.dataSourceMode === 'flow';
+    }
+
+    // Edit-modal companion: the modal doesn't have a separate dataSourceMode
+    // toggle (since data-source choice is set at creation time), so detect
+    // the FlowJsonData sentinel directly off editTemplateObject.
+    get isEditFlowDataSource() {
+        return this.editTemplateObject === 'FlowJsonData';
+    }
+    get editBaseObjectDisplay() {
+        if (this.editTemplateObject === 'FlowJsonData') return 'JSON Data (from Flow)';
+        if (this.editTemplateObject === 'ApexProvider') return 'Apex Data Provider';
+        return this.editTemplateObject;
     }
 
     get readableQueryConfig() {


### PR DESCRIPTION
Closes #110.

## Summary
- Adds **JSON Data (from Flow)** as a third Data Source option in the template wizard, alongside Salesforce Record (SOQL) and Apex Class (Data Provider).
- When selected, the wizard skips the Base Object picker, SOQL builder, and Apex Provider class picker entirely — Step 1 advances straight to template upload (Step 3).
- Persists `Base_Object_API__c = 'FlowJsonData'` (sentinel, mirrors the existing `'ApexProvider'` precedent) and `Query_Config__c = {"v":4,"source":"flowJsonData"}`.
- Reopened templates render "JSON Data (from Flow)" in the list Base Object column, Query Configuration tab header, and Step 3 review — sentinels never leak to the user.
- Naturally Flow-only: the record-page launcher's `WHERE Base_Object_API__c = :objectApiName` clause excludes the sentinel, so these templates only invoke via `DocGenFlowAction.jsonData`.

## Why this shape
No new field on `DocGen_Template__c` — `Base_Object_API__c` is schema-required (`required=true`), the sentinel satisfies that without a metadata change, and the `'ApexProvider'` precedent already established this pattern. `saveTemplate` is permissive (no required-field validation beyond the LWC), so no Apex change needed.

## Test plan
- [x] `DocGenControllerTests.testGetTemplatesForObjectExcludesFlowJsonData` — regression: FlowJsonData templates excluded from record-page launcher, still queryable directly (admin/import paths).
- [x] Deployed to `portwood-staging`, new test passes (208ms).
- [ ] Manual: create a new template with JSON Data source → confirm wizard skips Step 2 → upload → open edit modal → verify Query Configuration tab shows the Flow banner, not the Apex/SOQL toggles.
- [ ] Manual: confirm a JSON Flow template doesn't appear in the Generate Document picker on any record page.
- [ ] Manual: invoke via DocGenFlowAction with `jsonData` populated → verify render is identical to Joe's smoke test result.
- [ ] Release validation: full e2e suite + RunLocalTests + Code Analyzer before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)