### PR TITLE
chore: record v2.7.0-2 package alias

### DIFF
--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -157,6 +157,7 @@
     "Portwood DocGen Managed@2.5.0-2": "04tVx000000ZyyzIAC",
     "Portwood DocGen Managed@2.6.0-1": "04tVx000000Zzv3IAC",
     "Portwood DocGen Managed@2.6.0-2": "04tVx000000a037IAA",
-    "Portwood DocGen Managed@2.7.0-1": "04tVx000000a0O5IAI"
+    "Portwood DocGen Managed@2.7.0-1": "04tVx000000a0O5IAI",
+    "Portwood DocGen Managed@2.7.0-2": "04tVx000000a1IXIAY"
   }
 }


### PR DESCRIPTION
Build-generated `packageAlias` for the promoted v2.7.0 (`04tVx000000a1IXIAY`), which landed after the PR #141 branch commits. Adds it to main for the release record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)