### PR TITLE
fix: enable Translation Workbench in scratch def (unblocks i18n package build)

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,15 +1,20 @@
 {
-  "orgName": "DocGen Signatures Dev",
-  "edition": "developer",
-  "features": ["EnableSetPasswordInApi", "Sites"],
-  "settings": {
-    "lightningExperienceSettings": {
-      "enableS1DesktopEnabled": true
-    },
-    "securitySettings": {
-      "sessionSettings": {
-        "forceRelogin": false
-      }
+    "orgName": "DocGen Signatures Dev",
+    "edition": "developer",
+    "features": ["EnableSetPasswordInApi", "Sites"],
+    "settings": {
+        "languageSettings": {
+            "enableTranslationWorkbench": true,
+            "enableEndUserLanguages": true,
+            "enablePlatformLanguages": true
+        },
+        "lightningExperienceSettings": {
+            "enableS1DesktopEnabled": true
+        },
+        "securitySettings": {
+            "sessionSettings": {
+                "forceRelogin": false
+            }
+        }
     }
-  }
 }


### PR DESCRIPTION
Enables `languageSettings` (Translation Workbench + platform + end-user languages) in `config/project-scratch-def.json`.

## Why
The runner translations from #126/#127 only deploy to an org that has the language enabled. `sf package version create` deploys source into a temporary scratch build org based on this definition — so without these flags the next package build fails with *"Not available for deploy for this organization"* ([forcedotcom/cli#1272](https://github.com/forcedotcom/cli/issues/1272)).

## Effect
- Future scratch orgs + package build orgs accept all platform/end-user translations → i18n builds succeed.
- No runtime/app behavior change. Subscriber orgs are unaffected (English base labels always render; a translation simply applies only where that language is enabled, else falls back to English).

🤖 Generated with [Claude Code](https://claude.com/claude-code)