### PR TITLE
fix(#134): giant-query drops template chrome — snapshot read was USER_MODE

### DIFF
--- a/force-app/main/default/classes/DocGenGiantQueryAssembler.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryAssembler.cls
@@ -264,11 +264,21 @@ public with sharing class DocGenGiantQueryAssembler implements Queueable {
         String html = null;
         if (!vers.isEmpty()) {
             String htmlTitle = 'docgen_tmpl_html_' + vers[0].Id;
+            // SYSTEM_MODE per #114: docgen_tmpl_html_ is an internal package snapshot
+            // CV whose ContentDocumentLink defaults to Visibility=InternalUsers, so
+            // WITH USER_MODE returns empty even though the record exists. That empty
+            // result silently routed the giant-query path to its bare-table fallback,
+            // dropping the template's title/column-headers/footer (the >2000-row
+            // regression). User access is already gated by the active-version query
+            // above; this is the FLS-guard + SYSTEM_MODE hybrid used everywhere else in
+            // this class (see line ~381) and in DocGenController (the analogous read).
+            DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'VersionData' });
+            /* code-analyzer-suppress ApexFlsViolation */
             List<ContentVersion> htmlCvs = [
                 SELECT VersionData
                 FROM ContentVersion
                 WHERE Title = :htmlTitle
-                WITH USER_MODE
+                WITH SYSTEM_MODE
                 LIMIT 1
             ];
             if (!htmlCvs.isEmpty()) {

--- a/force-app/main/default/classes/DocGenGiantQueryTest.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryTest.cls
@@ -264,6 +264,88 @@ private class DocGenGiantQueryTest {
         }
     }
 
+    /**
+     * Regression guard (P1 #134): when a docgen_tmpl_html_ snapshot exists, the
+     * giant-query assembler must build the document AROUND it — preserving the
+     * template's title / column headers / footer — not fall back to the bare
+     * Query_Config table. The production bug was the snapshot read using
+     * WITH USER_MODE (invisible for InternalUsers-visibility package CVs), which
+     * silently took the bare-table branch and dropped all chrome.
+     *
+     * NOTE: test-context USER_MODE is lenient (the running user owns the test CV),
+     * so this asserts the chrome-preservation PATH rather than isolating the
+     * USER_MODE→SYSTEM_MODE access change (which only manifests with InternalUsers
+     * CDL visibility — covered by the customer-template reproduction).
+     */
+    @IsTest
+    static void testGiantQuerySnapshotChromePreserved() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            DocGen_Template__c tpl = [SELECT Id FROM DocGen_Template__c WHERE Name = 'Giant Query Test' LIMIT 1];
+            DocGen_Template_Version__c ver = [
+                SELECT Id
+                FROM DocGen_Template_Version__c
+                WHERE Template__c = :tpl.Id AND Is_Active__c = TRUE
+                LIMIT 1
+            ];
+
+            // Snapshot the template HTML with recognizable chrome wrapping the loop.
+            String snapshotHtml =
+                '<html><body>' +
+                '<h1>GQ_CHROME_TITLE</h1>' +
+                '<table>' +
+                '<tr><th>GQ_CHROME_HEADER</th></tr>' +
+                '<tr>{#Contacts}<td>{FirstName}</td>{/Contacts}</tr>' +
+                '</table>' +
+                '<p>GQ_CHROME_FOOTER</p>' +
+                '</body></html>';
+            insert new ContentVersion(
+                Title = 'docgen_tmpl_html_' + ver.Id,
+                PathOnClient = 'snapshot.html',
+                VersionData = Blob.valueOf(snapshotHtml),
+                IsMajorVersion = false
+            );
+
+            DocGen_Job__c job = new DocGen_Job__c(
+                Template__c = tpl.Id,
+                Status__c = 'Harvesting',
+                Parent_Record_Id__c = String.valueOf(acc.Id)
+            );
+            Database.insert(job, AccessLevel.SYSTEM_MODE);
+
+            // Run the assembler directly with one pre-rendered row fragment (mirrors
+            // testAssemblerParentFieldFormatting) so we can assert on the assembled
+            // HTML without going through the batch's Blob.toPdf path.
+            DocGenGiantQueryAssembler assembler = new DocGenGiantQueryAssembler(job.Id, tpl.Id, acc.Id, 'Contacts');
+            String prefix = 'docgen_giant_' + job.Id + '_';
+            insert new ContentVersion(
+                Title = prefix + '00001',
+                PathOnClient = prefix + '00001.html',
+                VersionData = Blob.valueOf('<tr><td>Row0</td></tr>')
+            );
+
+            Test.startTest();
+            System.enqueueJob(assembler);
+            Test.stopTest();
+
+            List<ContentVersion> debug = [
+                SELECT VersionData
+                FROM ContentVersion
+                WHERE Title = :(prefix + 'debug_html')
+                LIMIT 1
+            ];
+            System.assert(!debug.isEmpty(), 'Assembler should have produced debug HTML');
+            String assembled = debug[0].VersionData.toString();
+            System.assert(
+                assembled.contains('GQ_CHROME_TITLE'),
+                'Title chrome must survive (snapshot used, not bare-table fallback). Got: ' + assembled.abbreviate(400)
+            );
+            System.assert(assembled.contains('GQ_CHROME_HEADER'), 'Column-header chrome must survive');
+            System.assert(assembled.contains('GQ_CHROME_FOOTER'), 'Footer chrome must survive');
+        }
+    }
+
     @IsTest
     static void testStitchJobExecution() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];


### PR DESCRIPTION
Resolves #134 (P1).

## Symptom
Templates over the ~2,000-row giant-query threshold render **only data rows** — no title, no column headers, no footer. The customer's working (May 13) and broken (May 26) PDFs have the **same 3,553-row dataset**, so it's a regression, not a data-volume engine switch — and **not v2.4.0** (the giant-query path is untouched by that release).

## Root cause (one line)
`DocGenGiantQueryAssembler.cls` loaded the internal `docgen_tmpl_html_<versionId>` snapshot **`WITH USER_MODE`**. That CV's CDL defaults to `Visibility=InternalUsers` → invisible under USER_MODE (#114 quirk) → empty read → assembler silently falls back to a **bare table** from Query_Config field names, dropping all chrome.

It was the **only** USER_MODE read in the class (every other is SYSTEM_MODE; `DocGenController.cls:1019` keeps SYSTEM_MODE with a comment citing this exact reason).

## Fix
FLS-guard + `WITH SYSTEM_MODE` hybrid (matching line ~381 and the controller). Package-internal snapshot read; user entitlement already gated by the active-version query above.

## Tests
- New `testGiantQuerySnapshotChromePreserved` — asserts a present snapshot's title/header/footer survive (not the bare-table fallback).
- Full `DocGenGiantQueryTest`: **42/42 pass**. Prettier clean.
- Honest caveat: test-context USER_MODE is lenient, so the access-mode change is validated by code consistency + the customer reproduction (pending their `Short_Codes_Compliance_Team__r` object schema for the definitive before/after).

## Follow-ups (separate, lower priority — noted on #134)
- Giant-query path skips `processXml` → section/conditional/secondary-loop tags leak raw.
- "Save to Record" on the giant-query path also downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)