### PR TITLE
fix(#114): revert pre-decomp CV lookups to WITH SYSTEM_MODE

### DIFF
--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -877,8 +877,8 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                         SELECT VersionData
                         FROM ContentVersion
                         WHERE Title = :xmlKey
-                        WITH USER_MODE
-                        LIMIT 1 // NOPMD — internal pre-decomposed part
+                        WITH SYSTEM_MODE
+                        LIMIT 1 // NOPMD — package-internal pre-decomposed part; access gated by DocGen permission sets via the parent template (#114)
                     ];
                     if (!xmlCvs.isEmpty()) {
                         documentXml = xmlCvs[0].VersionData.toString();
@@ -1210,8 +1210,8 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                         SELECT VersionData
                         FROM ContentVersion
                         WHERE Title = :xmlKey
-                        WITH USER_MODE
-                        LIMIT 1 // NOPMD — internal pre-decomposed part
+                        WITH SYSTEM_MODE
+                        LIMIT 1 // NOPMD — package-internal pre-decomposed part; access gated by DocGen permission sets via the parent template (#114)
                     ];
                     if (!xmlCvs.isEmpty()) {
                         documentXml = xmlCvs[0].VersionData.toString();

--- a/force-app/main/default/classes/DocGenGiantQueryFlowAction.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryFlowAction.cls
@@ -173,8 +173,8 @@ global with sharing class DocGenGiantQueryFlowAction { // NOPMD AvoidGlobalModif
                 SELECT VersionData
                 FROM ContentVersion
                 WHERE Title = :xmlKey
-                WITH USER_MODE
-                LIMIT 1 // NOPMD — internal pre-decomposed part
+                WITH SYSTEM_MODE
+                LIMIT 1 // NOPMD — package-internal pre-decomposed part; access gated by DocGen permission sets via the parent template (#114)
             ];
             if (!xmlCvs.isEmpty()) {
                 documentXml = xmlCvs[0].VersionData.toString();

--- a/force-app/main/default/classes/DocGenMiscTests.cls
+++ b/force-app/main/default/classes/DocGenMiscTests.cls
@@ -8960,4 +8960,56 @@ private class DocGenMiscTests {
         Map<String, Object> simple = DocGenService.loadRecordDataForTitle(acc.Id);
         System.assertEquals('Edge', simple.get('Name'));
     }
+
+    // =========================================================================
+    // Issue #114 — pre-decomposed template CVs are looked up at render time
+    // in four production sites (DocGenService.cls, two in DocGenController.cls,
+    // DocGenGiantQueryFlowAction.cls). All four MUST use WITH SYSTEM_MODE so
+    // FLS/CRUD on ContentVersion fields don't block non-admin users whose
+    // implicit CDL access already permits them to read the CV.
+    //
+    // Commit a0b10ee (v1.15.0) flipped these to WITH USER_MODE during the
+    // Checkmarx hardening pass and broke render for non-admin users with the
+    // DocGen_User permset. A true cross-user runtime test for this is brittle
+    // — the implicit CDL chain depends on permset + sharing + CDL Visibility
+    // none of which a focused unit test can mock cleanly — so guard the fix
+    // with a source-text assertion that catches any future revert to USER_MODE.
+    // =========================================================================
+    @IsTest
+    static void testIssue114NoUserModeOnPreDecompCvLookups() {
+        List<String> classNames = new List<String>{ 'DocGenService', 'DocGenController', 'DocGenGiantQueryFlowAction' };
+        for (ApexClass ac : [SELECT Name, Body FROM ApexClass WHERE Name IN :classNames AND NamespacePrefix = NULL]) {
+            String body = ac.Body;
+            Integer cursor = 0;
+            Integer hits = 0;
+            while (true) {
+                Integer idx = body.indexOf('docgen_tmpl_xml_', cursor);
+                if (idx == -1) {
+                    break;
+                }
+                hits++;
+                // Look forward to the SOQL closing bracket and assert no
+                // WITH USER_MODE appears between the prefix and that bracket.
+                Integer close = body.indexOf('];', idx);
+                if (close != -1) {
+                    String slice = body.substring(idx, close);
+                    System.assert(
+                        !slice.contains('WITH USER_MODE'),
+                        ac.Name +
+                            ' uses WITH USER_MODE for a pre-decomposed CV lookup — see #114. ' +
+                            'Offending block starts around char ' +
+                            idx +
+                            '.'
+                    );
+                }
+                cursor = idx + 16;
+            }
+            System.assert(
+                hits > 0,
+                'Sanity: expected at least one docgen_tmpl_xml_ reference in ' +
+                    ac.Name +
+                    ' — test may need updating if the prefix was renamed.'
+            );
+        }
+    }
 }

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -1140,7 +1140,7 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             SELECT Title, VersionData
             FROM ContentVersion
             WHERE Title IN (:docKey, :stylesKey)
-            WITH USER_MODE // NOPMD — internal pre-decomposed parts
+            WITH SYSTEM_MODE // NOPMD — package-internal pre-decomposed parts; access gated by DocGen permission sets via the parent template (#114)
         ];
         for (ContentVersion cv : xmlCvs) {
             if (cv.Title == docKey) {


### PR DESCRIPTION
Fixes #114.

## Summary

- Reverts four pre-decomposed template CV lookups from `WITH USER_MODE` (introduced in `a0b10ee`, v1.15.0 during the Checkmarx hardening pass) back to `WITH SYSTEM_MODE`.
- Affected non-admin users with the `DocGen_User` permset — they hit `Pre-decomposed template parts not found. Please re-save the template.` whenever the template's pre-decomp CVs were owned by another user (typical: admin saved/re-saved the template).
- Restores consistency with the adjacent `DocGen_Template_Version__c` lookups in the same blocks, which were already `WITH SYSTEM_MODE` with the same package-internal justification.

## Sites changed

- `force-app/main/default/classes/DocGenService.cls:1143` — `assembleGiantQueryPdf` style + body lookup
- `force-app/main/default/classes/DocGenController.cls:880` — `generateDocument` body lookup
- `force-app/main/default/classes/DocGenController.cls:1213` — `submitGiantQueryJob` body lookup
- `force-app/main/default/classes/DocGenGiantQueryFlowAction.cls:176` — Flow-invoked Giant Query body lookup

NOPMD comments refreshed to document the package-internal justification explicitly and cite `#114` so a future security pass doesn't re-flip them.

## Why SYSTEM_MODE is safe

- The CVs hold package-internal serialized DOCX/XML (titles always start `docgen_tmpl_xml_<versionId>_`); no PII, no user data.
- Access to the parent `DocGen_Template__c` / `DocGen_Template_Version__c` is permset-gated already (`DocGen_User`, `DocGen_Admin`).
- The parent version lookup in the same SOQL blocks already uses `WITH SYSTEM_MODE` with the same comment — these four sites were an inconsistency.

## Regression coverage

New `DocGenMiscTests.testIssue114NoUserModeOnPreDecompCvLookups` greps each affected class's `ApexClass.Body` for `docgen_tmpl_xml_` references and asserts no surrounding SOQL block contains `WITH USER_MODE`. Source-text guard rather than runtime — the cross-user CDL chain (permset + sharing + CDL Visibility) is too brittle to mock in a unit test, but the source assertion fails loudly on any future revert.

## Test plan

- [x] `npm run format:check` — clean
- [x] Deployed to `portwood-staging`
- [x] `DocGenMiscTests.testIssue114NoUserModeOnPreDecompCvLookups` — PASS
- [ ] Reviewer: full e2e + RunLocalTests against validation org
- [ ] Reporter @gregdevine: re-verify with the affected non-admin user after release

## Credit

Thanks to Greg Devine for the precise diagnostic (admins unaffected, non-admins fail on merge, started after a template re-save) that pointed straight at the user-vs-system mode regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)