### PR TITLE
fix: restore table styles in Print-Ready Packet bulk renders (#109)

### DIFF
--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -2551,10 +2551,30 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             return mr.documentXml == null ? '' : mr.documentXml;
         }
 
-        Map<String, String> pdfImages = buildPdfImageMap(mr, templateId);
-        setNumberingXml(mr);
-        applyWatermarkOverride(templateId);
-        return DocGenHtmlRenderer.convertToHtml(combineXmlWithHeadersFooters(mr), pdfImages);
+        // Mirror renderPdf's renderer setup. Without these, the Print-Ready
+        // Packet (mergeOnly) path renders tables with no borders/padding when
+        // the template uses a named <w:tblStyle> (resolveTableStyleBorder
+        // returns empty if stylesXml is null), and ignores the template's
+        // orientation/size/margins. Cleared in finally so per-record state
+        // doesn't leak across the bulk loop.
+        DocGenHtmlRenderer.orientationOverride = mr.pageOrientation;
+        DocGenHtmlRenderer.pageSizeOverride = mr.pageSize;
+        DocGenHtmlRenderer.marginsOverride = mr.pageMargins;
+        DocGenHtmlRenderer.customMarginsOverride = mr.customMargins;
+        try {
+            Map<String, String> pdfImages = buildPdfImageMap(mr, templateId);
+            if (mr.processedXmlEntries != null && mr.processedXmlEntries.containsKey('word/styles.xml')) {
+                DocGenHtmlRenderer.stylesXml = mr.processedXmlEntries.get('word/styles.xml');
+            }
+            setNumberingXml(mr);
+            applyWatermarkOverride(templateId);
+            return DocGenHtmlRenderer.convertToHtml(combineXmlWithHeadersFooters(mr), pdfImages);
+        } finally {
+            DocGenHtmlRenderer.orientationOverride = null;
+            DocGenHtmlRenderer.pageSizeOverride = null;
+            DocGenHtmlRenderer.marginsOverride = null;
+            DocGenHtmlRenderer.customMarginsOverride = null;
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- Fixes #109 — bulk generation in "Print-Ready Packet" mode rendered tables without borders, padding, or shading whenever the template used a named Word table style (Light Grid, Plain Table, etc.). Individual mode and "Combined + Individual" mode worked.
- Root cause: `DocGenService.generateHtmlForRecord` (the per-record entry point used only by the `mergeOnly` bulk path) was missing the renderer-state setup `renderPdf` performs before invoking `convertToHtml` — specifically `DocGenHtmlRenderer.stylesXml`, plus the orientation/size/margin overrides.
- Without `stylesXml`, `resolveTableStyleBorder` / `resolveStyleTextAttributes` returned empty for `<w:tblStyle>` references — so styling that lived on the named style (not inline `<w:tblBorders>`) was silently dropped.
- The fix mirrors `renderPdf`'s setup and clears the page overrides in a `finally` so per-record state doesn't leak across the bulk loop.

## Test plan

- [x] `npm run format:check` — clean
- [x] Deployed to `portwood-staging` (Deploy ID `0Afcb000008YmKBCA0`)
- [x] `sf apex run --target-org portwood-staging -f scripts/e2e-05-generate-bulk.apex` — 13/13 PASS
- [x] Manual verification on `portwood-staging` with template `a08cb00000L4HMdAAN` — Print-Ready Packet now matches Individual output
- [ ] Reviewer: re-run e2e-05 against your validation org

## Credit

Thanks to @sergiuBuru for the precise repro narrowing the bug down to Print-Ready Packet mode specifically (vs. Individual or Combined + Individual). That diagnostic pointed straight at the divergent `generateHtmlForRecord` call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)