### PR TITLE
chore(release): v1.98.0 — Microsoft-shop polish, community fixes, Flow-driven templates, guest path removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,13 +48,57 @@ When a `<w:numPr>` (numbered/bulleted) paragraph contained multiple sibling sect
 - Code Analyzer: 0 High, 38 Moderate (within the documented ~30–41 baseline of `pmd:ProtectSensitiveData` false-positives on signature-domain field metadata).
 - Org-wide coverage: 75% (at threshold).
 
-## v1.98.0 — Experience Cloud guest render path removed (preliminary — flesh out at release)
+## v1.98.0 — Microsoft-shop polish, community fixes, Flow-driven templates, guest path removed
 
-Single-focus removal that takes out the unauthenticated guest-context document rendering path (introduced v1.86.0, PR #70). The original "public-facing downloads" requirement was reread with customers as "generate server-side and host on a public website," not "guest user triggers the render themselves." After the architecture was in place no customer asked for the latter, while the supporting code (platform-event reroute, LWR shepherd basePath logic, Automated Process CV-access quirks, the DOCX-via-Automated-Process dead-end documented in v1.92.0 #72) carried meaningful complexity tax. With the path gone, the merge engine and runner LWC drop their guest branches, freeing the planned DOCX→HTML parser refactor from dual-path validation.
+Five things ride this release. Two field-reported P0/P1 bugs from non-admin Microsoft-shop users (#109 Print-Ready Packet tables silently rendered without styling, #114 giant-query merge threw "Pre-decomposed template parts not found" for everyone who wasn't the template's CV owner); the **binary-asset carry-over** in cross-org template export/import (#100 — Header/Footer/body inline images and watermark CVs now travel with the bundle); a new **JSON Data (from Flow)** template data source (#110) that bypasses the SOQL builder when the data comes pre-shaped from an invoking Flow; and the long-planned **Experience Cloud guest render path removal** — net -914 LOC across 17 files, freeing the planned DOCX→HTML parser refactor from dual-path validation. Authored together, validated together, shipped together.
+
+### Print-Ready Packet renders table borders correctly again (#109)
+
+Reported by @sergiuBuru (community-contribution) with a precise diagnostic: bulk Print-Ready Packet mode lost table borders / padding / shading, while Individual mode and Combined + Individual mode rendered the same template correctly.
+
+- **Root cause** — `DocGenService.generateHtmlForRecord` (the per-record HTML entry point used only by the `mergeOnly` bulk path) was missing the renderer setup `renderPdf` performs before invoking `convertToHtml`: specifically the `DocGenHtmlRenderer.stylesXml` assignment plus the orientation / size / margin overrides. Without `stylesXml`, `resolveTableStyleBorder` / `resolveStyleTextAttributes` returned empty for `<w:tblStyle>` references — so styling that lived on the named Word table style (Light Grid, Plain Table, etc., rather than inline `<w:tblBorders>`) was silently dropped.
+- **Fix** — mirror `renderPdf`'s setup in `generateHtmlForRecord` and clear the page overrides in a `finally` so per-record state doesn't leak across the bulk loop. `stylesXml` is left set (matches `renderPdf` semantics).
+- **Severity classification** — P0 silent-corruption (output renders, just without the formatting authors intended; no error surface for the user to chase). Per the TRIAGE rubric this jumps the queue regardless of milestone.
+
+### Giant Query merge no longer fails for non-admin users (#114)
+
+Reported by Greg Devine. Affected user had `DocGen_User` permset + full FLS, but the merge threw `Pre-decomposed template parts not found. Please re-save the template.` whenever the template's pre-decomposed CVs were owned by another user (typical: an admin saved/re-saved the template). Admins were unaffected, hiding the breakage in most internal testing.
+
+- **Regression origin** — commit `a0b10ee` (v1.15.0, Checkmarx hardening pass) flipped four `ContentVersion` lookups for the `docgen_tmpl_xml_<versionId>_` pre-decomposed parts from `WITH SYSTEM_MODE` to `WITH USER_MODE`. The CVs hold package-internal serialized DOCX XML — they carry no user data — but USER_MODE enforces FLS/CRUD on ContentVersion fields the `DocGen_User` permset doesn't grant, blocking the read. Has shipped broken for non-admins since v1.15.0; the new picklist values in v1.97 that prompted template re-saves likely triggered the field reports.
+- **Fix** — revert all four sites to `WITH SYSTEM_MODE` and refresh the NOPMD comments to document the package-internal justification explicitly. Restores consistency with the adjacent `DocGen_Template_Version__c` lookups in the same blocks, which were already SYSTEM_MODE.
+- **Sites changed** — `DocGenService.cls:1143`, `DocGenController.cls:880`, `DocGenController.cls:1213`, `DocGenGiantQueryFlowAction.cls:176`. (The Explore agent initially flagged three sites; replace-all caught a fourth identical block during the fix.)
+- **Regression** — `testIssue114NoUserModeOnPreDecompCvLookups` greps each affected class's `ApexClass.Body` for `docgen_tmpl_xml_` references and asserts no surrounding SOQL contains `WITH USER_MODE`. Source-text guard rather than runtime — the cross-user CDL chain (permset + sharing + CDL Visibility) is too brittle to mock cleanly in a unit test, but the source assertion fails loudly on any future revert.
+
+### Cross-org template export/import now carries binary assets (#100)
+
+Sibling to the v1.96 scalar-field-drift fix (#102). The scalar fix preserved settings like `Page_Size__c` / `Lock_Output_Format__c` across orgs; this finishes the job for the two binary cases that were still broken:
+
+- **HTML inline images** — for HTML-type templates, the body bytes contain rewritten `<img src="/sfc/servlet.shepherd/version/download/<sourceCvId>">` URLs pointing at the source org's ContentVersions. On import those URLs 404'd because the referenced CVs don't exist in the target org. Same problem for any `<img>` URLs inside `Header_Html__c` / `Footer_Html__c`.
+- **Watermark** — `DocGen_Template_Version__c.Watermark_Image_CV_Id__c` held a source-org CV ID with no corresponding bundle entry, so on import the field either pointed at a non-existent ID or was silently dropped.
+
+`exportTemplate` now scans body HTML / header / footer for shepherd CV URLs and includes the active version's watermark CV, bundling each referenced `ContentVersion` as `{originalCvId, fileName, base64, fileExtension}` in a new `assets` array on the bundle. `importTemplate` re-uploads each asset linked to the new template (`FirstPublishLocationId`), builds an `oldCvId → newCvId` map, and rewrites:
+
+- `Header_Html__c` / `Footer_Html__c` post-insert (one extra DML because the asset upload requires the parent template Id),
+- the HTML body bytes BEFORE the body CV insert (`ContentVersion.VersionData` is immutable post-insert; rewriting after upload would need a v2 ContentVersion), and
+- `Watermark_Image_CV_Id__c` on the new active version.
+
+Two private helpers (`extractShepherdCvIds`, `rewriteShepherdCvIds`) factor the URL scanning + replacement; both `@TestVisible`. The URL prefix is regex-anchored so a raw `068...` string elsewhere in the body can't false-match.
+
+`docgenExportVersion` is still `'1'` — v1 bundles missing the `assets` key import unchanged (asset refs stay pointed at source-org IDs, same behavior they had before this version).
+
+### JSON Data (from Flow) template data source (#110)
+
+Adds a third Data Source option in the template wizard alongside **Salesforce Record (SOQL)** and **Apex Class (Data Provider)**. When selected, Step 1 skips the Base Object picker, SOQL builder, and Apex Provider class picker entirely and advances straight to template upload (Step 3). Persists `Base_Object_API__c = 'FlowJsonData'` (sentinel, mirrors the existing `'ApexProvider'` precedent) and `Query_Config__c = {"v":4,"source":"flowJsonData"}`. The Template Library lists "JSON Data (from Flow)" in the Base Object column; the template generates from data passed via `DocGenFlowAction.jsonData` at runtime instead of querying Salesforce.
+
+Lifts the longstanding constraint where Flow-driven templates with pre-shaped JSON had to be backed by a stub SObject just to satisfy the wizard's "needs a base object" gate.
+
+### Experience Cloud guest render path removed
+
+Net **-914 LOC across 17 files**. Removes the unauthenticated guest-context document rendering path (introduced v1.86.0, PR #70). The original "public-facing downloads" requirement was reread with customers as "generate server-side and host on a public website," not "guest user triggers the render themselves." After the architecture was in place no customer asked for the latter, while the supporting code (platform-event reroute, LWR shepherd basePath logic, Automated Process CV-access quirks, the DOCX-via-Automated-Process dead-end documented in v1.92.0 #72) carried meaningful complexity tax. With the path gone, the merge engine and runner LWC drop their guest branches, freeing the planned DOCX→HTML parser refactor from dual-path validation.
 
 **E-signature guest signing is unaffected.** That uses a different code path (`DocGenSignaturePdfTrigger`, `DocGen_Guest_Signature` permset, token-gated record access) and stays exactly as-is.
 
-### Removed (full deletion)
+#### Removed (full deletion)
 
 - `DocGenGuestRenderQueueable.cls` and its test class
 - `DocGenGuestRenderTrigger.trigger` (platform-event consumer)
@@ -64,21 +108,22 @@ Single-focus removal that takes out the unauthenticated guest-context document r
 - UserGuide §8.6 ("From an Experience Cloud public page (guest users)") and §8.6.1 (the InternalUsers CDL workaround)
 - `DocGen_Guest_Runner` row in the UserGuide permset table
 
-### Stubbed (preserved as empty shells for subscriber upgrade compatibility)
+#### Stubbed (preserved as empty shells for subscriber upgrade compatibility)
 
 - `DocGen_Guest_Render__e` platform event — metadata retained; description marked deprecated. 2GP packages can't cleanly delete published events; the shell is benign (no publishers or subscribers remain in code).
-- `DocGen_Guest_Runner.permissionset` — all class/object/field access stripped; description marked deprecated; label renamed "(deprecated)". Safe to leave assigned or unassign from site guest users.
+- `DocGen_Guest_Runner.permissionset` — all class/object/field access stripped; description marked deprecated; label renamed "(deprecated)". Safe to leave assigned or unassign from site guest users. `e2e-01-permissions.apex` updated to assert the stub state (0 class grants, 0 object grants) so a future regression that re-adds them fails loudly.
 
-### Updated
+#### Updated
 
-- `DocGenService.cls` and `DocGenTemplateManager.cls` — comments referencing the removed platform event reworded; the `SYSTEM_MODE` template-body lookup and the two-step CV title lookup are otherwise unchanged (both still serve non-guest contexts).
+- `DocGenService.cls` and `DocGenTemplateManager.cls` — comments referencing the removed platform event reworded; the SYSTEM_MODE template-body lookup and the two-step CV title lookup are otherwise unchanged (both still serve non-guest contexts).
 - `CLAUDE.md` — removed "Critical: Experience Cloud guest path" section; updated the client-side DOCX assembly note.
 
-### Test counts
+### Tests
 
-- Apex local tests: TBD on release validation.
-- e2e suite (e2e-01 through e2e-08): expected green on `portwood-staging` (no guest-specific assertions exist; removal should be invisible).
-- Prettier: clean. Code Analyzer: 0 High, ~41 Moderate (unchanged from v1.96.0 baseline).
+- E2E suite: 11 scripts, **223 / 223 PASS** on `portwood-staging` (e2e-01 42, e2e-02 10, e2e-03 16, e2e-04 15, e2e-05 13, e2e-06 23, e2e-07-syntax1 35, syntax2 31, syntax3 17, syntax4 9, e2e-08 12).
+- Apex local tests: 1362 methods, **100% pass**, org-wide coverage **75%** (at threshold). New regressions: `testExportImportRoundTripPreservesBinaryAssets` (#100), `testIssue114NoUserModeOnPreDecompCvLookups` (#114).
+- Prettier: clean. Code Analyzer (Security + AppExchange): **0 High**, 38 Moderate — all `pmd:ProtectSensitiveData` false-positives on signature-domain field metadata (within the documented ~30–41 baseline).
+- Manual: Print-Ready Packet (#109) verified on `portwood-staging` against template `a08cb00000L4HMdAAN`; output matches Individual mode for table borders / padding / shading.
 
 ## v1.93.0 — Flow Save-to-Record honored (#90), signature decline cache cleared (#91), Template Status column symmetric labels (#92)
 

--- a/scripts/spike-117-compare.apex
+++ b/scripts/spike-117-compare.apex
@@ -1,0 +1,52 @@
+// #117 spike — compare PDF sizes with vs without SVG to detect silent drop.
+// If withSvgSize ≈ withoutSvgSize, Flying Saucer is ignoring the SVG.
+
+String headerHtml =
+    '<html><head><meta charset="utf-8"/><style>' +
+    '@page { size: letter; margin: 0.75in; }' +
+    'body { font-family: Arial, sans-serif; font-size: 11pt; }' +
+    '</style></head><body>';
+
+String footerHtml = '</body></html>';
+
+String svgBlock =
+    '<svg width="500" height="180" xmlns="http://www.w3.org/2000/svg">' +
+    '<rect x="0" y="0" width="500" height="180" fill="#3b82f6"/>' +
+    '<rect x="50" y="50" width="400" height="80" fill="#10b981"/>' +
+    '<text x="250" y="100" font-family="Arial" font-size="32" fill="#fff" text-anchor="middle">SVG TEST</text>' +
+    '<circle cx="100" cy="150" r="20" fill="#ef4444"/>' +
+    '<circle cx="200" cy="150" r="20" fill="#f59e0b"/>' +
+    '<circle cx="300" cy="150" r="20" fill="#8b5cf6"/>' +
+    '<circle cx="400" cy="150" r="20" fill="#ec4899"/>' +
+    '</svg>';
+
+String body = '<p>Some text paragraph that contributes to PDF size with text glyphs.</p>';
+
+String withSvg = headerHtml + body + '<div>' + svgBlock + '</div>' + body + footerHtml;
+String withoutSvg = headerHtml + body + '<div>(no svg here)</div>' + body + footerHtml;
+String withImg =
+    headerHtml +
+    body +
+    '<div><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=" ' +
+    'width="500" height="180" alt="placeholder"/></div>' +
+    body +
+    footerHtml;
+
+Blob pdfWith = Blob.toPdf(withSvg);
+Blob pdfWithout = Blob.toPdf(withoutSvg);
+Blob pdfImg = Blob.toPdf(withImg);
+
+System.debug('PDF size with SVG:    ' + pdfWith.size() + ' bytes');
+System.debug('PDF size without SVG: ' + pdfWithout.size() + ' bytes');
+System.debug('PDF size with <img>:  ' + pdfImg.size() + ' bytes');
+System.debug('Delta SVG vs control: ' + (pdfWith.size() - pdfWithout.size()) + ' bytes');
+System.debug('Delta IMG vs control: ' + (pdfImg.size() - pdfWithout.size()) + ' bytes');
+
+// PDF bytes are not UTF-8; base64-encode and search for hex signatures instead.
+String b64With = EncodingUtil.base64Encode(pdfWith);
+String b64Without = EncodingUtil.base64Encode(pdfWithout);
+System.debug('b64 size with SVG:    ' + b64With.length() + ' chars');
+System.debug('b64 size without SVG: ' + b64Without.length() + ' chars');
+// PDF "SVG TEST" text would be encoded in font glyphs, hard to grep. Size delta
+// is the signal — if SVG was rendered, the page content stream gains rect/text
+// operators and the base64 length grows by hundreds of bytes per shape.

--- a/scripts/spike-117-known-good-svg.apex
+++ b/scripts/spike-117-known-good-svg.apex
@@ -1,0 +1,74 @@
+// #117 spike round 4 — known-good SVG sample (Mozilla MDN canonical shape).
+// If THIS doesn't render via the CV-URL path, the SVG itself isn't the issue
+// — Flying Saucer's image renderer just doesn't rasterize SVG.
+
+// Canonical MDN SVG sample — simple shapes, no exotic features, well-formed.
+// Anyone visiting https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg
+// sees this rendered correctly in every modern browser.
+String svg =
+    '<?xml version="1.0" encoding="UTF-8" standalone="no"?>' +
+    '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" ' +
+    'width="300" height="200" viewBox="0 0 300 200">' +
+    '<rect width="100%" height="100%" fill="#f0f9ff"/>' +
+    '<circle cx="150" cy="100" r="80" stroke="#1e40af" stroke-width="4" fill="#3b82f6"/>' +
+    '<text x="150" y="105" font-family="Arial" font-size="24" fill="white" text-anchor="middle">OK</text>' +
+    '</svg>';
+
+ContentVersion svgCv = new ContentVersion(
+    Title = 'spike-117-mdn-svg-' + System.now().getTime(),
+    PathOnClient = 'mdn-canonical.svg',
+    VersionData = Blob.valueOf(svg),
+    IsMajorVersion = true
+);
+insert svgCv;
+ContentVersion svgSaved = [SELECT Id, FileExtension, FileType FROM ContentVersion WHERE Id = :svgCv.Id LIMIT 1];
+String svgUrl = '/sfc/servlet.shepherd/version/download/' + svgSaved.Id;
+System.debug('SVG saved: ' + svgSaved.FileType + ' / ' + svgSaved.FileExtension + ' at ' + svgUrl);
+
+// Same SVG, two reference forms — URL-via-CV and data-URI — in one PDF.
+String b64 = EncodingUtil.base64Encode(Blob.valueOf(svg));
+
+String html =
+    '<html><head><meta charset="utf-8"/><style>' +
+    '@page { size: letter; margin: 0.6in; }' +
+    'body { font-family: Arial, sans-serif; font-size: 11pt; }' +
+    '.box { border: 1px dashed #d1d5db; padding: 8pt; margin-bottom: 14pt; }' +
+    '</style></head><body>' +
+    '<h1>#117 spike round 4 — MDN-canonical SVG, two reference paths</h1>' +
+    '<p>Same well-formed SVG (the canonical MDN sample), embedded two ways.</p>' +
+    '<h2>Path A — via CV URL (' +
+    svgUrl +
+    ')</h2>' +
+    '<div class="box"><img src="' +
+    svgUrl +
+    '" width="300" height="200" alt="svg-via-cv-url"/></div>' +
+    '<h2>Path B — via data URI</h2>' +
+    '<div class="box"><img src="data:image/svg+xml;base64,' +
+    b64 +
+    '" width="300" height="200" alt="svg-data-uri"/></div>' +
+    '<h2>Control — same shape as PNG (visible red 100x50)</h2>' +
+    '<div class="box">' +
+    '<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAAAyCAYAAACqNX6+AAAAGUlEQVR42mP8z8DwHwAFBQIAXfa1KAAAAABJRU5ErkJggg==" ' +
+    'width="100" height="50" alt="png-control"/></div>' +
+    '</body></html>';
+
+Blob pdf = Blob.toPdf(html);
+ContentVersion pdfCv = new ContentVersion(
+    Title = 'spike-117-mdn-pdf-' + System.now().getTime(),
+    PathOnClient = 'spike-117-mdn.pdf',
+    VersionData = pdf,
+    IsMajorVersion = true
+);
+insert pdfCv;
+ContentVersion pdfSaved = [SELECT Id, ContentDocumentId FROM ContentVersion WHERE Id = :pdfCv.Id LIMIT 1];
+
+System.debug('=== Spike #117 round 4 ===');
+System.debug('PDF size:    ' + pdf.size() + ' bytes');
+System.debug('SVG CV URL:  ' + URL.getOrgDomainURL().toExternalForm() + svgUrl);
+System.debug(
+    'Open PDF:    ' +
+        URL.getOrgDomainURL().toExternalForm() +
+        '/lightning/r/ContentDocument/' +
+        pdfSaved.ContentDocumentId +
+        '/view'
+);

--- a/scripts/spike-117-svg-as-img.apex
+++ b/scripts/spike-117-svg-as-img.apex
@@ -1,0 +1,35 @@
+// #117 spike round 2 — does Flying Saucer accept SVG via <img src="data:image/svg+xml;base64,...">?
+// Inline <svg>...</svg> is silently dropped (spike round 1). SVG-as-img is the
+// fallback dance some PDF engines (xmlworker, PDFBox-backed) accept.
+
+String svg =
+    '<svg xmlns="http://www.w3.org/2000/svg" width="500" height="180">' +
+    '<rect x="0" y="0" width="500" height="180" fill="#3b82f6"/>' +
+    '<rect x="50" y="50" width="400" height="80" fill="#10b981"/>' +
+    '<text x="250" y="100" font-family="Arial" font-size="32" fill="#fff" text-anchor="middle">SVG IMG</text>' +
+    '<circle cx="100" cy="150" r="20" fill="#ef4444"/>' +
+    '</svg>';
+
+String b64Svg = EncodingUtil.base64Encode(Blob.valueOf(svg));
+String svgImg = '<img src="data:image/svg+xml;base64,' + b64Svg + '" width="500" height="180" alt="svg"/>';
+String pngImg =
+    '<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=" ' +
+    'width="500" height="180" alt="png"/>';
+
+String shell = '<html><head><style>@page { size: letter; margin: 0.75in; }</style></head><body><p>X</p>';
+String tail = '</body></html>';
+
+Blob pdfControl = Blob.toPdf(shell + tail);
+Blob pdfSvgImg = Blob.toPdf(shell + svgImg + tail);
+Blob pdfPngImg = Blob.toPdf(shell + pngImg + tail);
+Blob pdfSvgInline = Blob.toPdf(shell + '<div>' + svg + '</div>' + tail);
+
+System.debug('=== Spike #117 round 2 ===');
+System.debug('Control (just <p>X</p>):                       ' + pdfControl.size() + ' bytes');
+System.debug('+ <img src="data:image/svg+xml;base64,...">:   ' + pdfSvgImg.size() + ' bytes');
+System.debug('+ <img src="data:image/png;base64,...">:       ' + pdfPngImg.size() + ' bytes');
+System.debug('+ inline <svg>...</svg> (round 1 control):     ' + pdfSvgInline.size() + ' bytes');
+System.debug('');
+System.debug('Delta SVG-as-img vs control: ' + (pdfSvgImg.size() - pdfControl.size()));
+System.debug('Delta PNG-as-img vs control: ' + (pdfPngImg.size() - pdfControl.size()));
+System.debug('Delta inline-svg vs control: ' + (pdfSvgInline.size() - pdfControl.size()));

--- a/scripts/spike-117-svg-flying-saucer.apex
+++ b/scripts/spike-117-svg-flying-saucer.apex
@@ -1,0 +1,139 @@
+// Spike for #117 — verify Flying Saucer renders inline SVG inside Blob.toPdf
+// Run: sf apex run --target-org portwood-staging -f scripts/spike-117-svg-flying-saucer.apex
+// Output: ContentVersion with the rendered PDF — URL is logged at the end.
+//
+// Five test cards, each a self-contained SVG. If the resulting PDF shows all
+// five renderings correctly, the SVG serializer path (issue #117) is unblocked
+// for the PDF output target. Failures isolate which SVG features Flying Saucer
+// drops so the serializer can avoid them.
+
+// ---- Card 1 — minimal horizontal bar (the v1 chart shape) ----
+String card1 =
+    '<svg width="500" height="180" xmlns="http://www.w3.org/2000/svg">' +
+    '<text x="0" y="15" font-family="Arial" font-size="11" fill="#000">Very Satisfied</text>' +
+    '<rect x="120" y="3" width="320" height="15" fill="#3b82f6"/>' +
+    '<text x="445" y="15" font-family="Arial" font-size="11" fill="#000">42 (80%)</text>' +
+    '<text x="0" y="40" font-family="Arial" font-size="11" fill="#000">Satisfied</text>' +
+    '<rect x="120" y="28" width="200" height="15" fill="#10b981"/>' +
+    '<text x="325" y="40" font-family="Arial" font-size="11" fill="#000">27 (52%)</text>' +
+    '<text x="0" y="65" font-family="Arial" font-size="11" fill="#000">Neutral</text>' +
+    '<rect x="120" y="53" width="80" height="15" fill="#f59e0b"/>' +
+    '<text x="205" y="65" font-family="Arial" font-size="11" fill="#000">11 (21%)</text>' +
+    '<text x="0" y="90" font-family="Arial" font-size="11" fill="#000">Dissatisfied</text>' +
+    '<rect x="120" y="78" width="40" height="15" fill="#ef4444"/>' +
+    '<text x="165" y="90" font-family="Arial" font-size="11" fill="#000">5 (10%)</text>' +
+    '</svg>';
+
+// ---- Card 2 — same shape but grouped via <g> ----
+String card2 =
+    '<svg width="500" height="100" xmlns="http://www.w3.org/2000/svg">' +
+    '<g font-family="Arial" font-size="11" fill="#000">' +
+    '<text x="0" y="15">Engineering</text>' +
+    '<rect x="120" y="3" width="280" height="15" fill="#8b5cf6"/>' +
+    '<text x="405" y="15">35</text>' +
+    '<text x="0" y="40">Sales</text>' +
+    '<rect x="120" y="28" width="160" height="15" fill="#ec4899"/>' +
+    '<text x="285" y="40">20</text>' +
+    '</g>' +
+    '</svg>';
+
+// ---- Card 3 — vertical clustered bars (column chart) ----
+String card3 =
+    '<svg width="500" height="200" xmlns="http://www.w3.org/2000/svg">' +
+    '<line x1="40" y1="180" x2="480" y2="180" stroke="#000" stroke-width="1"/>' +
+    '<rect x="60" y="80" width="40" height="100" fill="#3b82f6"/>' +
+    '<rect x="105" y="50" width="40" height="130" fill="#10b981"/>' +
+    '<rect x="170" y="120" width="40" height="60" fill="#3b82f6"/>' +
+    '<rect x="215" y="100" width="40" height="80" fill="#10b981"/>' +
+    '<rect x="280" y="60" width="40" height="120" fill="#3b82f6"/>' +
+    '<rect x="325" y="40" width="40" height="140" fill="#10b981"/>' +
+    '<text x="60" y="195" font-family="Arial" font-size="10" fill="#000">Q1</text>' +
+    '<text x="170" y="195" font-family="Arial" font-size="10" fill="#000">Q2</text>' +
+    '<text x="280" y="195" font-family="Arial" font-size="10" fill="#000">Q3</text>' +
+    '</svg>';
+
+// ---- Card 4 — stacked horizontal bar (composition) ----
+String card4 =
+    '<svg width="500" height="80" xmlns="http://www.w3.org/2000/svg">' +
+    '<text x="0" y="20" font-family="Arial" font-size="11" fill="#000">2026 Q1 Mix</text>' +
+    '<rect x="100" y="8" width="180" height="20" fill="#3b82f6"/>' +
+    '<rect x="280" y="8" width="120" height="20" fill="#10b981"/>' +
+    '<rect x="400" y="8" width="60" height="20" fill="#f59e0b"/>' +
+    '<text x="0" y="55" font-family="Arial" font-size="11" fill="#000">2026 Q2 Mix</text>' +
+    '<rect x="100" y="43" width="220" height="20" fill="#3b82f6"/>' +
+    '<rect x="320" y="43" width="90" height="20" fill="#10b981"/>' +
+    '<rect x="410" y="43" width="50" height="20" fill="#f59e0b"/>' +
+    '</svg>';
+
+// ---- Card 5 — feature stress test (transform + opacity + nested g) ----
+String card5 =
+    '<svg width="500" height="120" xmlns="http://www.w3.org/2000/svg">' +
+    '<g transform="translate(20,20)">' +
+    '<rect x="0" y="0" width="100" height="60" fill="#3b82f6" opacity="0.8"/>' +
+    '<text x="50" y="35" font-family="Arial" font-size="14" fill="#fff" text-anchor="middle">SVG</text>' +
+    '</g>' +
+    '<g transform="translate(140,20)">' +
+    '<circle cx="50" cy="30" r="30" fill="#10b981"/>' +
+    '<text x="50" y="35" font-family="Arial" font-size="14" fill="#fff" text-anchor="middle">Circle</text>' +
+    '</g>' +
+    '<g transform="translate(260,20)">' +
+    '<polygon points="50,0 100,60 0,60" fill="#f59e0b"/>' +
+    '<text x="50" y="50" font-family="Arial" font-size="14" fill="#000" text-anchor="middle">Tri</text>' +
+    '</g>' +
+    '</svg>';
+
+String html =
+    '<html><head><meta charset="utf-8"/><style>' +
+    '@page { size: letter; margin: 0.75in; }' +
+    'body { font-family: Arial, sans-serif; font-size: 11pt; }' +
+    'h2 { font-size: 13pt; margin: 16pt 0 4pt 0; }' +
+    '.card { border: 1px solid #ccc; padding: 8pt; margin-bottom: 10pt; }' +
+    '</style></head><body>' +
+    '<h1>SVG-in-PDF spike for #117 (Flying Saucer / Blob.toPdf)</h1>' +
+    '<p>If each card below renders its SVG correctly, the SVG serializer for the chart epic (#116) ' +
+    'is unblocked for the PDF output target.</p>' +
+    '<h2>Card 1 — Horizontal bar (the v1 chart shape)</h2>' +
+    '<div class="card">' +
+    card1 +
+    '</div>' +
+    '<h2>Card 2 — Grouped via &lt;g&gt;</h2>' +
+    '<div class="card">' +
+    card2 +
+    '</div>' +
+    '<h2>Card 3 — Vertical clustered (columns)</h2>' +
+    '<div class="card">' +
+    card3 +
+    '</div>' +
+    '<h2>Card 4 — Stacked horizontal</h2>' +
+    '<div class="card">' +
+    card4 +
+    '</div>' +
+    '<h2>Card 5 — Feature stress (transform, opacity, circle, polygon, text-anchor)</h2>' +
+    '<div class="card">' +
+    card5 +
+    '</div>' +
+    '</body></html>';
+
+Blob pdf = Blob.toPdf(html);
+
+ContentVersion cv = new ContentVersion(
+    Title = 'spike-117-svg-flying-saucer-' + System.now().getTime(),
+    PathOnClient = 'spike-117-svg.pdf',
+    VersionData = pdf,
+    IsMajorVersion = true
+);
+insert cv;
+
+ContentVersion saved = [SELECT Id, ContentDocumentId FROM ContentVersion WHERE Id = :cv.Id LIMIT 1];
+System.debug('SPIKE PDF SAVED');
+System.debug('CV Id:    ' + saved.Id);
+System.debug('Doc Id:   ' + saved.ContentDocumentId);
+System.debug('PDF size: ' + pdf.size() + ' bytes');
+System.debug('URL:      /sfc/servlet.shepherd/version/download/' + saved.Id);
+System.debug(
+    'Or open:  ' +
+        URL.getOrgDomainURL().toExternalForm() +
+        '/lightning/r/ContentDocument/' +
+        saved.ContentDocumentId +
+        '/view'
+);

--- a/scripts/spike-117-svg-via-cv-url.apex
+++ b/scripts/spike-117-svg-via-cv-url.apex
@@ -1,0 +1,70 @@
+// #117 spike round 3 — SVG as CV referenced by relative URL.
+// Dave's insight: images render via URL in Blob.toPdf (the existing {%ImageField}
+// path). So persist the SVG as a ContentVersion with the svg MIME type and
+// reference its /sfc/servlet.shepherd/version/download/<cvId> URL in the HTML
+// like any other image. This sidesteps the inline-<svg> drop AND the iffy
+// data-URI path.
+
+String svg =
+    '<svg xmlns="http://www.w3.org/2000/svg" width="500" height="120">' +
+    '<rect x="0" y="0" width="500" height="120" fill="#fef3c7" stroke="#92400e" stroke-width="2"/>' +
+    '<rect x="20" y="40" width="200" height="40" fill="#3b82f6"/>' +
+    '<text x="120" y="65" font-family="Arial" font-size="20" fill="#fff" text-anchor="middle">BAR</text>' +
+    '<circle cx="320" cy="60" r="30" fill="#10b981"/>' +
+    '<text x="380" y="65" font-family="Arial" font-size="16" fill="#000">URL-referenced SVG</text>' +
+    '</svg>';
+
+// Save the SVG bytes as a CV. PathOnClient = .svg so Salesforce sets the
+// FileType / ContentType correctly. (FileExtension is derived from PathOnClient.)
+ContentVersion svgCv = new ContentVersion(
+    Title = 'spike-117-svg-asset-' + System.now().getTime(),
+    PathOnClient = 'chart.svg',
+    VersionData = Blob.valueOf(svg),
+    IsMajorVersion = true
+);
+insert svgCv;
+ContentVersion svgSaved = [SELECT Id, FileExtension, FileType FROM ContentVersion WHERE Id = :svgCv.Id LIMIT 1];
+System.debug('SVG CV file type: ' + svgSaved.FileType + ' / ext: ' + svgSaved.FileExtension);
+
+String svgUrl = '/sfc/servlet.shepherd/version/download/' + svgSaved.Id;
+
+String html =
+    '<html><head><meta charset="utf-8"/><style>' +
+    '@page { size: letter; margin: 0.6in; }' +
+    'body { font-family: Arial, sans-serif; font-size: 11pt; }' +
+    '.box { border: 1px dashed #d1d5db; padding: 8pt; margin-bottom: 14pt; min-height: 130px; }' +
+    '</style></head><body>' +
+    '<h1>#117 spike round 3 — SVG via CV URL</h1>' +
+    '<p>If the SVG renders below, the URL-referenced approach works and the SVG ' +
+    'serializer for the chart epic can persist its output as a CV and reference it ' +
+    'the same way {%ImageField} already does.</p>' +
+    '<p>SVG CV URL: <code>' +
+    svgUrl +
+    '</code></p>' +
+    '<div class="box"><img src="' +
+    svgUrl +
+    '" width="500" height="120" alt="svg-via-url"/></div>' +
+    '</body></html>';
+
+Blob pdf = Blob.toPdf(html);
+
+ContentVersion pdfCv = new ContentVersion(
+    Title = 'spike-117-svg-via-cv-url-' + System.now().getTime(),
+    PathOnClient = 'spike-117-svg-via-cv-url.pdf',
+    VersionData = pdf,
+    IsMajorVersion = true
+);
+insert pdfCv;
+ContentVersion pdfSaved = [SELECT Id, ContentDocumentId FROM ContentVersion WHERE Id = :pdfCv.Id LIMIT 1];
+
+System.debug('=== Spike #117 round 3 ===');
+System.debug('PDF size: ' + pdf.size() + ' bytes');
+System.debug('SVG CV:   ' + svgSaved.Id);
+System.debug('PDF CV:   ' + pdfSaved.Id);
+System.debug(
+    'Open PDF: ' +
+        URL.getOrgDomainURL().toExternalForm() +
+        '/lightning/r/ContentDocument/' +
+        pdfSaved.ContentDocumentId +
+        '/view'
+);

--- a/scripts/spike-117-visual.apex
+++ b/scripts/spike-117-visual.apex
@@ -1,0 +1,71 @@
+// #117 spike — single PDF with three rendering paths for the same chart.
+// Open the resulting PDF in Salesforce to see which (if any) actually rendered.
+//
+// Path A — inline <svg>
+// Path B — <img src="data:image/svg+xml;base64,...">
+// Path C — <img src="data:image/png;base64,...">  (real 200x80 red PNG)
+
+String svg =
+    '<svg xmlns="http://www.w3.org/2000/svg" width="500" height="120">' +
+    '<rect x="0" y="0" width="500" height="120" fill="#fef3c7" stroke="#92400e" stroke-width="2"/>' +
+    '<rect x="20" y="40" width="200" height="40" fill="#3b82f6"/>' +
+    '<text x="120" y="65" font-family="Arial" font-size="20" fill="#fff" text-anchor="middle">BAR</text>' +
+    '<circle cx="320" cy="60" r="30" fill="#10b981"/>' +
+    '<text x="400" y="65" font-family="Arial" font-size="18" fill="#000">If you see this, SVG works.</text>' +
+    '</svg>';
+
+String b64Svg = EncodingUtil.base64Encode(Blob.valueOf(svg));
+
+// Solid red 100x50 PNG (visible, not 1x1 like before)
+String pngBytes =
+    'iVBORw0KGgoAAAANSUhEUgAAAGQAAAAyCAYAAACqNX6+AAAAGUlEQVR42mP8z8DwHwAFBQIAX' + 'fa1KAAAAABJRU5ErkJggg==';
+
+String html =
+    '<html><head><meta charset="utf-8"/><style>' +
+    '@page { size: letter; margin: 0.6in; }' +
+    'body { font-family: Arial, sans-serif; font-size: 11pt; }' +
+    'h2 { font-size: 14pt; margin: 18pt 0 4pt 0; color: #1e40af; }' +
+    '.label { color: #6b7280; font-size: 10pt; margin: 0 0 4pt 0; }' +
+    '.box { border: 1px dashed #d1d5db; padding: 8pt; margin-bottom: 14pt; min-height: 130px; }' +
+    '</style></head><body>' +
+    '<h1>#117 spike — Flying Saucer SVG rendering paths</h1>' +
+    '<p>Three rendering paths, same target chart. Whichever cell shows the colored bar + circle + text ' +
+    '"If you see this, SVG works." renders correctly. Empty boxes mean Flying Saucer dropped the content.</p>' +
+    '<h2>Path A — inline &lt;svg&gt;</h2>' +
+    '<p class="label">Expected to fail per round-1 spike (silent drop).</p>' +
+    '<div class="box">' +
+    svg +
+    '</div>' +
+    '<h2>Path B — &lt;img src="data:image/svg+xml;base64,..."&gt;</h2>' +
+    '<p class="label">Unknown — round-2 byte delta was suspicious.</p>' +
+    '<div class="box"><img src="data:image/svg+xml;base64,' +
+    b64Svg +
+    '" width="500" height="120" alt="svg-as-img"/></div>' +
+    '<h2>Path C — &lt;img src="data:image/png;base64,..."&gt; (control: 100x50 red PNG)</h2>' +
+    '<p class="label">Should render — confirms the data-URI image path works at all.</p>' +
+    '<div class="box"><img src="data:image/png;base64,' +
+    pngBytes +
+    '" width="100" height="50" alt="png-control"/></div>' +
+    '</body></html>';
+
+Blob pdf = Blob.toPdf(html);
+
+ContentVersion cv = new ContentVersion(
+    Title = 'spike-117-visual-' + System.now().getTime(),
+    PathOnClient = 'spike-117-visual.pdf',
+    VersionData = pdf,
+    IsMajorVersion = true
+);
+insert cv;
+ContentVersion saved = [SELECT Id, ContentDocumentId FROM ContentVersion WHERE Id = :cv.Id LIMIT 1];
+
+System.debug('=== Spike #117 visual ===');
+System.debug('PDF size: ' + pdf.size() + ' bytes');
+System.debug('CV Id:    ' + saved.Id);
+System.debug(
+    'Open:     ' +
+        URL.getOrgDomainURL().toExternalForm() +
+        '/lightning/r/ContentDocument/' +
+        saved.ContentDocumentId +
+        '/view'
+);


### PR DESCRIPTION
Release notes for v1.98.0 covering the five PRs that have already merged to main:

- #112 — Cross-org export/import binary asset carry-over (closes #100)
- #113 — Print-Ready Packet table styles (closes #109, community report from @sergiuBuru)
- #111 — JSON Data (from Flow) template data source (closes #110)
- #118 — Giant Query non-admin pre-decomp CV access (closes #114, reported by Greg Devine)
- #103 — Experience Cloud guest render path removal (-914 LOC across 17 files)

## What's in this PR

Two commits:
1. `chore(release): v1.98.0` — fleshes out CHANGELOG.md. `sfdx-project.json` versionName / versionNumber / ancestorId are already set to `1.98.0 — next` / `1.98.0.NEXT` / `04tVx000000SFovIAG`; no metadata bump needed.
2. `chore(spike): #117 SVG-in-PDF investigation scripts` — preserves the four-round spike that informs the #117 SVG serializer strategy. Spike scripts live under `scripts/spike-117-*.apex` for future re-runs (e.g., when Salesforce updates their hosted Flying Saucer with an SVG ReplacedElementFactory).

## Spike finding referenced in CHANGELOG and #116/#117

Flying Saucer's documented SVG support requires a `ReplacedElementFactory` plus SVGSalamander or Batik on the classpath. Salesforce's hosted `Blob.toPdf` evidently includes neither — inline `<svg>`, `<img src="data:image/svg+xml;…">`, and URL-referenced SVG all fail to rasterize. The image plumbing works (PNG data URIs render); SVG specifically is silently unrendered. So the SVG serializer for the chart epic covers 4 of 5 outputs (DOCX / PPTX / XLSX via Office 2016+, HTML via inline `<svg>`); PDF stays on the existing HTML+CSS bar path.

## Test plan

- [x] Release validation matrix on `portwood-staging`:
  - `npm run format:check` — clean
  - E2E suite 11 scripts — 223 / 223 PASS
  - Apex local tests 1362 — 100% pass, org-wide coverage 75%
  - Code Analyzer (Security + AppExchange) — 0 High, 38 Moderate (baseline)
- [ ] Reviewer: spot-check the CHANGELOG framing
- [ ] After merge: `sf package version create` (separate authorization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)