### PR TITLE
fix: call the chart engine for PowerPoint templates (PPTX charts)

### DIFF
--- a/force-app/main/default/classes/DocGenChartImageController.cls
+++ b/force-app/main/default/classes/DocGenChartImageController.cls
@@ -88,11 +88,14 @@ public with sharing class DocGenChartImageController {
         }
         DocGen_Template__c template = templates[0];
 
-        if (template.Type__c != 'Word' && template.Type__c != 'HTML') {
+        // Word, HTML, and PowerPoint all flow through the PNG-via-CV pipeline.
+        // PowerPoint scans its slide XML for chart tags; the merge-time expander
+        // + postProcessPowerPointSlides embed the resulting PNG as a <p:pic>. (#116/PPTX)
+        if (template.Type__c != 'Word' && template.Type__c != 'HTML' && template.Type__c != 'PowerPoint') {
             return new List<ChartImageRequest>();
         }
 
-        String body = template.Type__c == 'HTML' ? loadActiveHtmlBody(templateId) : loadActiveWordBody(templateId);
+        String body = loadActiveBody(template.Type__c, templateId);
         if (String.isBlank(body) || !body.contains(CHART_OPEN_PREFIX)) {
             return new List<ChartImageRequest>();
         }
@@ -163,15 +166,13 @@ public with sharing class DocGenChartImageController {
         DocGen_Template__c template = templates[0];
 
         Map<String, String> chartCvMap = new Map<String, String>();
-        // Word AND HTML templates both flow through the PNG-via-CV pipeline.
-        // PowerPoint/Excel use their own embedding helpers in DocGenService;
-        // they're routed via Apex callers that pass templateType explicitly,
-        // not through this LWC entry point.
-        if (template.Type__c != 'Word' && template.Type__c != 'HTML') {
+        // Word, HTML, and PowerPoint flow through the PNG-via-CV pipeline.
+        // Excel embedding is not wired on this path yet.
+        if (template.Type__c != 'Word' && template.Type__c != 'HTML' && template.Type__c != 'PowerPoint') {
             return chartCvMap;
         }
 
-        String body = template.Type__c == 'HTML' ? loadActiveHtmlBody(templateId) : loadActiveWordBody(templateId);
+        String body = loadActiveBody(template.Type__c, templateId);
         if (String.isBlank(body) || !body.contains(CHART_OPEN_PREFIX)) {
             return chartCvMap;
         }
@@ -332,6 +333,67 @@ public with sharing class DocGenChartImageController {
     // =====================================================================
     // Internals
     // =====================================================================
+
+    /**
+     * Dispatches to the right active-version body loader for chart-tag scanning,
+     * so prepareChartImages / prepareChartImagesServerSide see the same body text
+     * the merge engine processes. HTML → raw template HTML; PowerPoint → all slide
+     * XML concatenated; everything else (Word) → word/document.xml.
+     */
+    private static String loadActiveBody(String templateType, Id templateId) {
+        if (templateType == 'HTML') {
+            return loadActiveHtmlBody(templateId);
+        }
+        if (templateType == 'PowerPoint') {
+            return loadActivePptxBody(templateId);
+        }
+        return loadActiveWordBody(templateId);
+    }
+
+    /**
+     * PowerPoint body loader — concatenates every pre-decomposed slide part
+     * (docgen_tmpl_xml_<versionId>_ppt__slides__slideN.xml) so findTopLevelChartTags
+     * can locate {Chart:...} tags across all slides. Mirrors loadActiveWordBody;
+     * the merge-time expander in processXml de-fragments <a:t> runs and recomputes
+     * the same signature, so contiguous tags match the CV uploaded here. (PPTX charts)
+     */
+    private static String loadActivePptxBody(Id templateId) {
+        DocGenFlsGuard.assertAccessible(
+            DocGen_Template_Version__c.sObjectType,
+            new Set<String>{ 'Template__c', 'Is_Active__c' }
+        );
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<DocGen_Template_Version__c> vs = [
+            SELECT Id
+            FROM DocGen_Template_Version__c
+            WHERE Template__c = :templateId AND Is_Active__c = TRUE
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (vs.isEmpty()) {
+            return null;
+        }
+        // ppt/slides/slide1.xml → docgen_tmpl_xml_<vid>_ppt__slides__slide1.xml
+        // (the '/' → '__' encoding from DocGenService pre-decomposition).
+        String slidePrefix = 'docgen_tmpl_xml_' + vs[0].Id + '_ppt__slides__slide';
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<ContentVersion> cvs = [
+            SELECT VersionData
+            FROM ContentVersion
+            WHERE Title LIKE :(slidePrefix + '%') AND IsLatest = TRUE
+            WITH USER_MODE
+        ];
+        if (cvs.isEmpty()) {
+            return null;
+        }
+        String body = '';
+        for (ContentVersion cv : cvs) {
+            if (cv.VersionData != null) {
+                body += cv.VersionData.toString();
+            }
+        }
+        return body;
+    }
 
     private static String loadActiveWordBody(Id templateId) {
         DocGenFlsGuard.assertAccessible(

--- a/force-app/main/default/classes/DocGenChartImageControllerTest.cls
+++ b/force-app/main/default/classes/DocGenChartImageControllerTest.cls
@@ -217,6 +217,64 @@ private class DocGenChartImageControllerTest {
     }
 
     @IsTest
+    static void prepareChartImages_powerPointTemplateWithChartTag_emitsRequest() {
+        // PPTX charts (#116 follow-up): prepareChartImages must scan PowerPoint
+        // slide XML, not just word/document.xml. Two slides are pre-decomposed;
+        // the chart tag lives on slide 2, so this also proves loadActivePptxBody
+        // concatenates ALL slide parts (a single-slide test wouldn't).
+        Account acc = new Account(Name = 'Chart Pipeline PPTX Test');
+        insert acc;
+        DocGen_Template__c tpl = new DocGen_Template__c(
+            Name = 'Chart Pipeline PPTX Tpl',
+            Base_Object_API__c = 'Account',
+            Type__c = 'PowerPoint',
+            Query_Config__c = 'Name'
+        );
+        Database.insert(tpl, AccessLevel.SYSTEM_MODE);
+        DocGen_Template_Version__c ver = new DocGen_Template_Version__c(Template__c = tpl.Id, Is_Active__c = true);
+        Database.insert(ver, AccessLevel.SYSTEM_MODE);
+
+        String slide1 =
+            '<?xml version="1.0" encoding="UTF-8"?>' +
+            '<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"' +
+            ' xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">' +
+            '<p:cSld><p:spTree><a:p><a:r><a:t>Title slide, no chart</a:t></a:r></a:p></p:spTree></p:cSld></p:sld>';
+        String slide2 =
+            '<?xml version="1.0" encoding="UTF-8"?>' +
+            '<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"' +
+            ' xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">' +
+            '<p:cSld><p:spTree><a:p><a:r>' +
+            '<a:t>{Chart:Survey_Responses__r:A__c:bar:title=Demo}</a:t>' +
+            '</a:r></a:p></p:spTree></p:cSld></p:sld>';
+        insert new List<ContentVersion>{
+            new ContentVersion(
+                Title = 'docgen_tmpl_xml_' + ver.Id + '_ppt__slides__slide1.xml',
+                PathOnClient = 'slide1.xml',
+                VersionData = Blob.valueOf(slide1)
+            ),
+            new ContentVersion(
+                Title = 'docgen_tmpl_xml_' + ver.Id + '_ppt__slides__slide2.xml',
+                PathOnClient = 'slide2.xml',
+                VersionData = Blob.valueOf(slide2)
+            )
+        };
+
+        Test.startTest();
+        List<DocGenChartImageController.ChartImageRequest> reqs = DocGenChartImageController.prepareChartImages(
+            tpl.Id,
+            acc.Id
+        );
+        Test.stopTest();
+
+        System.assertNotEquals(null, reqs);
+        System.assertEquals(1, reqs.size(), 'Chart tag on slide 2 should produce one request.');
+        DocGenChartImageController.ChartImageRequest r = reqs[0];
+        System.assertEquals(16, r.signature.length(), 'Signature is 16 hex chars.');
+        System.assert(String.isNotBlank(r.svgString) && r.svgString.contains('<svg'), 'SVG should be well-formed.');
+        System.assert(r.width > 0 && r.height > 0, 'Dimensions should be positive.');
+    }
+
+    @IsTest
     static void prepareChartImages_wordTemplate_chartInLoopBodySkipped() {
         // Charts inside loop bodies are intentionally skipped — their bucket
         // data depends on the loop iteration item, which isn't in scope at

--- a/force-app/main/default/lwc/docGenRunner/docGenRunner.js
+++ b/force-app/main/default/lwc/docGenRunner/docGenRunner.js
@@ -684,10 +684,10 @@ export default class DocGenRunner extends NavigationMixin(LightningElement) {
                 this.showToast('Info', 'Generating document...', 'info');
                 await this._generateOfficeClientSide(saveToRecord, ext, 'application/octet-stream');
             } else {
-                // PowerPoint — server-side. Chart prep runs but PPTX chart
-                // embed is task #10 (deferred); the merge will text-fallback
-                // chart tags until that lands. Wiring it consistently now so
-                // the runner doesn't need re-plumbing later.
+                // PowerPoint — server-side merge. Chart prep rasterizes each
+                // {Chart:...} to a PNG CV (prepareChartImages now scans PPTX
+                // slide XML); the merge substitutes the marker and
+                // postProcessPowerPointSlides embeds it as a real <p:pic>.
                 const chartContext = await this._prepareCharts();
                 let result;
                 try {

--- a/scripts/e2e-07-syntax4.apex
+++ b/scripts/e2e-07-syntax4.apex
@@ -279,6 +279,28 @@ try {
     System.debug('CHART PIPELINE WORD SUBSTITUTION: FAIL — ' + e.getMessage());
 }
 
+// PowerPoint routes through the same PNG-via-CV branch as Word (PPTX charts).
+try {
+    Map<String, String> opts = new Map<String, String>();
+    String sig = DocGenChartImageController.tagSignature('R__r', 'F__c', 'bar', opts);
+    String fakeCvId = '0681x00000000000002';
+    Map<String, String> chartCvMap = new Map<String, String>{ sig => fakeCvId };
+    Map<String, Object> data = new Map<String, Object>();
+    String out = DocGenChartTagExpander.expand('{Chart:R__r:F__c:bar}', 'PowerPoint', data, chartCvMap);
+    Boolean tagOk = out.contains('{%__dgchart_' + fakeCvId + '}');
+    Boolean dataSeeded = data.get('__dgchart_' + fakeCvId) == fakeCvId;
+    if (tagOk && dataSeeded) {
+        pass++;
+        System.debug('CHART PIPELINE PPTX SUBSTITUTION: PASS');
+    } else {
+        fail++;
+        System.debug('CHART PIPELINE PPTX SUBSTITUTION: FAIL — tagOk=' + tagOk + ' dataSeeded=' + dataSeeded);
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('CHART PIPELINE PPTX SUBSTITUTION: FAIL — ' + e.getMessage());
+}
+
 // ============================================================
 // #115 — merge errors name the tag + show a snippet
 // ============================================================


### PR DESCRIPTION
Fixes the gap @davemoudy caught: PowerPoint chart tags rendered as `[Chart: title]` text because the chart **prep** path was gated to Word/HTML — even though the PPTX **embed** path (`postProcessPowerPointSlides` → `<p:pic>`) was already built.

## Change
- Un-gate `PowerPoint` in `prepareChartImages` + `prepareChartImagesServerSide`.
- New `loadActivePptxBody()` — concatenates pre-decomposed `…_ppt__slides__slideN.xml` parts so `findTopLevelChartTags` scans all slides; `loadActiveBody()` dispatcher.
- Signature parity is automatic (both prep and the expander call `tagSignature`).
- Refresh the stale runner PPTX comment.

## Verified end-to-end on staging
Generated the **Chart Showcase (PowerPoint)** template from a Survey record via the runner (browser-rasterized). The downloaded .pptx contains **6 charts embedded as real `<p:pic>` PNGs** (slides 4–9; `ppt/media/docgen_image_*.png`) — **was 0** before this fix (all text).

## Known limitation (follow-up: https://github.com/Portwood-Global-Solutions/DocGen/issues/130)
Charts whose tag text is split across runs (author applied a font) aren't found by the prep scan and still text-fall-back — same pre-existing limitation Word has (slides 2–3 in the showcase). Author workaround: clear formatting on the tag.

## Server-side note
The pure-Apex `prepareChartImagesServerSide` (Flow/batch) rasterizes ~5.5s/chart; a multi-chart deck exceeds the 10s sync CPU limit. The runner path rasterizes in the **browser**, so it's unaffected. Server-side multi-chart batching is a separate concern.

## Tests
- New `prepareChartImages_powerPointTemplateWithChartTag_emitsRequest` (chart on slide 2 → also proves multi-slide concatenation).
- e2e-07-syntax4 PPTX substitution assertion.
- RunLocalTests green (lone UNABLE_TO_LOCK_ROW was live-e2e concurrency; passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)