### PR TITLE
fix(v1.98): restore deleted guest-render Apex as no-op stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,8 +100,6 @@ Net **-914 LOC across 17 files**. Removes the unauthenticated guest-context docu
 
 #### Removed (full deletion)
 
-- `DocGenGuestRenderQueueable.cls` and its test class
-- `DocGenGuestRenderTrigger.trigger` (platform-event consumer)
 - `DocGenController.isCurrentUserGuest()`, `getSiteUrlPathPrefix()`, `queueGuestRender()`, `getGuestRenderStatus()`, and the `GuestRenderHelper` inner class
 - `docGenRunner.js` guest imports, `_isGuest` field, `wiredIsGuest` callback, `_generateGuestPdf()` method, and the guest branch in the generate flow
 - `docGenRunner` guest-context exemption in `allowedOutputModes` mobile restriction
@@ -110,8 +108,13 @@ Net **-914 LOC across 17 files**. Removes the unauthenticated guest-context docu
 
 #### Stubbed (preserved as empty shells for subscriber upgrade compatibility)
 
-- `DocGen_Guest_Render__e` platform event — metadata retained; description marked deprecated. 2GP packages can't cleanly delete published events; the shell is benign (no publishers or subscribers remain in code).
+Five components retained as no-op stubs because 2GP managed packages cannot drop Apex classes, triggers, or published platform events without explicit Remove Metadata Components feature access from Salesforce Partner Community. All five are functionally inert — no publishers, no callers — and will be removed in a future release once that feature is granted.
+
+- `DocGen_Guest_Render__e` platform event — metadata retained; description marked deprecated.
 - `DocGen_Guest_Runner.permissionset` — all class/object/field access stripped; description marked deprecated; label renamed "(deprecated)". Safe to leave assigned or unassign from site guest users. `e2e-01-permissions.apex` updated to assert the stub state (0 class grants, 0 object grants) so a future regression that re-adds them fails loudly.
+- `DocGenGuestRenderQueueable.cls` — empty `execute()` method; deprecation comment in the class header.
+- `DocGenGuestRenderQueueableTest.cls` — single test that enqueues the stub to keep its coverage non-zero.
+- `DocGenGuestRenderTrigger.trigger` — empty handler on `DocGen_Guest_Render__e(after insert)`.
 
 #### Updated
 

--- a/force-app/main/default/classes/DocGenGuestRenderQueueable.cls
+++ b/force-app/main/default/classes/DocGenGuestRenderQueueable.cls
@@ -1,0 +1,15 @@
+/**
+ * Deprecated as of v1.98.0 — the Experience Cloud guest render path was
+ * removed. This class is preserved as an inert stub because 2GP managed
+ * packages cannot drop Apex classes without explicit "Remove Metadata
+ * Components" feature access from Salesforce Partner Community.
+ *
+ * No publishers, callers, or trigger handlers remain in the codebase. The
+ * class is unreachable at runtime. The stub will be removed in a future
+ * release once Remove Metadata Components is granted on the DevHub.
+ */
+public without sharing class DocGenGuestRenderQueueable implements Queueable { // NOPMD AvoidPublicWithoutSharing — deprecated no-op
+    public void execute(QueueableContext ctx) {
+        // No-op — see class comment.
+    }
+}

--- a/force-app/main/default/classes/DocGenGuestRenderQueueable.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenGuestRenderQueueable.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenGuestRenderQueueableTest.cls
+++ b/force-app/main/default/classes/DocGenGuestRenderQueueableTest.cls
@@ -1,0 +1,16 @@
+/**
+ * Coverage for the deprecated DocGenGuestRenderQueueable stub. The stub itself
+ * is a no-op retained for 2GP packaging compatibility (see that class for the
+ * fuller context); this test exists only to keep the class coverage non-zero
+ * until both can be removed via Remove Metadata Components feature access.
+ */
+@IsTest
+private class DocGenGuestRenderQueueableTest {
+    @IsTest
+    static void deprecatedStubEnqueuesWithoutEffect() {
+        Test.startTest();
+        System.enqueueJob(new DocGenGuestRenderQueueable());
+        Test.stopTest();
+        System.assert(true, 'Deprecated queueable stub enqueued without error');
+    }
+}

--- a/force-app/main/default/classes/DocGenGuestRenderQueueableTest.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenGuestRenderQueueableTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/triggers/DocGenGuestRenderTrigger.trigger
+++ b/force-app/main/default/triggers/DocGenGuestRenderTrigger.trigger
@@ -1,0 +1,10 @@
+/**
+ * Deprecated as of v1.98.0 — the Experience Cloud guest render path was
+ * removed. Empty handler retained for 2GP packaging compatibility (triggers
+ * are subject to the same Remove Metadata Components restriction as classes
+ * for managed packages). No publishers exist for DocGen_Guest_Render__e, so
+ * this trigger never fires at runtime.
+ */
+trigger DocGenGuestRenderTrigger on DocGen_Guest_Render__e(after insert) {
+    // No-op — see trigger comment.
+}

--- a/force-app/main/default/triggers/DocGenGuestRenderTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/DocGenGuestRenderTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexTrigger>


### PR DESCRIPTION
Restores DocGenGuestRenderQueueable, DocGenGuestRenderQueueableTest, and DocGenGuestRenderTrigger as no-op stubs after `sf package version create` for v1.98 failed with:

> Can't create package version. Before you can remove metadata components from a second-generation managed package, you must first request access to this feature by logging a case in the Salesforce Partner Community.

2GP managed packages can't drop Apex classes / triggers / published platform events without the **Remove Metadata Components** feature granted on the DevHub. PR #103 already used the stub approach for the platform event and permset; this PR extends the same treatment to the three components the deletion attempt forced our hand on.

## What's in this PR

- Three .cls/.trigger files + their meta-xml restored as functionally-inert stubs (each with a deprecation comment explaining the 2GP constraint)
- One test method to keep DocGenGuestRenderQueueable coverage non-zero
- CHANGELOG.md updated — three components moved from "Removed" to "Stubbed" with the new rationale

## Why this is safe

PR #103 removed every publisher of `DocGen_Guest_Render__e` and every caller of `DocGenGuestRenderQueueable`. The trigger never fires, the queueable is unreachable. The stubs are dead weight that costs nothing at runtime.

## Test plan

- [x] `npm run format:check` — clean
- [x] Deployed three stub files to `portwood-staging` — Succeeded
- [x] `DocGenGuestRenderQueueableTest.deprecatedStubEnqueuesWithoutEffect` — PASS
- [ ] After merge: re-run `sf package version create` (was the blocker)

## Follow-up

File a Salesforce Partner Community case to enable Remove Metadata Components on the DevHub. Once granted, a future release can clean-delete these stubs (likely as part of v2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)