### PR TITLE
chore(release): v2.5.0 — large-dataset template chrome fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## v2.5.0 — Large-dataset template chrome fix (`04tVx000000ZyyzIAC`, build `2.5.0-2`, promoted 2026-05-26)
+
+P1 bug fix (#134). Templates over the ~2,000-child-row giant-query threshold rendered **only their data rows** — the title, text-above-table, column headers, and footer were dropped. Fixed so large reports render with full formatting, identical to smaller ones.
+
+### Root cause
+
+`DocGenGiantQueryAssembler` loaded the internal `docgen_tmpl_html_<versionId>` template snapshot `WITH USER_MODE`. That CV's ContentDocumentLink defaults to `Visibility=InternalUsers`, which is invisible under USER_MODE (the documented #114 quirk), so the read returned empty and the assembler silently fell back to a bare table built from the Query_Config field names — dropping all template chrome. It was the lone USER_MODE read in the class; every other snapshot/CV read here is `WITH SYSTEM_MODE`, as is the analogous read in `DocGenController`.
+
+Confirmed a regression (not data volume, not v2.4.0): the customer's working (3,553 rows, full chrome) and broken (3,552 rows, bare table) outputs had the same dataset — both giant-query. A template re-save regenerated the snapshot with the InternalUsers visibility default, which the USER_MODE read then couldn't see.
+
+### Fix
+
+`DocGenGiantQueryAssembler.cls` snapshot read → FLS-guard (`DocGenFlsGuard.assertAccessible`) + `WITH SYSTEM_MODE` (the hybrid pattern used everywhere else for these package-internal reads). User entitlement is already gated by the active-version query above.
+
+### Release validation
+
+| Check                     | Result                                                     |
+| ------------------------- | ---------------------------------------------------------- |
+| DocGenGiantQueryTest      | 42/42 pass (incl. new chrome-preservation regression test) |
+| RunLocalTests             | passed — build coverage check 76% org-wide                 |
+| `sf code-analyzer` (S+AE) | 0 violations (45 suppressed — known FPs)                   |
+| e2e-01 … e2e-08           | all PASS / FAIL 0                                          |
+
+### Known follow-ups (#134, lower priority)
+
+- Giant-query path skips `processXml`, so parent-level section/conditional/inverse tags and secondary child loops leak as raw text.
+- "Save to Record" on the giant-query path also downloads.
+
 ## v2.4.0 — Multi-language runner + PowerPoint charts (`04tVx000000ZyanIAC`, build `2.4.0-2`, promoted 2026-05-25)
 
 Feature release. Brings the document runner UI to 10 languages, fixes PowerPoint chart rendering, and adds location-aware template error messages. 100% native — no external services or callouts.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 
 [Join the Community Channel](https://portwood.dev/community) | [Website](https://portwood.dev) | [Roadmap](https://portwood.dev/changelog)
 
-[![Version](https://img.shields.io/badge/version-2.4.0-blue.svg)](#install)
+[![Version](https://img.shields.io/badge/version-2.5.0-blue.svg)](#install)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Salesforce-00A1E0.svg)](https://www.salesforce.com)
 [![Namespace](https://img.shields.io/badge/namespace-portwoodglobal-purple.svg)](#install)
@@ -440,7 +440,8 @@ Found a vulnerability? See [SECURITY.md](SECURITY.md).
 
 | Version | Channel                                 | Package ID           |
 | ------- | --------------------------------------- | -------------------- |
-| v2.4.0  | **Latest (Released)**                   | `04tVx000000ZyanIAC` |
+| v2.5.0  | **Latest (Released)**                   | `04tVx000000ZyyzIAC` |
+| v2.4.0  | Previous                                | `04tVx000000ZyanIAC` |
 | v2.3.0  | Previous                                | `04tVx000000ZxDJIA0` |
 | v2.2.0  | Previous                                | `04tVx000000ZxBhIAK` |
 | v2.1.0  | Previous                                | `04tVx000000Zw5xIAC` |

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,14 +1,14 @@
 {
   "packageDirectories": [
     {
-      "versionName": "2.4.0 — Multi-language runner + PowerPoint charts",
-      "versionNumber": "2.4.0.NEXT",
-      "ancestorId": "04tVx000000ZxDJIA0",
+      "versionName": "2.5.0 — Large-dataset template chrome fix",
+      "versionNumber": "2.5.0.NEXT",
+      "ancestorId": "04tVx000000ZyanIAC",
       "path": "force-app",
       "default": true,
       "definitionFile": "config/build-def.json",
       "package": "Portwood DocGen Managed",
-      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v2.4 brings the document runner to 10 languages (Spanish, Japanese, Chinese, French, German, Portuguese, Italian, Korean, and Dutch): each user sees the interface in their own Salesforce language automatically. Charts now render natively in PowerPoint output as well, alongside Word, PDF, Excel, and HTML. Template authors also get clearer, location-aware error messages when building templates. Free for all users."
+      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v2.5 fixes a rendering issue where documents built from very large datasets (2,000+ related records) could lose their title, column headers, and footer — large reports now render with full formatting, identical to smaller ones. Free for all users."
     }
   ],
   "name": "Portwood DocGen",
@@ -152,6 +152,8 @@
     "Portwood DocGen Managed@2.1.0-1": "04tVx000000Zw5xIAC",
     "Portwood DocGen Managed@2.2.0-2": "04tVx000000ZxBhIAK",
     "Portwood DocGen Managed@2.3.0-1": "04tVx000000ZxDJIA0",
-    "Portwood DocGen Managed@2.4.0-2": "04tVx000000ZyanIAC"
+    "Portwood DocGen Managed@2.4.0-2": "04tVx000000ZyanIAC",
+    "Portwood DocGen Managed@2.5.0-1": "04tVx000000ZyxNIAS",
+    "Portwood DocGen Managed@2.5.0-2": "04tVx000000ZyyzIAC"
   }
 }


### PR DESCRIPTION
Release prep for **v2.5.0**. Validated package **2.5.0-2** (`04tVx000000ZyyzIAC`) is built — **pending promote** (awaiting go-ahead).

## What ships
The P1 #134 / #135 fix: giant-query (>2,000-row) templates no longer drop their title, column headers, and footer. The internal `docgen_tmpl_html_` snapshot read switched from `USER_MODE` (invisible for InternalUsers-visibility package CVs → bare-table fallback) to the FLS-guard + `SYSTEM_MODE` hybrid.

## Gates (staging-v250 — fresh scratch from the TWB-enabled def)
- ✅ e2e-01…08 — all PASS / FAIL 0
- ✅ DocGenGiantQueryTest — 42/42 (incl. new chrome-preservation regression test)
- ✅ Build coverage check — passed, **76%** org-wide
- ✅ `sf code-analyzer` (Security + AppExchange) — 0 violations

## Working copy already shipped
Beta **2.5.0-1** (`04tVx000000ZyxNIAS`) is available now for sandbox verification of the fix against the customer's real dataset (unvalidated → non-production).

## Pending
Promote `04tVx000000ZyyzIAC` (held for go-ahead), then merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)