### PR TITLE
chore(release): v2.4.0 — multi-language runner + PowerPoint charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## v2.4.0 — Multi-language runner + PowerPoint charts (`04tVx000000ZyanIAC`, build `2.4.0-2`, promoted 2026-05-25)
+
+Feature release. Brings the document runner UI to 10 languages, fixes PowerPoint chart rendering, and adds location-aware template error messages. 100% native — no external services or callouts.
+
+### Runner internationalization (#95, #126)
+
+The `docGenRunner` UI was hardcoded English. Extracted the user-facing strings into 12 **Custom Labels** (`DocGenRunner_*`) referenced via `@salesforce/label/c.*`, so the interface follows each user's Salesforce Language automatically — no custom picker, no org-wide override. Shipped translations for **10 languages**: Spanish (`es`), Japanese (`ja`), Chinese Simplified/Traditional (`zh_CN`/`zh_TW`), French (`fr`), German (`de`), Portuguese-Brazil (`pt_BR`), Italian (`it`), Korean (`ko`), Dutch (`nl_NL`). Each `translations/<locale>.translation-meta.xml` translates all 12 labels. Adding a language = one more translation file. `docGenBulkRunner` / `docGenAdmin` string extraction is queued as a follow-up.
+
+**Packaging prerequisite:** each language must be enabled under Setup → Translation Language Settings in the build org for the translations to deploy/package. `config/project-scratch-def.json` now sets `enableTranslationWorkbench` / `enableEndUserLanguages` / `enablePlatformLanguages` (#128) so scratch + build orgs accept them.
+
+### PowerPoint charts (#131)
+
+`{Chart:...}` tags in PowerPoint templates rendered as `[Chart: title]` text because `DocGenChartImageController.prepareChartImages` / `prepareChartImagesServerSide` hard-returned empty for any non-Word/HTML type — even though the embed side (`postProcessPowerPointSlides` → `<p:pic>`) was already complete. Un-gated `PowerPoint` and added `loadActivePptxBody()` (concatenates the pre-decomposed `…_ppt__slides__slideN.xml` parts so `findTopLevelChartTags` scans all slides). Verified end-to-end on staging: the Chart Showcase deck embeds charts as real `<p:pic>` PNGs. Known limitation (shared with Word, #130): chart tags whose text is split across runs by character formatting still text-fall-back.
+
+### Template error messages (#115)
+
+`DocGenService.processXml` now enriches the three author-facing merge errors (missing `}`, unclosed loop `{#X}`, unclosed inverse `{^X}`) with the offending tag text, a surrounding snippet, and an HTML source line number, plus a try/catch that names the tag on any resolution failure (e.g. a null relationship walk). `HeapPressureException` is re-thrown ahead of the generic catch so the giant-query fallback signal is preserved.
+
+### Release validation (staging-v240, fresh scratch from the TWB-enabled def)
+
+| Check                     | Result                                   |
+| ------------------------- | ---------------------------------------- |
+| e2e-01 … e2e-08           | all PASS / FAIL 0                        |
+| RunLocalTests             | 1415 methods, 0 failures; org-wide 76%   |
+| `sf code-analyzer` (S+AE) | 0 violations (45 suppressed — known FPs) |
+
+### Customer impact
+
+Spanish/Japanese/Chinese/etc. users now see the runner in their own language. PowerPoint chart templates render real charts instead of placeholder text. Template authors get errors that point to where in the template the problem is.
+
 ## v2.3.0 — Guest-aware FLS reads (`04tVx000000ZxDJIA0`, build `2.3.0-1`, promoted 2026-05-23)
 
 Hotfix completing the v2.2.0 fix. v2.2.0 added `DocGenFlsGuard.guestAssertCreateable / guestAssertUpdateable / guestAssertAccessible` and swapped the 18 admin-context **write** guards in `DocGenSignatureController.cls` to the guest variants. But the **read** guards (`DocGenFlsGuard.assertAccessible`) were left as admin variants — and those throw the same way on guest context, just with the per-field FLS describe verdict on the SOQL select-list. Customers hit:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 
 [Join the Community Channel](https://portwood.dev/community) | [Website](https://portwood.dev) | [Roadmap](https://portwood.dev/changelog)
 
-[![Version](https://img.shields.io/badge/version-2.3.0-blue.svg)](#install)
+[![Version](https://img.shields.io/badge/version-2.4.0-blue.svg)](#install)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Salesforce-00A1E0.svg)](https://www.salesforce.com)
 [![Namespace](https://img.shields.io/badge/namespace-portwoodglobal-purple.svg)](#install)
@@ -440,7 +440,8 @@ Found a vulnerability? See [SECURITY.md](SECURITY.md).
 
 | Version | Channel                                 | Package ID           |
 | ------- | --------------------------------------- | -------------------- |
-| v2.3.0  | **Latest (Released)**                   | `04tVx000000ZxDJIA0` |
+| v2.4.0  | **Latest (Released)**                   | `04tVx000000ZyanIAC` |
+| v2.3.0  | Previous                                | `04tVx000000ZxDJIA0` |
 | v2.2.0  | Previous                                | `04tVx000000ZxBhIAK` |
 | v2.1.0  | Previous                                | `04tVx000000Zw5xIAC` |
 | v2.0.0  | Previous                                | `04tVx000000ZqBpIAK` |

--- a/config/build-def.json
+++ b/config/build-def.json
@@ -1,0 +1,10 @@
+{
+    "orgName": "DocGen Package Build",
+    "settings": {
+        "languageSettings": {
+            "enableTranslationWorkbench": true,
+            "enableEndUserLanguages": true,
+            "enablePlatformLanguages": true
+        }
+    }
+}

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,13 +1,14 @@
 {
   "packageDirectories": [
     {
-      "versionName": "2.3.0 — Guest-Aware FLS Reads (verifier + signing read paths)",
-      "versionNumber": "2.3.0.NEXT",
-      "ancestorId": "04tVx000000ZxBhIAK",
+      "versionName": "2.4.0 — Multi-language runner + PowerPoint charts",
+      "versionNumber": "2.4.0.NEXT",
+      "ancestorId": "04tVx000000ZxDJIA0",
       "path": "force-app",
       "default": true,
+      "definitionFile": "config/build-def.json",
       "package": "Portwood DocGen Managed",
-      "versionDescription": "Portwood DocGen is a native Salesforce document generation engine. Build Word and PDF documents from any Salesforce record using merge tags in your own templates. Includes a visual query builder, bulk generation, multi-object support, electronic signatures, and Flow integration — all without leaving Salesforce. v2.3 completes the v2.2 signature flow fix — guest signers and the public document verifier now work end-to-end."
+      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v2.4 brings the document runner to 10 languages (Spanish, Japanese, Chinese, French, German, Portuguese, Italian, Korean, and Dutch): each user sees the interface in their own Salesforce language automatically. Charts now render natively in PowerPoint output as well, alongside Word, PDF, Excel, and HTML. Template authors also get clearer, location-aware error messages when building templates. Free for all users."
     }
   ],
   "name": "Portwood DocGen",
@@ -150,6 +151,7 @@
     "Portwood DocGen Managed@2.0.0-2": "04tVx000000ZqBpIAK",
     "Portwood DocGen Managed@2.1.0-1": "04tVx000000Zw5xIAC",
     "Portwood DocGen Managed@2.2.0-2": "04tVx000000ZxBhIAK",
-    "Portwood DocGen Managed@2.3.0-1": "04tVx000000ZxDJIA0"
+    "Portwood DocGen Managed@2.3.0-1": "04tVx000000ZxDJIA0",
+    "Portwood DocGen Managed@2.4.0-2": "04tVx000000ZyanIAC"
   }
 }


### PR DESCRIPTION
Release prep for **v2.4.0**. Package version **2.4.0-2** (`04tVx000000ZyanIAC`) is built and validated — **pending promote** (awaiting go-ahead).

## What ships
- **Runner i18n** — 10 languages (es/ja/zh_CN/zh_TW/fr/de/pt_BR/it/ko/nl), native per-user (#95, #126)
- **PowerPoint charts** now render as real images (#131)
- **Location-aware template error messages** (#115)

## Validation (staging-v240 — fresh scratch from the TWB-enabled def)
- ✅ e2e-01…08 — all PASS / FAIL 0
- ✅ RunLocalTests — 1415 methods, **0 failures**, org-wide coverage **76%**
- ✅ `sf code-analyzer` (Security + AppExchange) — 0 violations (45 suppressed FPs)

## Build-org translations fix (the notable infra change)
The 10 translations require Translation Workbench in the build org. The Dev Hub captures an **org shape** for builds, so a def *with* `edition` collides ("edition cannot be specified when copying an org's shape"). Fix: `config/build-def.json` adds `languageSettings` with **no** `edition` (the shape supplies it), wired via `packageDirectory.definitionFile`. Build succeeded with this in place.

## Not done in this PR (deliberate)
- **Promote** — held for explicit go-ahead (irreversible). On go-ahead: `sf package version promote 04tVx000000ZyanIAC`, then merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)