### PR TITLE
Security: close unauthenticated IDOR in signature verification + harden audit IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v3.06.0 — HTML Signature Placement Detection (`04tVx000000nIv4IAE`, build `3.6.0-1`, promoted 2026-06-11)
+
+This release fixes HTML-template signature sending. HTML templates that contained valid signature tags such as `{@Signature_Customer}` or `{@Signature_Customer:1:Date}` could render the tag text in generated output but still show **No Signature Placements Found** in the signature sender component.
+
+Related: [#152](https://github.com/Portwood-Global-Solutions/DocGen/issues/152)
+
+### 1. HTML signature tags are detected by the sender
+
+Signature placement discovery now reads the active HTML template body when the template type is HTML. Word templates continue to use the existing pre-decomposed `word/document.xml` path.
+
+The parser behavior is unchanged: bare tags like `{@Signature_Customer}` still default to a full-signature placement, and v3 tags like `{@Signature_Customer:1:Date}` keep their explicit order/type.
+
+### Release validation
+
+- Package version create: validated build, `ValidationSkipped = false`
+- Promoted package: `04tVx000000nIv4IAE` · [Install URL](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nIv4IAE)
+- Package build coverage: 76%, code coverage check passed
+- Focused Apex validation in `triage-sumit-footer`: `DocGenSignatureTests`, 270/270 tests passed
+- Full e2e suite on `triage-sumit-footer`: PASS/FAIL0 across `e2e-01` through `e2e-08`
+- Full Apex suite: `RunLocalTests`, 1465 tests, 100% pass rate, 76% org-wide coverage
+- `sf code-analyzer` Security + AppExchange: 0 violations; SFGE printed internal timeout diagnostics on existing large controller/service paths before returning a clean summary
+- `npm run format:check`: pass
+- `git diff --check`
+
 ## v3.05.0 — Signature Template Fidelity (`04tVx000000nI5RIAU`, build `3.5.0-1`, promoted 2026-06-11)
 
 This release tightens the e-signature path so Word-authored template branding survives from preview through the final signed PDF, and updates the bundled permission sets for signature Flow and reminder features.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v3.08.0 — Signature Images and Generation Access (`04tVx000000nOFhIAM`, build `3.8.0-1`, promoted 2026-06-11)
+
+This release closes two field-reported support issues: HTML e-signature templates with embedded Salesforce Files images now render those images in signer-facing previews, and non-admin users who can access a template can generate large/giant-query documents without needing DocGen Admin just to read DocGen's internal generated parts.
+
+Related: [#152](https://github.com/Portwood-Global-Solutions/DocGen/issues/152), [#154](https://github.com/Portwood-Global-Solutions/DocGen/issues/154)
+
+### 1. HTML signature previews can render template images
+
+HTML signature preview generation now creates public distribution URLs for Salesforce Files images referenced by HTML template bodies. The cached signer preview HTML rewrites `/sfc/servlet.shepherd/version/download/068...` image sources to those distribution URLs so signer-facing browser previews can load the images, while final PDF rendering keeps the relative `/sfc/...` path required by Salesforce's PDF renderer.
+
+### 2. Non-admin users can generate large templates when internal parts are private
+
+Giant-query generation now reads DocGen-managed internal `docgen_%` / `docgen_giant_%` ContentVersion artifacts with the established FLS guard + `SYSTEM_MODE` pattern after the user's template/job access has already been gated. This fixes the support-thread symptom where a non-admin could see a shared template but generation failed with "Pre-decomposed template parts not found", while admins could generate the same document.
+
+### Release validation
+
+- Package version create: `08cVx000000iKvtIAE` succeeded; package coverage 76%; subscriber package `04tVx000000nOFhIAM`
+- Promoted package: `04tVx000000nOFhIAM` · [Install URL](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOFhIAM) · [Sandbox Install URL](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOFhIAM)
+- Full e2e suite in `triage-sumit-footer`: e2e-01 through e2e-08 PASS/FAIL0
+- Full Apex validation in `triage-sumit-footer`: `RunLocalTests` 1487/1487, org coverage 76% (`707cf00000zNB7s`)
+- Code Analyzer: Security + AppExchange selectors, 0 violations
+- Focused proof in `triage-sumit-footer`: `DocGenSignatureTests` HTML image assertions + giant-query internal content guard passed (`707cf00000zMYTW`)
+- Broader focused Apex validation in `triage-sumit-footer`: `DocGenSignatureTests` 277/277, `DocGenGiantQueryTest` 46/46, `DocGenControllerTests` 223/223
+
 ## v3.07.0 — HTML Signature Rendering (`04tVx000000nLOHIA2`, build `3.7.0-1`, promoted 2026-06-11)
 
 This release completes HTML-template e-signature support. v3.06 fixed sender-side signature placement detection, but HTML signature previews and completed signed PDFs could still render blank because the signing flow sent already-rendered HTML through the Word-to-HTML renderer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v3.07.0 — HTML Signature Rendering (`04tVx000000nLOHIA2`, build `3.7.0-1`, promoted 2026-06-11)
+
+This release completes HTML-template e-signature support. v3.06 fixed sender-side signature placement detection, but HTML signature previews and completed signed PDFs could still render blank because the signing flow sent already-rendered HTML through the Word-to-HTML renderer.
+
+Related: [#152](https://github.com/Portwood-Global-Solutions/DocGen/issues/152)
+
+### 1. HTML signature previews render the merged HTML directly
+
+Signature preview generation now carries the template type through the merge result. HTML templates use the merged HTML body directly, while Word templates continue through the existing DOCX XML renderer with header/footer handling.
+
+### 2. Completed HTML signature PDFs stamp tags in HTML
+
+Final signed PDF rendering now uses an HTML-safe stamping path for HTML templates and keeps the existing XML-safe stamping path for Word templates. Signed values are HTML-escaped before replacement.
+
+### Release validation
+
+- Package version create: validated build, `ValidationSkipped = false`
+- Promoted package: `04tVx000000nLOHIA2` · [Install URL](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nLOHIA2)
+- Package build coverage: 76%, code coverage check passed
+- Focused Apex validation in `triage-sumit-footer`: `DocGenSignatureTests`, 274/274 tests passed
+- Visual E2E in `triage-sumit-footer`: sender LWC PDF preview, signer preview, completed signed PDF, and verification certificate all rendered successfully for an HTML signature template
+- Full e2e suite on `triage-sumit-footer`: PASS/FAIL0 across `e2e-01` through `e2e-08`
+- Full Apex suite: `RunLocalTests`, 1469 tests, 100% pass rate, 76% org-wide coverage
+- `sf code-analyzer` Security + AppExchange: 0 violations; SFGE printed internal timeout diagnostics on existing large controller paths before returning a clean summary
+
 ## v3.06.0 — HTML Signature Placement Detection (`04tVx000000nIv4IAE`, build `3.6.0-1`, promoted 2026-06-11)
 
 This release fixes HTML-template signature sending. HTML templates that contained valid signature tags such as `{@Signature_Customer}` or `{@Signature_Customer:1:Date}` could render the tag text in generated output but still show **No Signature Placements Found** in the signature sender component.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## v3.11.0 — Shared Template Image Rendering (`04tVx000000nPGbIAM`, build `3.11.0-1`, promoted 2026-06-12)
+
+This release fixes the follow-up shared-template image issue reported from Slack. Non-admin users could generate both HTML and Word/giant-query PDFs, but template-owned images referenced by `/sfc/servlet.shepherd/version/download/<ContentVersionId>` could render as broken when the running user did not own or otherwise have file access to the image file.
+
+Related: [#154](https://github.com/Portwood-Global-Solutions/DocGen/issues/154)
+
+### 1. Non-admin PDF renders can fetch referenced template image assets
+
+`Blob.toPdf()` fetches relative shepherd image URLs as the running user. Before PDF rendering, DocGen now extracts the referenced ContentVersion IDs from the final HTML and links only the current template's DocGen-managed image assets to the source record as Viewer / AllUsers.
+
+The fix applies to normal HTML-template PDFs, Word-to-PDF rendering, and the giant-query final PDF path.
+
+### 2. The access handoff is scoped to template-owned assets
+
+The helper filters candidate files by DocGen template image title prefixes for the active template/version, so it does not broaden access to arbitrary customer files or row-level image data. It also preserves the zero-heap PDF image behavior: images remain relative shepherd URLs and no `VersionData` is loaded for PDF rendering.
+
+### 3. Regression coverage and non-admin visual proof
+
+Regression coverage verifies that a referenced template image file is linked to the source record before PDF rendering. Browser proof in the release validation scratch org used the actual Lightning runner button as a standard DocGen user and generated both HTML and Word giant-query PDFs with the embedded image visible.
+
+### Release validation
+
+- Package version create: `08cVx000000iNP7IAM` succeeded; package coverage 76%; subscriber package `04tVx000000nPGbIAM`
+- Promoted package: `04tVx000000nPGbIAM` · [Install URL](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nPGbIAM) · [Sandbox Install URL](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nPGbIAM)
+- Release landing config updated in production: `DocGen_Landing_Config__mdt.Current` → version `3.11.0`, package `04tVx000000nPGbIAM`
+- Full e2e suite in `triage-sumit-footer`: e2e-01 through e2e-08 PASS/FAIL0
+- Full Apex validation in `triage-sumit-footer`: `RunLocalTests` completed with 0 failures, org coverage 76% (`707cf00000zV0iE`)
+- Focused Apex validation in `triage-sumit-footer`: `DocGenMiscTests.testTemplateAssetImageAccessLinkedForPdfRender` passed
+- Browser proof in `triage-sumit-footer`: standard non-admin user generated HTML and Word giant-query PDFs from the real runner button; both showed rendered template images
+- Visual artifacts: `outputs/proof-images/html-giant-nonadmin.png`, `outputs/proof-images/word-giant-nonadmin.png`
+- Code Analyzer: Security + AppExchange selectors completed with 0 emitted unsuppressed violations
+- `npm run format:check`: pass
+- Customer data note: validation used synthetic scratch-org data; the customer-provided template was inspected locally only to identify document structure and embedded image behavior
+
 ## v3.10.0 — Large-template Snapshot Fidelity (`04tVx000000nOh7IAE`, build `3.10.0-1`, promoted 2026-06-12)
 
 This release fixes the follow-up large-template rendering issue reported from Slack. Non-admin users could generate the document after v3.09.0, but large/giant-query output could still lose template chrome and render as a bare data table when the internal pre-baked HTML snapshot was not visible from the queueable's sharing context.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v3.09.0 — Non-admin Large-template Access (`04tVx000000nOdtIAE`, build `3.9.0-1`, promoted 2026-06-11)
+
+This release completes the non-admin large-template support fix reported from Slack. Users with the DocGen User permission set could see shared templates and start generation, but large/giant-query jobs still failed because the job record needed to store internal generation context in fields that were not editable by non-admin users.
+
+Related: [#154](https://github.com/Portwood-Global-Solutions/DocGen/issues/154)
+
+### 1. DocGen users can generate giant-query documents
+
+`DocGen_User` now grants editable access to `DocGen_Job__c.Parent_Record_Id__c` and `DocGen_Job__c.Giant_Query_Config__c`, matching the fields the controller writes when it creates a large-template generation job. This keeps non-admin generation gated by normal DocGen permissions while allowing the server-side giant-query pipeline to persist its own job state.
+
+### 2. Regression coverage for non-admin job creation
+
+Bulk-controller permission tests now assert that a DocGen User can create jobs with the fields required by the giant-query generation path. The affected test fixture also links its synthetic pre-decomposed internal ContentVersion to the template version, matching how the fixed loader discovers package-managed parts.
+
+### Release validation
+
+- Package version create: `08cVx000000iNDpIAM` succeeded; package coverage 76%; subscriber package `04tVx000000nOdtIAE`
+- Promoted package: `04tVx000000nOdtIAE` · [Install URL](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOdtIAE) · [Sandbox Install URL](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOdtIAE)
+- Full e2e suite in `triage-sumit-footer`: e2e-01 through e2e-08 PASS/FAIL0
+- Full Apex validation in `triage-sumit-footer`: `RunLocalTests` 1474/1474, org coverage 76% (`707cf00000zPzdYAAS`)
+- Code Analyzer: Security + AppExchange selectors, 0 violations
+- Browser proof in `triage-sumit-footer`: standard non-admin user generated a 2,105-contact giant-query PDF from the real runner button and received the success toast
+- Test data note: validation used synthetic scratch-org data only; the manual proof fixture was removed after validation
+
 ## v3.08.0 — Signature Images and Generation Access (`04tVx000000nOFhIAM`, build `3.8.0-1`, promoted 2026-06-11)
 
 This release closes two field-reported support issues: HTML e-signature templates with embedded Salesforce Files images now render those images in signer-facing previews, and non-admin users who can access a template can generate large/giant-query documents without needing DocGen Admin just to read DocGen's internal generated parts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## v3.10.0 — Large-template Snapshot Fidelity (`04tVx000000nOh7IAE`, build `3.10.0-1`, promoted 2026-06-12)
+
+This release fixes the follow-up large-template rendering issue reported from Slack. Non-admin users could generate the document after v3.09.0, but large/giant-query output could still lose template chrome and render as a bare data table when the internal pre-baked HTML snapshot was not visible from the queueable's sharing context.
+
+Related: [#154](https://github.com/Portwood-Global-Solutions/DocGen/issues/154)
+
+### 1. Giant-query output preserves headers, footers, and embedded template images
+
+`DocGenGiantQueryAssembler` now loads the pre-baked HTML snapshot through the template-version-linked internal ContentVersion helper before falling back to the legacy title-only lookup. This keeps the large-template path aligned with DocGen's internal part sharing model and prevents the bare-table fallback from dropping document titles, table headers, footers, and embedded Word-template images.
+
+The customer-provided DOCX used an embedded `word/media/image1.jpeg` logo, not a `{%ImageField}` merge image. The fix preserves that image by preserving the whole pre-baked snapshot/part payload for the giant-query renderer.
+
+### 2. Split footer merge tags are normalized before snapshot creation
+
+Pre-baked HTML snapshot creation now merges Word runs in header/footer XML before storing those entries, matching the normal render path. This covers templates where Word splits a footer tag across runs, such as `{`, `Date_for_merge_document__c`, and `}`.
+
+### 3. Regression coverage for the actual failure shape
+
+Giant-query chrome preservation tests now assert that snapshot title/header/footer content and an image marker survive assembly. Footer-run regression coverage verifies split-brace merge tags normalize before merge processing.
+
+### Release validation
+
+- Package version create: `08cVx000000iNH3IAM` succeeded; package coverage 76%; subscriber package `04tVx000000nOh7IAE`
+- Promoted package: `04tVx000000nOh7IAE` · [Install URL](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOh7IAE) · [Sandbox Install URL](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOh7IAE)
+- Release landing config updated in production: `DocGen_Landing_Config__mdt.Current` → version `3.10.0`, package `04tVx000000nOh7IAE`
+- Full e2e suite in `triage-sumit-footer`: e2e-01 through e2e-08 PASS/FAIL0
+- Full Apex validation in `triage-sumit-footer`: `RunLocalTests` completed with 0 failures, org coverage 76% (`05mcf000001WhinAAC`)
+- Focused Apex validation in `triage-sumit-footer`: `DocGenGiantQueryTest` plus footer split-tag regression passed 48/48 (`707cf00000zQuQE`)
+- Code Analyzer: Security + AppExchange selectors, 0 violations
+- `npm run format:check`: pass
+- `git diff --check`: pass
+- Customer data note: validation used synthetic scratch-org data; the customer-provided template was inspected only as local DOCX structure to identify embedded media/merge-tag shape
+
 ## v3.09.0 — Non-admin Large-template Access (`04tVx000000nOdtIAE`, build `3.9.0-1`, promoted 2026-06-11)
 
 This release completes the non-admin large-template support fix reported from Slack. Users with the DocGen User permission set could see shared templates and start generation, but large/giant-query jobs still failed because the job record needed to store internal generation context in fields that were not editable by non-admin users.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 
 [Join the Community Channel](https://portwood.dev/community) | [Website](https://portwood.dev) | [Roadmap](https://portwood.dev/roadmap)
 
-[![Version](https://img.shields.io/badge/version-3.05.0-blue.svg)](#install)
+[![Version](https://img.shields.io/badge/version-3.06.0-blue.svg)](#install)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Salesforce-00A1E0.svg)](https://www.salesforce.com)
 [![Namespace](https://img.shields.io/badge/namespace-portwoodglobal-purple.svg)](#install)
@@ -18,10 +18,10 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 ## Install
 
 ```bash
-sf package install --package 04tVx000000nI5RIAU --wait 10 --target-org <your-org>
+sf package install --package 04tVx000000nIv4IAE --wait 10 --target-org <your-org>
 ```
 
-[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nI5RIAU) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nI5RIAU)
+[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nIv4IAE) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nIv4IAE)
 
 **Then:** Assign **DocGen Admin** permission set | Enable **Blob.toPdf() Release Update** | Open the **DocGen** app
 
@@ -371,7 +371,7 @@ Decompress → Merge XML tags → Recompress
 
 ## Releases
 
-DocGen ships on a **biweekly release cycle**. Latest release: **v3.05.0 — Signature Template Fidelity**.
+DocGen ships on a **biweekly release cycle**. Latest release: **v3.06.0 — HTML Signature Placement Detection**.
 
 See [CHANGELOG.md](CHANGELOG.md) for full version history.
 
@@ -444,7 +444,8 @@ Found a vulnerability? See [SECURITY.md](SECURITY.md).
 
 | Version | Channel                                 | Package ID           |
 | ------- | --------------------------------------- | -------------------- |
-| v3.05.0 | **Latest (Released)**                   | `04tVx000000nI5RIAU` |
+| v3.06.0 | **Latest (Released)**                   | `04tVx000000nIv4IAE` |
+| v3.05.0 | Previous                                | `04tVx000000nI5RIAU` |
 | v3.04.0 | Previous                                | `04tVx000000nGZtIAM` |
 | v3.03.0 | Previous                                | `04tVx000000nEHxIAM` |
 | v3.02.0 | Previous                                | `04tVx000000muJFIAY` |

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 
 [Join the Community Channel](https://portwood.dev/community) | [Website](https://portwood.dev) | [Roadmap](https://portwood.dev/roadmap)
 
-[![Version](https://img.shields.io/badge/version-3.09.0-blue.svg)](#install)
+[![Version](https://img.shields.io/badge/version-3.10.0-blue.svg)](#install)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Salesforce-00A1E0.svg)](https://www.salesforce.com)
 [![Namespace](https://img.shields.io/badge/namespace-portwoodglobal-purple.svg)](#install)
-[![Apex Tests](https://img.shields.io/badge/Apex_Tests-1474%2F1474_passing-brightgreen)](#code-quality)
+[![Apex Tests](https://img.shields.io/badge/Apex_Tests-1453_passing-brightgreen)](#code-quality)
 [![Coverage](https://img.shields.io/badge/Coverage-76%25-brightgreen)](#code-quality)
 [![Security](https://img.shields.io/badge/Code_Analyzer-0%2F0%2F0-brightgreen)](#security)
 [![Website](https://img.shields.io/badge/website-portwood.dev-blue)](https://portwood.dev)
@@ -18,10 +18,10 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 ## Install
 
 ```bash
-sf package install --package 04tVx000000nOdtIAE --wait 10 --target-org <your-org>
+sf package install --package 04tVx000000nOh7IAE --wait 10 --target-org <your-org>
 ```
 
-[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOdtIAE) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOdtIAE)
+[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOh7IAE) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOh7IAE)
 
 **Then:** Assign **DocGen Admin** permission set | Enable **Blob.toPdf() Release Update** | Open the **DocGen** app
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 
 [Join the Community Channel](https://portwood.dev/community) | [Website](https://portwood.dev) | [Roadmap](https://portwood.dev/roadmap)
 
-[![Version](https://img.shields.io/badge/version-3.08.0-blue.svg)](#install)
+[![Version](https://img.shields.io/badge/version-3.09.0-blue.svg)](#install)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Salesforce-00A1E0.svg)](https://www.salesforce.com)
 [![Namespace](https://img.shields.io/badge/namespace-portwoodglobal-purple.svg)](#install)
-[![Apex Tests](https://img.shields.io/badge/Apex_Tests-1487%2F1487_passing-brightgreen)](#code-quality)
+[![Apex Tests](https://img.shields.io/badge/Apex_Tests-1474%2F1474_passing-brightgreen)](#code-quality)
 [![Coverage](https://img.shields.io/badge/Coverage-76%25-brightgreen)](#code-quality)
 [![Security](https://img.shields.io/badge/Code_Analyzer-0%2F0%2F0-brightgreen)](#security)
 [![Website](https://img.shields.io/badge/website-portwood.dev-blue)](https://portwood.dev)
@@ -18,10 +18,10 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 ## Install
 
 ```bash
-sf package install --package 04tVx000000nOFhIAM --wait 10 --target-org <your-org>
+sf package install --package 04tVx000000nOdtIAE --wait 10 --target-org <your-org>
 ```
 
-[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOFhIAM) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOFhIAM)
+[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOdtIAE) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOdtIAE)
 
 **Then:** Assign **DocGen Admin** permission set | Enable **Blob.toPdf() Release Update** | Open the **DocGen** app
 
@@ -371,7 +371,7 @@ Decompress → Merge XML tags → Recompress
 
 ## Releases
 
-DocGen ships on a **biweekly release cycle**. Latest release: **v3.08.0 — Signature Images and Generation Access**.
+DocGen ships on a **biweekly release cycle**. Latest release: **v3.09.0 — Non-admin Large-template Access**.
 
 See [CHANGELOG.md](CHANGELOG.md) for full version history.
 
@@ -444,7 +444,8 @@ Found a vulnerability? See [SECURITY.md](SECURITY.md).
 
 | Version | Channel                                 | Package ID           |
 | ------- | --------------------------------------- | -------------------- |
-| v3.08.0 | **Latest (Released)**                   | `04tVx000000nOFhIAM` |
+| v3.09.0 | **Latest (Released)**                   | `04tVx000000nOdtIAE` |
+| v3.08.0 | Previous                                | `04tVx000000nOFhIAM` |
 | v3.07.0 | Previous                                | `04tVx000000nLOHIA2` |
 | v3.06.0 | Previous                                | `04tVx000000nIv4IAE` |
 | v3.05.0 | Previous                                | `04tVx000000nI5RIAU` |

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 
 [Join the Community Channel](https://portwood.dev/community) | [Website](https://portwood.dev) | [Roadmap](https://portwood.dev/roadmap)
 
-[![Version](https://img.shields.io/badge/version-3.06.0-blue.svg)](#install)
+[![Version](https://img.shields.io/badge/version-3.07.0-blue.svg)](#install)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Salesforce-00A1E0.svg)](https://www.salesforce.com)
 [![Namespace](https://img.shields.io/badge/namespace-portwoodglobal-purple.svg)](#install)
-[![Apex Tests](https://img.shields.io/badge/Apex_Tests-1478%2F1478_passing-brightgreen)](#code-quality)
+[![Apex Tests](https://img.shields.io/badge/Apex_Tests-1469%2F1469_passing-brightgreen)](#code-quality)
 [![Coverage](https://img.shields.io/badge/Coverage-76%25-brightgreen)](#code-quality)
 [![Security](https://img.shields.io/badge/Code_Analyzer-0%2F0%2F0-brightgreen)](#security)
 [![Website](https://img.shields.io/badge/website-portwood.dev-blue)](https://portwood.dev)
@@ -18,10 +18,10 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 ## Install
 
 ```bash
-sf package install --package 04tVx000000nIv4IAE --wait 10 --target-org <your-org>
+sf package install --package 04tVx000000nLOHIA2 --wait 10 --target-org <your-org>
 ```
 
-[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nIv4IAE) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nIv4IAE)
+[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nLOHIA2) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nLOHIA2)
 
 **Then:** Assign **DocGen Admin** permission set | Enable **Blob.toPdf() Release Update** | Open the **DocGen** app
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 
 [Join the Community Channel](https://portwood.dev/community) | [Website](https://portwood.dev) | [Roadmap](https://portwood.dev/roadmap)
 
-[![Version](https://img.shields.io/badge/version-3.07.0-blue.svg)](#install)
+[![Version](https://img.shields.io/badge/version-3.08.0-blue.svg)](#install)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Salesforce-00A1E0.svg)](https://www.salesforce.com)
 [![Namespace](https://img.shields.io/badge/namespace-portwoodglobal-purple.svg)](#install)
-[![Apex Tests](https://img.shields.io/badge/Apex_Tests-1469%2F1469_passing-brightgreen)](#code-quality)
+[![Apex Tests](https://img.shields.io/badge/Apex_Tests-1487%2F1487_passing-brightgreen)](#code-quality)
 [![Coverage](https://img.shields.io/badge/Coverage-76%25-brightgreen)](#code-quality)
 [![Security](https://img.shields.io/badge/Code_Analyzer-0%2F0%2F0-brightgreen)](#security)
 [![Website](https://img.shields.io/badge/website-portwood.dev-blue)](https://portwood.dev)
@@ -18,10 +18,10 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 ## Install
 
 ```bash
-sf package install --package 04tVx000000nLOHIA2 --wait 10 --target-org <your-org>
+sf package install --package 04tVx000000nOFhIAM --wait 10 --target-org <your-org>
 ```
 
-[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nLOHIA2) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nLOHIA2)
+[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOFhIAM) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOFhIAM)
 
 **Then:** Assign **DocGen Admin** permission set | Enable **Blob.toPdf() Release Update** | Open the **DocGen** app
 
@@ -371,7 +371,7 @@ Decompress → Merge XML tags → Recompress
 
 ## Releases
 
-DocGen ships on a **biweekly release cycle**. Latest release: **v3.06.0 — HTML Signature Placement Detection**.
+DocGen ships on a **biweekly release cycle**. Latest release: **v3.08.0 — Signature Images and Generation Access**.
 
 See [CHANGELOG.md](CHANGELOG.md) for full version history.
 
@@ -444,7 +444,9 @@ Found a vulnerability? See [SECURITY.md](SECURITY.md).
 
 | Version | Channel                                 | Package ID           |
 | ------- | --------------------------------------- | -------------------- |
-| v3.06.0 | **Latest (Released)**                   | `04tVx000000nIv4IAE` |
+| v3.08.0 | **Latest (Released)**                   | `04tVx000000nOFhIAM` |
+| v3.07.0 | Previous                                | `04tVx000000nLOHIA2` |
+| v3.06.0 | Previous                                | `04tVx000000nIv4IAE` |
 | v3.05.0 | Previous                                | `04tVx000000nI5RIAU` |
 | v3.04.0 | Previous                                | `04tVx000000nGZtIAM` |
 | v3.03.0 | Previous                                | `04tVx000000nEHxIAM` |

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 
 [Join the Community Channel](https://portwood.dev/community) | [Website](https://portwood.dev) | [Roadmap](https://portwood.dev/roadmap)
 
-[![Version](https://img.shields.io/badge/version-3.10.0-blue.svg)](#install)
+[![Version](https://img.shields.io/badge/version-3.11.0-blue.svg)](#install)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Salesforce-00A1E0.svg)](https://www.salesforce.com)
 [![Namespace](https://img.shields.io/badge/namespace-portwoodglobal-purple.svg)](#install)
-[![Apex Tests](https://img.shields.io/badge/Apex_Tests-1453_passing-brightgreen)](#code-quality)
+[![Apex Tests](https://img.shields.io/badge/Apex_Tests-1490_passing-brightgreen)](#code-quality)
 [![Coverage](https://img.shields.io/badge/Coverage-76%25-brightgreen)](#code-quality)
 [![Security](https://img.shields.io/badge/Code_Analyzer-0%2F0%2F0-brightgreen)](#security)
 [![Website](https://img.shields.io/badge/website-portwood.dev-blue)](https://portwood.dev)
@@ -18,10 +18,10 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 ## Install
 
 ```bash
-sf package install --package 04tVx000000nOh7IAE --wait 10 --target-org <your-org>
+sf package install --package 04tVx000000nPGbIAM --wait 10 --target-org <your-org>
 ```
 
-[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOh7IAE) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOh7IAE)
+[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nPGbIAM) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nPGbIAM)
 
 **Then:** Assign **DocGen Admin** permission set | Enable **Blob.toPdf() Release Update** | Open the **DocGen** app
 
@@ -371,7 +371,7 @@ Decompress → Merge XML tags → Recompress
 
 ## Releases
 
-DocGen ships on a **biweekly release cycle**. Latest release: **v3.09.0 — Non-admin Large-template Access**.
+DocGen ships on a **biweekly release cycle**. Latest release: **v3.11.0 — Shared Template Image Rendering**.
 
 See [CHANGELOG.md](CHANGELOG.md) for full version history.
 
@@ -444,7 +444,9 @@ Found a vulnerability? See [SECURITY.md](SECURITY.md).
 
 | Version | Channel                                 | Package ID           |
 | ------- | --------------------------------------- | -------------------- |
-| v3.09.0 | **Latest (Released)**                   | `04tVx000000nOdtIAE` |
+| v3.11.0 | **Latest (Released)**                   | `04tVx000000nPGbIAM` |
+| v3.10.0 | Previous                                | `04tVx000000nOh7IAE` |
+| v3.09.0 | Previous                                | `04tVx000000nOdtIAE` |
 | v3.08.0 | Previous                                | `04tVx000000nOFhIAM` |
 | v3.07.0 | Previous                                | `04tVx000000nLOHIA2` |
 | v3.06.0 | Previous                                | `04tVx000000nIv4IAE` |

--- a/force-app/main/default/classes/DocGenAuthenticatorController.cls
+++ b/force-app/main/default/classes/DocGenAuthenticatorController.cls
@@ -1,8 +1,8 @@
 public without sharing class DocGenAuthenticatorController {
-    // SHA-256 hex digest = 64 lowercase/uppercase hex characters
+    // SHA-256 hex digest = 64 lowercase/uppercase hex characters.
+    // Both capabilities in this class are 64-hex: the document hash (verifyDocument)
+    // and the request verification token (verifyByRequestId).
     private static final Pattern SHA256_HEX = Pattern.compile('^[a-fA-F0-9]{64}$');
-    // Salesforce Id = 15 or 18 alphanumeric characters
-    private static final Pattern SF_ID = Pattern.compile('^[a-zA-Z0-9]{15}([a-zA-Z0-9]{3})?$');
 
     /**
      * Verifies a document by its SHA-256 hash.
@@ -89,31 +89,36 @@ public without sharing class DocGenAuthenticatorController {
     }
 
     /**
-     * Looks up all audit records for a signature request by ID.
-     * Used by the verification page when accessed via request ID link.
-     *
-     * Note: the request Id IS the verification capability — this endpoint is meant to
-     * let recipients verify their audit trail via a public-link flow. We therefore do
-     * NOT gate on caller identity, but we DO strictly validate the input shape and
-     * return only fields that are part of the verification contract.
+     * Looks up all audit records for a signature request via the request's
+     * unguessable Secure_Token__c (the verify link printed on the certificate
+     * carries ?token=...). The token IS the capability — possession of the
+     * signed document (which displays the link) is what authorizes viewing the
+     * audit roster. The previous version keyed on the raw record Id, which is
+     * enumerable, allowing anonymous PII harvest; that IDOR is closed here.
+     * The method name is retained for managed-package/binary compatibility.
      */
     @AuraEnabled
     @RemoteAction
-    public static List<VerificationResult> verifyByRequestId(String requestId) {
+    public static List<VerificationResult> verifyByRequestId(String requestToken) {
         List<VerificationResult> results = new List<VerificationResult>();
 
-        // Strict input validation: must be a well-formed 15- or 18-char alphanumeric Salesforce Id.
-        // Reject early with empty list if malformed — never reach SOQL.
+        // SECURITY (hotfix): the capability is now the request's unguessable
+        // 64-hex Secure_Token__c, NOT the raw Signature_Request__c Id. Salesforce
+        // record Ids are enumerable (fixed key-prefix, appear in URLs, partially
+        // sequential), so the previous Id-keyed lookup let any anonymous guest
+        // harvest every signer's name/email/IP for a guessed request. The verify
+        // link printed on the certificate now carries this token (?token=...).
+        // Legacy ?id= links (15/18-char Ids) fail this 64-hex check and return
+        // empty — those documents are still verifiable by upload (verifyDocument).
         if (
-            String.isBlank(requestId) ||
-            (requestId.length() != 15 &&
-            requestId.length() != 18) ||
-            !SF_ID.matcher(requestId).matches()
+            String.isBlank(requestToken) ||
+            requestToken.length() != 64 ||
+            !SHA256_HEX.matcher(requestToken).matches()
         ) {
             return results;
         }
 
-        // Public verifier — capability is holding the Signature_Request__c Id.
+        // Public verifier — capability is holding the request Secure_Token__c.
         // Describe check below is the explicit CRUD/FLS enforcement signal
         // documented in DocGenSignatureGuestSecurity.
         DocGenSignatureGuestSecurity.assertAuditReadable();
@@ -152,7 +157,7 @@ public without sharing class DocGenAuthenticatorController {
                 Document_Hash_SHA256__c,
                 Signer__r.Role_Name__c
             FROM DocGen_Signature_Audit__c
-            WHERE Signature_Request__c = :requestId AND Signer_Name__c != 'SYSTEM'
+            WHERE Signature_Request__r.Secure_Token__c = :requestToken AND Signer_Name__c != 'SYSTEM'
             WITH SYSTEM_MODE
             ORDER BY Signed_Date__c ASC
         ];

--- a/force-app/main/default/classes/DocGenAuthenticatorControllerTest.cls
+++ b/force-app/main/default/classes/DocGenAuthenticatorControllerTest.cls
@@ -47,7 +47,7 @@ private class DocGenAuthenticatorControllerTest {
     }
 
     private static DocGen_Signature_Request__c getRequest() {
-        return [SELECT Id FROM DocGen_Signature_Request__c LIMIT 1];
+        return [SELECT Id, Secure_Token__c FROM DocGen_Signature_Request__c LIMIT 1];
     }
 
     // =========================================================================
@@ -168,24 +168,40 @@ private class DocGenAuthenticatorControllerTest {
     // =========================================================================
 
     @isTest
-    static void testVerifyByRequestId_valid18() {
+    static void testVerifyByRequestId_validToken() {
         DocGen_Signature_Request__c req = getRequest();
-        // Salesforce 18-char Id — req.Id is already 18 chars in Apex
-        System.assertEquals(18, String.valueOf(req.Id).length(), 'Id should be 18 chars');
+        // Capability is now the request's unguessable 64-hex Secure_Token__c.
+        System.assertEquals(64, req.Secure_Token__c.length(), 'Request token should be 64 hex chars');
 
         Test.startTest();
         List<DocGenAuthenticatorController.VerificationResult> results = DocGenAuthenticatorController.verifyByRequestId(
-            req.Id
+            req.Secure_Token__c
         );
         Test.stopTest();
 
-        System.assertEquals(1, results.size(), 'Should find the one inserted audit');
+        System.assertEquals(1, results.size(), 'Should find the one inserted audit via request token');
         DocGenAuthenticatorController.VerificationResult r = results[0];
         System.assertEquals(true, r.isValid);
         System.assertEquals('Auth Signer', r.signerName);
         System.assertEquals('Buyer', r.roleName, 'Role from Signer__r should be populated');
         System.assertEquals(VALID_HASH, r.documentHash);
         System.assertEquals('Signature verified', r.message);
+    }
+
+    @isTest
+    static void testVerifyByRequestId_rawIdIsRejected() {
+        // SECURITY REGRESSION GUARD: the old IDOR returned signer PII for any
+        // guessed record Id. The endpoint must now reject a raw Signature_Request
+        // Id (15/18-char, not 64-hex) and disclose nothing.
+        DocGen_Signature_Request__c req = getRequest();
+
+        Test.startTest();
+        List<DocGenAuthenticatorController.VerificationResult> byId = DocGenAuthenticatorController.verifyByRequestId(
+            req.Id
+        );
+        Test.stopTest();
+
+        System.assertEquals(0, byId.size(), 'A raw record Id must NOT return any signer data');
     }
 
     @isTest
@@ -196,17 +212,17 @@ private class DocGenAuthenticatorControllerTest {
         );
         System.assertEquals(0, r1.size(), '14-char input must return empty');
 
-        // 19 chars (too long)
+        // 65 chars (too long for a SHA-256 hex token)
         List<DocGenAuthenticatorController.VerificationResult> r2 = DocGenAuthenticatorController.verifyByRequestId(
-            '0011223344556677889'
+            '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0'
         );
-        System.assertEquals(0, r2.size(), '19-char input must return empty');
+        System.assertEquals(0, r2.size(), '65-char input must return empty');
 
-        // 18 chars with special characters (not alphanumeric)
+        // 64 chars with non-hex characters
         List<DocGenAuthenticatorController.VerificationResult> r3 = DocGenAuthenticatorController.verifyByRequestId(
-            '001122334455667!@#'
+            'ghijklmnopqrstuvwxyz0123456789abcdef0123456789abcdef0123456789abcd'.substring(0, 64)
         );
-        System.assertEquals(0, r3.size(), 'Special chars must return empty');
+        System.assertEquals(0, r3.size(), 'Non-hex chars must return empty');
 
         // null
         List<DocGenAuthenticatorController.VerificationResult> r4 = DocGenAuthenticatorController.verifyByRequestId(
@@ -217,20 +233,14 @@ private class DocGenAuthenticatorControllerTest {
         // empty string
         List<DocGenAuthenticatorController.VerificationResult> r5 = DocGenAuthenticatorController.verifyByRequestId('');
         System.assertEquals(0, r5.size(), 'Empty must return empty');
-
-        // SOQL injection attempt — ' OR ' in the middle, length matched to 18
-        List<DocGenAuthenticatorController.VerificationResult> r6 = DocGenAuthenticatorController.verifyByRequestId(
-            '001\' OR Id != \'X'
-        );
-        System.assertEquals(0, r6.size(), 'Injection attempt must be rejected by validator');
     }
 
     @isTest
     static void testVerifyByRequestId_notFound() {
-        // Well-formed but unused 15-char alphanumeric Id
+        // Well-formed 64-hex token that matches no request
         Test.startTest();
         List<DocGenAuthenticatorController.VerificationResult> results = DocGenAuthenticatorController.verifyByRequestId(
-            'a0B000000000ABC'
+            'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
         );
         Test.stopTest();
 

--- a/force-app/main/default/classes/DocGenBulkControllerTest.cls
+++ b/force-app/main/default/classes/DocGenBulkControllerTest.cls
@@ -44,7 +44,8 @@ public with sharing class DocGenBulkControllerTest {
         ContentVersion xmlCv = new ContentVersion(
             Title = 'docgen_tmpl_xml_' + ver.Id + '_word__document.xml',
             PathOnClient = 'document.xml',
-            VersionData = Blob.valueOf(docXml)
+            VersionData = Blob.valueOf(docXml),
+            FirstPublishLocationId = ver.Id
         );
         insert xmlCv;
     }

--- a/force-app/main/default/classes/DocGenBulkTests.cls
+++ b/force-app/main/default/classes/DocGenBulkTests.cls
@@ -143,6 +143,8 @@ private class DocGenBulkTests {
         PermissionSet userPermSet = [SELECT Id FROM PermissionSet WHERE Name = 'DocGen_User' LIMIT 1];
         FieldPermissions labelPerm;
         FieldPermissions mergeOnlyPerm;
+        FieldPermissions parentRecordPerm;
+        FieldPermissions giantConfigPerm;
         for (FieldPermissions fp : [
             SELECT Field, PermissionsEdit, PermissionsRead
             FROM FieldPermissions
@@ -152,6 +154,10 @@ private class DocGenBulkTests {
                 labelPerm = fp;
             } else if (isFieldPermission(fp.Field, 'DocGen_Job__c', 'Merge_Only__c')) {
                 mergeOnlyPerm = fp;
+            } else if (isFieldPermission(fp.Field, 'DocGen_Job__c', 'Parent_Record_Id__c')) {
+                parentRecordPerm = fp;
+            } else if (isFieldPermission(fp.Field, 'DocGen_Job__c', 'Giant_Query_Config__c')) {
+                giantConfigPerm = fp;
             }
         }
 
@@ -174,6 +180,26 @@ private class DocGenBulkTests {
             true,
             mergeOnlyPerm.PermissionsEdit,
             'DocGen_User must be able to create Merge_Only__c because submitJob writes it before SYSTEM_MODE insert.'
+        );
+        System.assertNotEquals(
+            null,
+            parentRecordPerm,
+            'DocGen_User must declare DocGen_Job__c.Parent_Record_Id__c FLS for giant-query job creation.'
+        );
+        System.assertEquals(
+            true,
+            parentRecordPerm.PermissionsEdit,
+            'DocGen_User must be able to create Parent_Record_Id__c because giant-query launch writes it before SYSTEM_MODE insert.'
+        );
+        System.assertNotEquals(
+            null,
+            giantConfigPerm,
+            'DocGen_User must declare DocGen_Job__c.Giant_Query_Config__c FLS for giant-query job creation.'
+        );
+        System.assertEquals(
+            true,
+            giantConfigPerm.PermissionsEdit,
+            'DocGen_User must be able to create Giant_Query_Config__c because the controller giant-query launch writes it before SYSTEM_MODE insert.'
         );
     }
 

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -643,7 +643,7 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 SELECT Id, VersionData
                 FROM ContentVersion
                 WHERE Id = :contentVersionId AND Title LIKE 'docgen_%'
-                WITH USER_MODE
+                WITH SYSTEM_MODE
                 LIMIT 1
             ];
         } else if (safeFields == 'Id, ContentSize') {
@@ -651,7 +651,7 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 SELECT Id, ContentSize
                 FROM ContentVersion
                 WHERE Id = :contentVersionId AND Title LIKE 'docgen_%'
-                WITH USER_MODE
+                WITH SYSTEM_MODE
                 LIMIT 1
             ];
         } else {
@@ -659,7 +659,7 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 SELECT Id, ContentDocumentId
                 FROM ContentVersion
                 WHERE Id = :contentVersionId AND Title LIKE 'docgen_%'
-                WITH USER_MODE
+                WITH SYSTEM_MODE
                 LIMIT 1
             ];
         }
@@ -1005,12 +1005,13 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 // already been rewritten at upload time (image src → /sfc/ URLs).
                 if (!activeVersions.isEmpty() && String.isNotBlank(activeVersions[0].Content_Version_Id__c)) {
                     Id bodyCvId = (Id) activeVersions[0].Content_Version_Id__c;
+                    DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'VersionData' });
                     /* code-analyzer-suppress ApexFlsViolation */
                     List<ContentVersion> htmlCvs = [
                         SELECT VersionData
                         FROM ContentVersion
                         WHERE Id = :bodyCvId
-                        WITH USER_MODE
+                        WITH SYSTEM_MODE
                         LIMIT 1
                     ];
                     if (!htmlCvs.isEmpty()) {
@@ -1185,11 +1186,13 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
     public static Map<String, Object> getGiantQueryFragments(Id jobId) {
         String prefix = 'docgen_giant_' + jobId + '_';
         String shellTitle = 'docgen_giant_' + jobId + '_shell';
+        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title' });
+        /* code-analyzer-suppress ApexFlsViolation */
         List<ContentVersion> fragments = [
             SELECT Id, Title
             FROM ContentVersion
             WHERE Title LIKE :(prefix + '%') AND Title != :shellTitle
-            WITH USER_MODE
+            WITH SYSTEM_MODE
             ORDER BY Title // NOPMD — internal fragment lookup
         ];
         List<String> fragmentIds = new List<String>();
@@ -1226,11 +1229,13 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
         if (finalCvId == null) {
             // Legacy lookup: title pattern (pre-v1.90 jobs)
             String finalTitle = 'docgen_giant_' + jobId + '_final';
+            DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title' });
+            /* code-analyzer-suppress ApexFlsViolation */
             List<ContentVersion> finalCvs = [
                 SELECT Id
                 FROM ContentVersion
                 WHERE Title = :finalTitle
-                WITH USER_MODE
+                WITH SYSTEM_MODE
                 LIMIT 1 // NOPMD — internal lookup
             ];
             if (!finalCvs.isEmpty()) {
@@ -1240,11 +1245,13 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
 
         // Look up PDF parts if multiple chunks were rendered
         String partPrefix = 'docgen_giant_' + jobId + '_part_';
+        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title' });
+        /* code-analyzer-suppress ApexFlsViolation */
         List<ContentVersion> partCvs = [
             SELECT Id
             FROM ContentVersion
             WHERE Title LIKE :(partPrefix + '%')
-            WITH USER_MODE
+            WITH SYSTEM_MODE
             ORDER BY Title // NOPMD
         ];
         List<String> partIds = new List<String>();
@@ -1302,19 +1309,21 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
     public static void cleanupGiantQueryFragments(Id jobId) {
         String prefix = 'docgen_giant_' + jobId + '_';
         Set<Id> docIds = new Set<Id>();
+        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'ContentDocumentId', 'Title' });
+        /* code-analyzer-suppress ApexFlsViolation */
         for (ContentVersion cv : [
             SELECT ContentDocumentId
             FROM ContentVersion
             WHERE Title LIKE :(prefix + '%')
-            WITH USER_MODE // NOPMD — internal fragment cleanup
+            WITH SYSTEM_MODE // NOPMD — internal fragment cleanup
         ]) {
             docIds.add(cv.ContentDocumentId);
         }
         if (!docIds.isEmpty()) {
             Database.delete(
-                [SELECT Id FROM ContentDocument WHERE Id IN :docIds WITH USER_MODE],
+                [SELECT Id FROM ContentDocument WHERE Id IN :docIds WITH SYSTEM_MODE],
                 true,
-                AccessLevel.USER_MODE
+                AccessLevel.SYSTEM_MODE
             );
         }
     }

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -1034,18 +1034,10 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                     if (!Schema.sObjectType.ContentVersion.isAccessible()) {
                         throw new DocGenException('ContentVersion access denied.');
                     }
-                    DocGenFlsGuard.assertAccessible(
-                        ContentVersion.sObjectType,
-                        new Set<String>{ 'VersionData', 'Title' }
+                    List<ContentVersion> xmlCvs = DocGenService.loadInternalContentVersionsForVersionByTitle(
+                        activeVersions[0].Id,
+                        xmlKey
                     );
-                    /* code-analyzer-suppress ApexFlsViolation */
-                    List<ContentVersion> xmlCvs = [
-                        SELECT VersionData
-                        FROM ContentVersion
-                        WHERE Title = :xmlKey
-                        WITH SYSTEM_MODE
-                        LIMIT 1
-                    ];
                     if (!xmlCvs.isEmpty()) {
                         documentXml = xmlCvs[0].VersionData.toString();
                     }
@@ -1386,12 +1378,13 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             if (templateType == 'HTML') {
                 if (!activeVersions.isEmpty() && String.isNotBlank(activeVersions[0].Content_Version_Id__c)) {
                     Id bodyCvId = (Id) activeVersions[0].Content_Version_Id__c;
+                    DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'VersionData' });
                     /* code-analyzer-suppress ApexFlsViolation */
                     List<ContentVersion> htmlCvs = [
                         SELECT VersionData
                         FROM ContentVersion
                         WHERE Id = :bodyCvId
-                        WITH USER_MODE
+                        WITH SYSTEM_MODE
                         LIMIT 1
                     ];
                     if (!htmlCvs.isEmpty()) {
@@ -1410,18 +1403,10 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                     if (!Schema.sObjectType.ContentVersion.isAccessible()) {
                         throw new DocGenException('ContentVersion access denied.');
                     }
-                    DocGenFlsGuard.assertAccessible(
-                        ContentVersion.sObjectType,
-                        new Set<String>{ 'VersionData', 'Title' }
+                    List<ContentVersion> xmlCvs = DocGenService.loadInternalContentVersionsForVersionByTitle(
+                        activeVersions[0].Id,
+                        xmlKey
                     );
-                    /* code-analyzer-suppress ApexFlsViolation */
-                    List<ContentVersion> xmlCvs = [
-                        SELECT VersionData
-                        FROM ContentVersion
-                        WHERE Title = :xmlKey
-                        WITH SYSTEM_MODE
-                        LIMIT 1
-                    ];
                     if (!xmlCvs.isEmpty()) {
                         documentXml = xmlCvs[0].VersionData.toString();
                     }

--- a/force-app/main/default/classes/DocGenGiantQueryAssembler.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryAssembler.cls
@@ -282,23 +282,17 @@ public with sharing class DocGenGiantQueryAssembler implements Queueable {
         String html = null;
         if (!vers.isEmpty()) {
             String htmlTitle = 'docgen_tmpl_html_' + vers[0].Id;
-            // SYSTEM_MODE per #114: docgen_tmpl_html_ is an internal package snapshot
-            // CV whose ContentDocumentLink defaults to Visibility=InternalUsers, so
-            // WITH USER_MODE returns empty even though the record exists. That empty
-            // result silently routed the giant-query path to its bare-table fallback,
-            // dropping the template's title/column-headers/footer (the >2000-row
-            // regression). User access is already gated by the active-version query
-            // above; this is the FLS-guard + SYSTEM_MODE hybrid used everywhere else in
-            // this class (see line ~381) and in DocGenController (the analogous read).
-            DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'VersionData' });
-            /* code-analyzer-suppress ApexFlsViolation */
-            List<ContentVersion> htmlCvs = [
-                SELECT VersionData
-                FROM ContentVersion
-                WHERE Title = :htmlTitle
-                WITH SYSTEM_MODE
-                LIMIT 1
-            ];
+            // Load through the template-version ContentDocumentLink in the same
+            // without-sharing helper used for XML parts. A title-only ContentVersion
+            // query from this with-sharing queueable can return empty for internal
+            // snapshot files, which silently falls back to the bare-table renderer.
+            List<ContentVersion> htmlCvs = DocGenService.loadInternalContentVersionsForVersionByTitle(
+                vers[0].Id,
+                htmlTitle
+            );
+            if (htmlCvs.isEmpty()) {
+                htmlCvs = DocGenService.loadInternalContentVersionsByTitle(htmlTitle);
+            }
             if (!htmlCvs.isEmpty()) {
                 html = htmlCvs[0].VersionData.toString();
             }

--- a/force-app/main/default/classes/DocGenGiantQueryAssembler.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryAssembler.cls
@@ -134,6 +134,7 @@ public with sharing class DocGenGiantQueryAssembler implements Queueable {
         String html = injectRowsIntoTemplate(htmlTemplate, allRows);
         allRows = null;
         htmlTemplate = null;
+        DocGenService.ensureTemplateAssetImageAccessForPdf(templateId, recordId, html);
 
         // DEBUG: save HTML for inspection before Blob.toPdf()
         ContentVersion debugCv = new ContentVersion(

--- a/force-app/main/default/classes/DocGenGiantQueryAssembler.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryAssembler.cls
@@ -66,10 +66,16 @@ public with sharing class DocGenGiantQueryAssembler implements Queueable {
             String allRows = '';
             Set<Id> fragDocIds = new Set<Id>();
 
+            DocGenFlsGuard.assertAccessible(
+                ContentVersion.sObjectType,
+                new Set<String>{ 'Title', 'VersionData', 'ContentDocumentId' }
+            );
+            /* code-analyzer-suppress ApexFlsViolation */
             List<ContentVersion> frags = [
                 SELECT Title, VersionData, ContentDocumentId
                 FROM ContentVersion
                 WHERE Title LIKE :(prefix + '%') AND Title != :finalExclude AND (NOT Title LIKE :partExclude)
+                WITH SYSTEM_MODE
                 ORDER BY Title
                 LIMIT 10000 // NOPMD — need all fragments for assembly
             ];

--- a/force-app/main/default/classes/DocGenGiantQueryFlowAction.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryFlowAction.cls
@@ -196,15 +196,10 @@ global with sharing class DocGenGiantQueryFlowAction { // NOPMD AvoidGlobalModif
             // Visibility=InternalUsers on fresh upload (subscriber-org artifact of
             // the platform behavior). Access is gated upstream by the active
             // template version USER_MODE query.
-            DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'VersionData', 'Title' });
-            /* code-analyzer-suppress ApexFlsViolation */
-            List<ContentVersion> xmlCvs = [
-                SELECT VersionData
-                FROM ContentVersion
-                WHERE Title = :xmlKey
-                WITH SYSTEM_MODE
-                LIMIT 1
-            ];
+            List<ContentVersion> xmlCvs = DocGenService.loadInternalContentVersionsForVersionByTitle(
+                activeVersions[0].Id,
+                xmlKey
+            );
             if (!xmlCvs.isEmpty()) {
                 documentXml = xmlCvs[0].VersionData.toString();
             }

--- a/force-app/main/default/classes/DocGenGiantQueryStitchJob.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryStitchJob.cls
@@ -64,7 +64,14 @@ public with sharing class DocGenGiantQueryStitchJob implements Database.Batchabl
         this.templateName = tmpl.Name;
 
         String prefix = 'docgen_giant_' + jobId + '_';
-        Integer fragmentCount = [SELECT COUNT() FROM ContentVersion WHERE Title LIKE :(prefix + '%') WITH USER_MODE];
+        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title' });
+        /* code-analyzer-suppress ApexFlsViolation */
+        Integer fragmentCount = [
+            SELECT COUNT()
+            FROM ContentVersion
+            WHERE Title LIKE :(prefix + '%')
+            WITH SYSTEM_MODE
+        ];
 
         if (fragmentCount == 0) {
             update new DocGen_Job__c(Id = jobId, Status__c = 'Failed', Label__c = 'No fragments found'); // NOPMD ApexCRUDViolation — package-internal; CRUD controlled by permission sets
@@ -87,11 +94,13 @@ public with sharing class DocGenGiantQueryStitchJob implements Database.Batchabl
             Integer groupIdx = Integer.valueOf(groupDescriptor.substringAfter(':'));
 
             String prefix = 'docgen_giant_' + jobId + '_';
+            DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title' });
+            /* code-analyzer-suppress ApexFlsViolation */
             List<ContentVersion> allHeaders = [
                 SELECT Id, Title
                 FROM ContentVersion
                 WHERE Title LIKE :(prefix + '%')
-                WITH USER_MODE
+                WITH SYSTEM_MODE
                 ORDER BY Title
             ];
 
@@ -105,11 +114,13 @@ public with sharing class DocGenGiantQueryStitchJob implements Database.Batchabl
             }
 
             String combinedHtml = '';
+            DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'VersionData', 'Title' });
+            /* code-analyzer-suppress ApexFlsViolation */
             for (ContentVersion cv : [
                 SELECT VersionData, Title
                 FROM ContentVersion
                 WHERE Id IN :groupIds
-                WITH USER_MODE
+                WITH SYSTEM_MODE
                 ORDER BY Title
             ]) {
                 combinedHtml += cv.VersionData.toString();
@@ -166,11 +177,16 @@ public with sharing class DocGenGiantQueryStitchJob implements Database.Batchabl
             // Clean up HTML fragments (no longer needed)
             String fragPrefix = 'docgen_giant_' + jobId + '_';
             Set<Id> fragmentDocIds = new Set<Id>();
+            DocGenFlsGuard.assertAccessible(
+                ContentVersion.sObjectType,
+                new Set<String>{ 'ContentDocumentId', 'Title' }
+            );
+            /* code-analyzer-suppress ApexFlsViolation */
             for (ContentVersion cv : [
                 SELECT ContentDocumentId
                 FROM ContentVersion
                 WHERE Title LIKE :(fragPrefix + '%')
-                WITH USER_MODE
+                WITH SYSTEM_MODE
             ]) {
                 fragmentDocIds.add(cv.ContentDocumentId);
             }
@@ -180,11 +196,16 @@ public with sharing class DocGenGiantQueryStitchJob implements Database.Batchabl
 
             // Load all part PDFs — ~15KB each, 20 parts = ~300KB total, trivially within heap
             String partPrefix = 'docgen_part_' + jobId + '_';
+            DocGenFlsGuard.assertAccessible(
+                ContentVersion.sObjectType,
+                new Set<String>{ 'VersionData', 'ContentDocumentId', 'Title' }
+            );
+            /* code-analyzer-suppress ApexFlsViolation */
             List<ContentVersion> parts = [
                 SELECT Id, VersionData, ContentDocumentId
                 FROM ContentVersion
                 WHERE Title LIKE :(partPrefix + '%')
-                WITH USER_MODE
+                WITH SYSTEM_MODE
                 ORDER BY Title
             ];
 

--- a/force-app/main/default/classes/DocGenGiantQueryTest.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryTest.cls
@@ -294,6 +294,7 @@ private class DocGenGiantQueryTest {
             String snapshotHtml =
                 '<html><body>' +
                 '<h1>GQ_CHROME_TITLE</h1>' +
+                '<p><img src="/sfc/servlet.shepherd/version/download/068000000000000AAA" alt="GQ_CHROME_LOGO"/></p>' +
                 '<table>' +
                 '<tr><th>GQ_CHROME_HEADER</th></tr>' +
                 '<tr>{#Contacts}<td>{FirstName}</td>{/Contacts}</tr>' +
@@ -304,7 +305,8 @@ private class DocGenGiantQueryTest {
                 Title = 'docgen_tmpl_html_' + ver.Id,
                 PathOnClient = 'snapshot.html',
                 VersionData = Blob.valueOf(snapshotHtml),
-                IsMajorVersion = false
+                IsMajorVersion = false,
+                FirstPublishLocationId = ver.Id
             );
 
             DocGen_Job__c job = new DocGen_Job__c(
@@ -343,6 +345,7 @@ private class DocGenGiantQueryTest {
             );
             System.assert(assembled.contains('GQ_CHROME_HEADER'), 'Column-header chrome must survive');
             System.assert(assembled.contains('GQ_CHROME_FOOTER'), 'Footer chrome must survive');
+            System.assert(assembled.contains('GQ_CHROME_LOGO'), 'Embedded template image HTML must survive');
         }
     }
 

--- a/force-app/main/default/classes/DocGenMiscTests.cls
+++ b/force-app/main/default/classes/DocGenMiscTests.cls
@@ -9451,6 +9451,59 @@ private class DocGenMiscTests {
         assertGiantLauncherUsesInternalLoader(flowActionBody, 'DocGenGiantQueryFlowAction');
     }
 
+    @IsTest
+    static void testTemplateAssetImageAccessLinkedForPdfRender() {
+        Account acc = new Account(Name = 'Template Asset Image Access');
+        insert acc;
+
+        DocGen_Template__c tpl = new DocGen_Template__c(
+            Name = 'Template Asset Image Access',
+            Base_Object_API__c = 'Account',
+            Type__c = 'Word',
+            Output_Format__c = 'PDF',
+            Query_Config__c = 'Name'
+        );
+        Database.insert(tpl, AccessLevel.SYSTEM_MODE);
+
+        DocGen_Template_Version__c ver = new DocGen_Template_Version__c(
+            Template__c = tpl.Id,
+            Is_Active__c = true,
+            Query_Config__c = 'Name',
+            Type__c = 'Word',
+            Base_Object_API__c = 'Account',
+            Output_Format__c = 'PDF'
+        );
+        Database.insert(ver, AccessLevel.SYSTEM_MODE);
+
+        ContentVersion img = new ContentVersion(
+            Title = 'docgen_tmpl_img_' + ver.Id + '_rIdLogo',
+            PathOnClient = 'logo.png',
+            VersionData = Blob.valueOf('PNG'),
+            FirstPublishLocationId = ver.Id
+        );
+        insert img;
+        img = [SELECT Id, ContentDocumentId FROM ContentVersion WHERE Id = :img.Id];
+
+        String html = '<html><body><img src="/sfc/servlet.shepherd/version/download/' + img.Id + '" /></body></html>';
+
+        Test.startTest();
+        DocGenService.ensureTemplateAssetImageAccessForPdf(tpl.Id, acc.Id, html);
+        Test.stopTest();
+
+        List<ContentDocumentLink> links = [
+            SELECT Id, Visibility, ShareType
+            FROM ContentDocumentLink
+            WHERE LinkedEntityId = :acc.Id AND ContentDocumentId = :img.ContentDocumentId
+        ];
+        System.assertEquals(
+            1,
+            links.size(),
+            'Template image file should be linked to the source record for PDF fetch.'
+        );
+        System.assertEquals('AllUsers', links[0].Visibility, 'PDF fetch link should be visible to internal users.');
+        System.assertEquals('V', links[0].ShareType, 'PDF fetch link should grant viewer access only.');
+    }
+
     private static void assertGiantLauncherUsesInternalLoader(String body, String className) {
         Integer idx = body.indexOf('docgen_tmpl_xml_');
         System.assert(idx >= 0, className + ' should reference pre-decomposed template XML.');

--- a/force-app/main/default/classes/DocGenMiscTests.cls
+++ b/force-app/main/default/classes/DocGenMiscTests.cls
@@ -9250,9 +9250,55 @@ private class DocGenMiscTests {
     // with a source-text assertion that catches any future revert to USER_MODE.
     // =========================================================================
     @IsTest
+    static void testInternalContentVersionLoaderWorksForNonAdminUser() {
+        Profile p = [SELECT Id FROM Profile WHERE Name = 'Standard User' LIMIT 1];
+        User stdUser = new User(
+            Alias = 'dgload',
+            Email = 'docgen-loader@example.com',
+            EmailEncodingKey = 'UTF-8',
+            LastName = 'Loader',
+            LanguageLocaleKey = 'en_US',
+            LocaleSidKey = 'en_US',
+            ProfileId = p.Id,
+            TimeZoneSidKey = 'America/Los_Angeles',
+            UserName = 'docgen.loader.' + System.currentTimeMillis() + '@example.com'
+        );
+        User currentUser = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(currentUser) {
+            insert stdUser;
+        }
+
+        DocGen_Template_Version__c version = TestDataFactory.getTestTemplateVersion();
+        String title = 'docgen_tmpl_xml_' + version.Id + '_word__document.xml';
+        insert new ContentVersion(
+            Title = title,
+            PathOnClient = title + '.xml',
+            VersionData = Blob.valueOf('<w:document>{#Contacts}<w:t>{LastName}</w:t>{/Contacts}</w:document>'),
+            FirstPublishLocationId = version.Id,
+            IsMajorVersion = true
+        );
+
+        System.runAs(stdUser) {
+            Test.startTest();
+            List<ContentVersion> loaded = DocGenService.loadInternalContentVersionsForVersionByTitle(version.Id, title);
+            Test.stopTest();
+
+            System.assertEquals(
+                1,
+                loaded.size(),
+                'Non-admin user should load package-internal CV through the template version link'
+            );
+            System.assert(
+                loaded[0].VersionData.toString().contains('{#Contacts}'),
+                'Loaded CV should include the pre-decomposed template body'
+            );
+        }
+    }
+
+    @IsTest
     static void testIssue114NoUserModeOnPreDecompCvLookups() {
         List<String> classNames = new List<String>{ 'DocGenService', 'DocGenController', 'DocGenGiantQueryFlowAction' };
-        for (ApexClass ac : [SELECT Name, Body FROM ApexClass WHERE Name IN :classNames AND NamespacePrefix = NULL]) {
+        for (ApexClass ac : [SELECT Name, Body FROM ApexClass WHERE Name IN :classNames]) {
             String body = ac.Body;
             Integer cursor = 0;
             Integer hits = 0;
@@ -9310,7 +9356,13 @@ private class DocGenMiscTests {
         for (ApexClass ac : [
             SELECT Name, Body
             FROM ApexClass
-            WHERE Name IN ('DocGenController', 'DocGenGiantQueryAssembler', 'DocGenGiantQueryStitchJob')
+            WHERE
+                Name IN (
+                    'DocGenController',
+                    'DocGenGiantQueryAssembler',
+                    'DocGenGiantQueryStitchJob',
+                    'DocGenGiantQueryFlowAction'
+                )
         ]) {
             classesByName.put(ac.Name, ac);
         }
@@ -9373,6 +9425,20 @@ private class DocGenMiscTests {
             'DocGenGiantQueryStitchJob',
             'docgen_part_',
             'No PDF parts found'
+        );
+
+        String flowActionBody = classesByName.get('DocGenGiantQueryFlowAction').Body;
+        assertGiantLauncherUsesInternalLoader(controllerBody, 'DocGenController');
+        assertGiantLauncherUsesInternalLoader(flowActionBody, 'DocGenGiantQueryFlowAction');
+    }
+
+    private static void assertGiantLauncherUsesInternalLoader(String body, String className) {
+        Integer idx = body.indexOf('docgen_tmpl_xml_');
+        System.assert(idx >= 0, className + ' should reference pre-decomposed template XML.');
+        Integer loaderIdx = body.indexOf('DocGenService.loadInternalContentVersionsForVersionByTitle', idx);
+        System.assert(
+            loaderIdx > idx,
+            className + ' must use the without-sharing internal ContentVersion loader for giant-query pre-decomp reads.'
         );
     }
 

--- a/force-app/main/default/classes/DocGenMiscTests.cls
+++ b/force-app/main/default/classes/DocGenMiscTests.cls
@@ -9303,4 +9303,112 @@ private class DocGenMiscTests {
             );
         }
     }
+
+    @IsTest
+    static void testGiantQueryInternalContentReadsUseSystemMode() {
+        Map<String, ApexClass> classesByName = new Map<String, ApexClass>();
+        for (ApexClass ac : [
+            SELECT Name, Body
+            FROM ApexClass
+            WHERE Name IN ('DocGenController', 'DocGenGiantQueryAssembler', 'DocGenGiantQueryStitchJob')
+        ]) {
+            classesByName.put(ac.Name, ac);
+        }
+
+        String assemblerBody = classesByName.get('DocGenGiantQueryAssembler').Body;
+        Integer giantPrefixIdx = assemblerBody.indexOf('String prefix = \'docgen_giant_\' + jobId + \'_\';');
+        Integer assemblerLoopIdx = assemblerBody.indexOf('for (ContentVersion cv : frags)', giantPrefixIdx);
+        System.assert(giantPrefixIdx >= 0 && assemblerLoopIdx > giantPrefixIdx, 'Assembler fragment lookup moved.');
+        String assemblerSlice = assemblerBody.substring(giantPrefixIdx, assemblerLoopIdx);
+        System.assert(
+            assemblerSlice.contains('WITH SYSTEM_MODE'),
+            'DocGenGiantQueryAssembler must read internal docgen_giant_ fragments WITH SYSTEM_MODE.'
+        );
+        System.assert(
+            !assemblerSlice.contains('WITH USER_MODE'),
+            'DocGenGiantQueryAssembler must not read internal docgen_giant_ fragments WITH USER_MODE.'
+        );
+
+        String controllerBody = classesByName.get('DocGenController').Body;
+        Integer htmlBodyIdx = controllerBody.indexOf('Id bodyCvId = (Id) activeVersions[0].Content_Version_Id__c;');
+        Integer htmlMissingIdx = controllerBody.indexOf('HTML template has no active version body.', htmlBodyIdx);
+        System.assert(htmlBodyIdx >= 0 && htmlMissingIdx > htmlBodyIdx, 'Giant HTML launch body lookup moved.');
+        String htmlBodySlice = controllerBody.substring(htmlBodyIdx, htmlMissingIdx);
+        System.assert(
+            htmlBodySlice.contains('WITH SYSTEM_MODE'),
+            'Giant-query HTML launch must read the active template body ContentVersion WITH SYSTEM_MODE.'
+        );
+        System.assert(
+            !htmlBodySlice.contains('WITH USER_MODE'),
+            'Giant-query HTML launch must not read the active template body ContentVersion WITH USER_MODE.'
+        );
+
+        Integer managedFallbackIdx = controllerBody.indexOf('WHERE Id = :contentVersionId AND Title LIKE \'docgen_%\'');
+        Integer managedFallbackEnd = controllerBody.indexOf(
+            'throw DocGenService.ahe(\'Access denied or content not found.\');'
+        );
+        System.assert(
+            managedFallbackIdx >= 0 && managedFallbackEnd > managedFallbackIdx,
+            'Managed ContentVersion fallback lookup moved.'
+        );
+        String managedFallbackSlice = controllerBody.substring(managedFallbackIdx, managedFallbackEnd);
+        System.assert(
+            managedFallbackSlice.contains('WITH SYSTEM_MODE'),
+            'Managed docgen_% ContentVersion fallback must use SYSTEM_MODE after the USER_MODE sharing check fails.'
+        );
+        System.assert(
+            !managedFallbackSlice.contains('WITH USER_MODE'),
+            'Managed docgen_% ContentVersion fallback must not keep using USER_MODE after sharing access fails.'
+        );
+
+        String stitchBody = classesByName.get('DocGenGiantQueryStitchJob').Body;
+        assertInternalContentQueryUsesSystemMode(
+            stitchBody,
+            'DocGenGiantQueryStitchJob',
+            'docgen_giant_',
+            'FRAGMENTS_PER_PDF'
+        );
+        assertInternalContentQueryUsesSystemMode(
+            stitchBody,
+            'DocGenGiantQueryStitchJob',
+            'docgen_part_',
+            'No PDF parts found'
+        );
+    }
+
+    private static void assertInternalContentQueryUsesSystemMode(
+        String body,
+        String className,
+        String titlePrefix,
+        String afterMarker
+    ) {
+        Integer cursor = 0;
+        Integer hits = 0;
+        while (true) {
+            Integer idx = body.indexOf(titlePrefix, cursor);
+            if (idx == -1) {
+                break;
+            }
+            Integer close = body.indexOf(afterMarker, idx);
+            if (close == -1) {
+                close = body.indexOf('];', idx);
+            }
+            if (close != -1) {
+                String slice = body.substring(idx, close);
+                if (slice.contains('FROM ContentVersion')) {
+                    hits++;
+                    System.assert(
+                        slice.contains('WITH SYSTEM_MODE'),
+                        className + ' must read internal ' + titlePrefix + ' ContentVersion rows WITH SYSTEM_MODE.'
+                    );
+                    System.assert(
+                        !slice.contains('WITH USER_MODE'),
+                        className + ' must not read internal ' + titlePrefix + ' ContentVersion rows WITH USER_MODE.'
+                    );
+                }
+            }
+            cursor = idx + titlePrefix.length();
+        }
+        System.assert(hits > 0, 'Sanity: expected internal ' + titlePrefix + ' ContentVersion reads in ' + className);
+    }
 }

--- a/force-app/main/default/classes/DocGenMiscTests.cls
+++ b/force-app/main/default/classes/DocGenMiscTests.cls
@@ -5992,6 +5992,25 @@ private class DocGenMiscTests {
     }
 
     @IsTest
+    static void testMergeRunsFooterTagSplitAcrossBraceRuns() {
+        String footerXml =
+            '<w:ftr xmlns:w="x"><w:p>' +
+            '<w:r><w:t>Premium Text short codes </w:t></w:r>' +
+            '<w:r><w:t>{</w:t></w:r>' +
+            '<w:r><w:t>Date_for_merge_document__c</w:t></w:r>' +
+            '<w:r><w:t>}</w:t></w:r>' +
+            '</w:p></w:ftr>';
+
+        String result = DocGenService.mergeRunsInTagsForTest(footerXml);
+
+        System.assert(
+            result.contains('{Date_for_merge_document__c}'),
+            'Footer/header tags split across brace runs must be merged before giant-query HTML snapshot conversion: ' +
+            result
+        );
+    }
+
+    @IsTest
     static void testNestedTableOuterCellOwnTcPrStillRespected() {
         // Outer cell has its own <w:tcPr> with shading; nested cells have their
         // own tcPr. Outer must use ITS OWN shading, not the inner cell's.

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -2150,6 +2150,132 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
     }
 
     /**
+     * Blob.toPdf() fetches relative shepherd image URLs as the running user. Template
+     * asset images can be linked only to DocGen's internal version records, so a
+     * non-owner/non-admin user who can read the shared template may still see broken
+     * images in the rendered PDF. Before calling Blob.toPdf(), link only referenced
+     * template-owned image files to the source record so the running user can fetch
+     * the existing /sfc/servlet.shepherd/version/download/<cvId> URL without loading
+     * image blobs into heap.
+     */
+    public static void ensureTemplateAssetImageAccessForPdf(Id templateId, Id recordId, String html) {
+        if (templateId == null || recordId == null || String.isBlank(html) || !html.contains('/version/download/')) {
+            return;
+        }
+
+        Set<Id> referencedCvIds = extractShepherdContentVersionIds(html);
+        if (referencedCvIds.isEmpty()) {
+            return;
+        }
+
+        DocGenFlsGuard.assertAccessible(
+            DocGen_Template_Version__c.sObjectType,
+            new Set<String>{ 'Template__c', 'Is_Active__c' }
+        );
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<DocGen_Template_Version__c> activeVersions = [
+            SELECT Id
+            FROM DocGen_Template_Version__c
+            WHERE Template__c = :templateId AND Is_Active__c = TRUE
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (activeVersions.isEmpty()) {
+            return;
+        }
+
+        String versionId = String.valueOf(activeVersions[0].Id);
+        String templateIdText = String.valueOf(templateId);
+        List<String> assetPrefixes = new List<String>{
+            'docgen_tmpl_img_' +
+            versionId +
+            '_',
+            'docgen_html_img_' +
+            versionId +
+            '_',
+            'docgen_html_img_' +
+            templateIdText +
+            '_'
+        };
+
+        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title', 'ContentDocumentId' });
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<ContentVersion> referenced = [
+            SELECT Id, Title, ContentDocumentId
+            FROM ContentVersion
+            WHERE Id IN :referencedCvIds
+            WITH SYSTEM_MODE
+        ];
+
+        Set<Id> assetDocIds = new Set<Id>();
+        for (ContentVersion cv : referenced) {
+            Boolean isTemplateAsset = false;
+            for (String prefix : assetPrefixes) {
+                if (cv.Title != null && cv.Title.startsWith(prefix)) {
+                    isTemplateAsset = true;
+                    break;
+                }
+            }
+            if (isTemplateAsset && cv.ContentDocumentId != null) {
+                assetDocIds.add(cv.ContentDocumentId);
+            }
+        }
+        if (assetDocIds.isEmpty()) {
+            return;
+        }
+
+        Set<Id> alreadyLinked = new Set<Id>();
+        /* code-analyzer-suppress ApexFlsViolation */
+        for (ContentDocumentLink existing : [
+            SELECT ContentDocumentId
+            FROM ContentDocumentLink
+            WHERE LinkedEntityId = :recordId AND ContentDocumentId IN :assetDocIds
+            WITH SYSTEM_MODE
+        ]) {
+            alreadyLinked.add(existing.ContentDocumentId);
+        }
+
+        List<ContentDocumentLink> links = new List<ContentDocumentLink>();
+        for (Id docId : assetDocIds) {
+            if (alreadyLinked.contains(docId)) {
+                continue;
+            }
+            links.add(
+                new ContentDocumentLink(
+                    ContentDocumentId = docId,
+                    LinkedEntityId = recordId,
+                    ShareType = 'V',
+                    Visibility = 'AllUsers'
+                )
+            );
+        }
+        if (!links.isEmpty()) {
+            /* code-analyzer-suppress ApexFlsViolation */
+            Database.insert(links, false, AccessLevel.SYSTEM_MODE);
+        }
+    }
+
+    private static Set<Id> extractShepherdContentVersionIds(String html) {
+        Set<Id> ids = new Set<Id>();
+        if (String.isBlank(html)) {
+            return ids;
+        }
+        Pattern p = Pattern.compile('/sfc/servlet\\.shepherd/version/download/([a-zA-Z0-9]{15,18})');
+        Matcher m = p.matcher(html);
+        while (m.find()) {
+            try {
+                Id cvId = Id.valueOf(m.group(1));
+                if (String.valueOf(cvId).startsWith('068')) {
+                    ids.add(cvId);
+                }
+            } catch (Exception ignored) {
+                // Not a Salesforce Id; ignore.
+            }
+        }
+        return ids;
+    }
+
+    /**
      * Generates a PDF Blob from a MergeResult using the unified image map.
      * Single entry point for all PDF rendering — used by generateDocument()
      * and generatePdfBlob().
@@ -2179,6 +2305,7 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             // HTML template type: documentXml is a ready-to-render HTML document —
             // skip the DOCX→HTML conversion entirely.
             if (mr.templateType == 'HTML') {
+                ensureTemplateAssetImageAccessForPdf(templateId, recordId, mr.documentXml);
                 lastRenderedHtml = mr.documentXml;
                 return Blob.toPdf(mr.documentXml);
             }
@@ -2191,6 +2318,7 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             setNumberingXml(mr);
             applyWatermarkOverride(templateId);
             String html = DocGenHtmlRenderer.convertToHtml(combineXmlWithHeadersFooters(mr), pdfImages);
+            ensureTemplateAssetImageAccessForPdf(templateId, recordId, html);
             lastRenderedHtml = html;
 
             return Blob.toPdf(html);

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -7446,7 +7446,7 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         MergeResult mr = mergeTemplate(templateId, recordIdStr, null, 'PDF');
 
         if (mr.templateType == 'PowerPoint') {
-            throw new DocGenException('Signature PDF generation is only supported for Word templates.');
+            throw new DocGenException('Signature PDF generation is only supported for Word and HTML templates.');
         }
 
         Map<String, String> pdfImages = buildPdfImageMap(mr, templateId);
@@ -7470,7 +7470,8 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
 
         return new Map<String, Object>{
             'documentXml' => mr.documentXml,
-            'combinedDocumentXml' => combineXmlWithHeadersFooters(mr),
+            'combinedDocumentXml' => mr.templateType == 'HTML' ? mr.documentXml : combineXmlWithHeadersFooters(mr),
+            'templateType' => mr.templateType,
             'relsXml' => mr.relsXml,
             'contentTypesXml' => mr.contentTypesXml,
             'pdfImageMap' => pdfImages,

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -2033,7 +2033,7 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
                     if (xmlName == 'word/styles.xml') {
                         htmlMr.processedXmlEntries.put(xmlName, xmlEntries.get(xmlName));
                     } else if (xmlName.startsWith('word/header') || xmlName.startsWith('word/footer')) {
-                        htmlMr.processedXmlEntries.put(xmlName, xmlEntries.get(xmlName));
+                        htmlMr.processedXmlEntries.put(xmlName, mergeRunsInTags(xmlEntries.get(xmlName)));
                     }
                 }
 

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -98,6 +98,33 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
      * so bypassing sharing is safe. Template access is still gated by DocGen_Admin/User
      * permsets at the upstream entry points. (#28)
      */
+    public static List<ContentVersion> loadInternalContentVersionsByTitle(String title) {
+        return new PreDecompXmlLoader().loadByTitles(new Set<String>{ title });
+    }
+
+    public static List<ContentVersion> loadInternalContentVersionsByTitles(Set<String> titles) {
+        return new PreDecompXmlLoader().loadByTitles(titles);
+    }
+
+    public static List<ContentVersion> loadInternalContentVersionsByTitlePrefix(String titlePrefix) {
+        return new PreDecompXmlLoader().loadByTitlePrefix(titlePrefix);
+    }
+
+    public static List<ContentVersion> loadInternalContentVersionsForVersionByTitle(Id versionId, String title) {
+        return new PreDecompXmlLoader().loadForLinkedEntityByTitles(versionId, new Set<String>{ title });
+    }
+
+    public static List<ContentVersion> loadInternalContentVersionsForVersionByTitles(Id versionId, Set<String> titles) {
+        return new PreDecompXmlLoader().loadForLinkedEntityByTitles(versionId, titles);
+    }
+
+    public static List<ContentVersion> loadInternalContentVersionsForVersionByTitlePrefix(
+        Id versionId,
+        String titlePrefix
+    ) {
+        return new PreDecompXmlLoader().loadForLinkedEntityByTitlePrefix(versionId, titlePrefix);
+    }
+
     private without sharing class PreDecompXmlLoader {
         public List<ContentVersion> loadByTitlePrefix(String titlePrefix) {
             String likePattern = titlePrefix + '%';
@@ -112,6 +139,75 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
                 WHERE Title LIKE :likePattern AND IsLatest = TRUE
                 WITH SYSTEM_MODE // NOPMD — package-internal pre-decomposed parts
             ];
+        }
+
+        public List<ContentVersion> loadByTitles(Set<String> titles) {
+            DocGenFlsGuard.assertAccessible(
+                ContentVersion.sObjectType,
+                new Set<String>{ 'Title', 'VersionData', 'IsLatest' }
+            );
+            /* code-analyzer-suppress ApexFlsViolation */
+            return [
+                SELECT Id, Title, VersionData
+                FROM ContentVersion
+                WHERE Title IN :titles AND IsLatest = TRUE
+                WITH SYSTEM_MODE // NOPMD — package-internal pre-decomposed parts
+            ];
+        }
+
+        public List<ContentVersion> loadForLinkedEntityByTitlePrefix(Id linkedEntityId, String titlePrefix) {
+            Set<Id> docIds = getLinkedContentDocumentIds(linkedEntityId);
+            if (docIds.isEmpty()) {
+                return new List<ContentVersion>();
+            }
+            String likePattern = titlePrefix + '%';
+            DocGenFlsGuard.assertAccessible(
+                ContentVersion.sObjectType,
+                new Set<String>{ 'ContentDocumentId', 'Title', 'VersionData', 'IsLatest' }
+            );
+            /* code-analyzer-suppress ApexFlsViolation */
+            return [
+                SELECT Id, ContentDocumentId, Title, VersionData
+                FROM ContentVersion
+                WHERE ContentDocumentId IN :docIds AND Title LIKE :likePattern AND IsLatest = TRUE
+                WITH SYSTEM_MODE // NOPMD — package-internal pre-decomposed parts linked to template version
+            ];
+        }
+
+        public List<ContentVersion> loadForLinkedEntityByTitles(Id linkedEntityId, Set<String> titles) {
+            Set<Id> docIds = getLinkedContentDocumentIds(linkedEntityId);
+            if (docIds.isEmpty()) {
+                return new List<ContentVersion>();
+            }
+            DocGenFlsGuard.assertAccessible(
+                ContentVersion.sObjectType,
+                new Set<String>{ 'ContentDocumentId', 'Title', 'VersionData', 'IsLatest' }
+            );
+            /* code-analyzer-suppress ApexFlsViolation */
+            return [
+                SELECT Id, ContentDocumentId, Title, VersionData
+                FROM ContentVersion
+                WHERE ContentDocumentId IN :docIds AND Title IN :titles AND IsLatest = TRUE
+                WITH SYSTEM_MODE // NOPMD — package-internal pre-decomposed parts linked to template version
+            ];
+        }
+
+        private Set<Id> getLinkedContentDocumentIds(Id linkedEntityId) {
+            DocGenFlsGuard.assertAccessible(
+                ContentDocumentLink.sObjectType,
+                new Set<String>{ 'LinkedEntityId', 'ContentDocumentId' }
+            );
+            Set<Id> docIds = new Set<Id>();
+            /* code-analyzer-suppress ApexFlsViolation */
+            for (ContentDocumentLink link : [
+                SELECT ContentDocumentId
+                FROM ContentDocumentLink
+                WHERE LinkedEntityId = :linkedEntityId
+                WITH SYSTEM_MODE // NOPMD — package-internal files linked to template version
+            ]) {
+                docIds.add(link.ContentDocumentId);
+            }
+            return docIds;
         }
     }
 
@@ -715,7 +811,8 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             // still can't see these ContentVersions due to Salesforce's ContentVersion
             // sharing quirk — the user has no ContentDocumentLink rows. Bypass sharing
             // for this internal package-metadata read. (#28)
-            List<ContentVersion> xmlCvs = new PreDecompXmlLoader().loadByTitlePrefix(xmlPrefix);
+            List<ContentVersion> xmlCvs = new PreDecompXmlLoader()
+                .loadForLinkedEntityByTitlePrefix(activeVersions[0].Id, xmlPrefix);
 
             if (xmlCvs.isEmpty()) {
                 return null;
@@ -1342,14 +1439,8 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         String rawDocumentXml = null;
         String capturedStylesXml = null;
 
-        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title', 'VersionData' });
-        /* code-analyzer-suppress ApexFlsViolation */
-        List<ContentVersion> xmlCvs = [
-            SELECT Title, VersionData
-            FROM ContentVersion
-            WHERE Title IN (:docKey, :stylesKey)
-            WITH SYSTEM_MODE // NOPMD — package-internal pre-decomposed parts; access gated by DocGen permission sets via the parent template (#114)
-        ];
+        List<ContentVersion> xmlCvs = new PreDecompXmlLoader()
+            .loadForLinkedEntityByTitles(activeVersions[0].Id, new Set<String>{ docKey, stylesKey });
         for (ContentVersion cv : xmlCvs) {
             if (cv.Title == docKey) {
                 rawDocumentXml = cv.VersionData.toString();
@@ -1521,17 +1612,8 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         // returned empty in that context, which is why the signed PDF path lost table-style
         // borders for guest-triggered signatures (#28). Template access is already gated by
         // DocGen permission sets; reading the pre-decomposed artifacts in system mode is safe.
-        DocGenFlsGuard.assertAccessible(
-            ContentVersion.sObjectType,
-            new Set<String>{ 'Title', 'VersionData', 'IsLatest' }
-        );
-        /* code-analyzer-suppress ApexFlsViolation */
-        List<ContentVersion> xmlCvs = [
-            SELECT Title, VersionData
-            FROM ContentVersion
-            WHERE Title LIKE :(xmlPrefix + '%') AND IsLatest = TRUE
-            WITH SYSTEM_MODE // NOPMD — package-internal pre-decomposed parts
-        ];
+        List<ContentVersion> xmlCvs = new PreDecompXmlLoader()
+            .loadForLinkedEntityByTitlePrefix(activeVersions[0].Id, xmlPrefix);
 
         String rawDocumentXml = null;
         for (ContentVersion cv : xmlCvs) {

--- a/force-app/main/default/classes/DocGenSignatureController.cls
+++ b/force-app/main/default/classes/DocGenSignatureController.cls
@@ -834,8 +834,13 @@ public without sharing class DocGenSignatureController {
                 }
                 Map<String, String> pdfImageMap = (Map<String, String>) mergeData.get('pdfImageMap');
                 if (String.isNotBlank(docXml)) {
-                    DocGenService.applyWatermarkOverride(templateId);
-                    String liveHtml = DocGenHtmlRenderer.convertToHtml(docXml, pdfImageMap);
+                    String liveHtml;
+                    if ((String) mergeData.get('templateType') == 'HTML') {
+                        liveHtml = docXml;
+                    } else {
+                        DocGenService.applyWatermarkOverride(templateId);
+                        liveHtml = DocGenHtmlRenderer.convertToHtml(docXml, pdfImageMap);
+                    }
                     liveHtml = DocGenSignatureSenderController.injectPreviewWatermarkOverlay(liveHtml, templateId);
                     res.templateBase64 = prepareSigningPreviewHtml(liveHtml);
                     return res;

--- a/force-app/main/default/classes/DocGenSignatureController.cls
+++ b/force-app/main/default/classes/DocGenSignatureController.cls
@@ -50,6 +50,21 @@ public without sharing class DocGenSignatureController {
      */
     @TestVisible
     private static String resolveClientIp(String supplied) {
+        // SECURITY (audit integrity): prefer the server-observed IP and never let
+        // the client-supplied `ipAddress` argument override it. Previously the
+        // caller-passed value won unconditionally, so a signer could forge the IP
+        // recorded on their own tamper-evident audit / certificate. The client
+        // hint is now used ONLY as a last resort when the server has no IP at all
+        // (e.g. a guest LWR context with no infrastructure header) — recorded as
+        // best-effort, not authoritative.
+        // NOTE: captureClientIp() still reads X-Forwarded-For, whose leftmost hop
+        // can be client-influenced behind some proxy configs. Validating the
+        // trusted-hop selection requires a live Experience Cloud guest test before
+        // hardening further.
+        String serverIp = captureClientIp();
+        if (String.isNotBlank(serverIp) && serverIp != 'Unknown') {
+            return serverIp;
+        }
         if (String.isNotBlank(supplied)) {
             String trimmed = supplied.trim();
             // Cheap sanity: length cap + only chars valid in IPv4/IPv6.
@@ -58,7 +73,7 @@ public without sharing class DocGenSignatureController {
                 return trimmed;
             }
         }
-        return captureClientIp();
+        return 'Unknown';
     }
 
     /**

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -147,11 +147,13 @@ public with sharing class DocGenSignatureSenderController {
     private static String extractTemplatePlainText(Id templateId) {
         DocGenFlsGuard.assertAccessible(
             DocGen_Template_Version__c.sObjectType,
-            new Set<String>{ 'Template__c', 'Is_Active__c' }
+            new Set<String>{ 'Template__c', 'Is_Active__c', 'Content_Version_Id__c' }
         );
+        DocGenFlsGuard.assertAccessible(DocGen_Template__c.sObjectType, new Set<String>{ 'Type__c' });
+        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title', 'VersionData' });
         /* code-analyzer-suppress ApexFlsViolation */
         List<DocGen_Template_Version__c> activeVersions = [
-            SELECT Id
+            SELECT Id, Content_Version_Id__c, Template__r.Type__c
             FROM DocGen_Template_Version__c
             WHERE Template__c = :templateId AND Is_Active__c = TRUE
             WITH SYSTEM_MODE
@@ -160,7 +162,24 @@ public with sharing class DocGenSignatureSenderController {
         if (activeVersions.isEmpty())
             return null;
 
-        String xmlPrefix = 'docgen_tmpl_xml_' + activeVersions[0].Id + '_';
+        DocGen_Template_Version__c activeVersion = activeVersions[0];
+        if (activeVersion.Template__r.Type__c == 'HTML') {
+            if (String.isBlank(activeVersion.Content_Version_Id__c))
+                return null;
+
+            Id bodyCvId = (Id) activeVersion.Content_Version_Id__c;
+            /* code-analyzer-suppress ApexFlsViolation */
+            List<ContentVersion> htmlCvs = [
+                SELECT VersionData
+                FROM ContentVersion
+                WHERE Id = :bodyCvId
+                WITH USER_MODE
+                LIMIT 1
+            ];
+            return htmlCvs.isEmpty() || htmlCvs[0].VersionData == null ? null : htmlCvs[0].VersionData.toString();
+        }
+
+        String xmlPrefix = 'docgen_tmpl_xml_' + activeVersion.Id + '_';
         /* code-analyzer-suppress ApexFlsViolation */
         List<ContentVersion> xmlCvs = [
             SELECT Title, VersionData

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -464,6 +464,18 @@ public with sharing class DocGenSignatureSenderController {
         return createTemplateSignerRequestWithOrder(templateId, relatedRecordId, signersJson, 'Parallel');
     }
 
+    /**
+     * Mints an unguessable 64-hex request-level verification token (256-bit CSPRNG
+     * via Crypto.generateAesKey, SHA-256 digested). Used as the capability on the
+     * certificate's post-signing verification link (?token=). It is NOT a signing
+     * token — it only gates read access to the signature audit roster.
+     */
+    private static String generateRequestVerificationToken() {
+        Blob randomBytes = Crypto.generateAesKey(256);
+        Blob hash = Crypto.generateDigest('SHA-256', randomBytes);
+        return EncodingUtil.convertToHex(hash);
+    }
+
     @AuraEnabled
     public static List<SignerResult> createTemplateSignerRequestWithOrder(
         Id templateId,
@@ -512,6 +524,10 @@ public with sharing class DocGenSignatureSenderController {
         if (String.isNotBlank(documentTitleFormat)) {
             req.Document_Title_Format__c = documentTitleFormat;
         }
+        // SECURITY: unguessable request-level token used as the capability for the
+        // post-signing verification link (?token=) printed on the certificate.
+        // Distinct from signer signing tokens — this only gates audit-roster reads.
+        req.Secure_Token__c = generateRequestVerificationToken();
         // Package-internal object — CRUD controlled by DocGen permission sets
         // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Create").
         DocGenFlsGuard.assertCreateable(
@@ -521,7 +537,8 @@ public with sharing class DocGenSignatureSenderController {
                 'Related_Record_Id__c',
                 'Status__c',
                 'Signing_Order__c',
-                'Document_Title_Format__c'
+                'Document_Title_Format__c',
+                'Secure_Token__c'
             }
         );
         /* code-analyzer-suppress ApexFlsViolation */
@@ -648,6 +665,9 @@ public with sharing class DocGenSignatureSenderController {
         if (String.isNotBlank(documentTitleFormat)) {
             req.Document_Title_Format__c = documentTitleFormat;
         }
+        // SECURITY: unguessable request-level verification-link capability — see
+        // createTemplateSignerRequestWithOrder for rationale.
+        req.Secure_Token__c = generateRequestVerificationToken();
         // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Create").
         DocGenFlsGuard.assertCreateable(
             req,
@@ -657,7 +677,8 @@ public with sharing class DocGenSignatureSenderController {
                 'Related_Record_Id__c',
                 'Status__c',
                 'Signing_Order__c',
-                'Document_Title_Format__c'
+                'Document_Title_Format__c',
+                'Secure_Token__c'
             }
         );
         /* code-analyzer-suppress ApexFlsViolation */

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -561,12 +561,7 @@ public with sharing class DocGenSignatureSenderController {
             }
 
             // Render preview HTML using public URLs (small, no base64 bloat)
-            String docXml = (String) mergeData.get('combinedDocumentXml');
-            if (String.isBlank(docXml)) {
-                docXml = (String) mergeData.get('documentXml');
-            }
-            DocGenService.applyWatermarkOverride(templateId);
-            String previewHtml = DocGenHtmlRenderer.convertToHtml(docXml, previewImageMap);
+            String previewHtml = renderMergedSignatureHtml(mergeData, templateId, previewImageMap);
 
             // Inject interactive placement spans for the guided signing UI.
             // Watermark overlay is NOT injected here — base64-embedded image would blow
@@ -727,12 +722,7 @@ public with sharing class DocGenSignatureSenderController {
                     }
                 }
 
-                String docXml = (String) mergeData.get('combinedDocumentXml');
-                if (String.isBlank(docXml)) {
-                    docXml = (String) mergeData.get('documentXml');
-                }
-                DocGenService.applyWatermarkOverride(tid);
-                String docHtml = DocGenHtmlRenderer.convertToHtml(docXml, previewImageMap);
+                String docHtml = renderMergedSignatureHtml(mergeData, tid, previewImageMap);
                 docHtml = injectPlacementSpans(docHtml);
                 // Watermark overlay deferred to read time (cache size constraint).
 
@@ -1655,13 +1645,8 @@ public with sharing class DocGenSignatureSenderController {
     public static String getDocumentPreviewHtml(Id templateId, String relatedRecordId) {
         try {
             Map<String, Object> mergeData = DocGenService.mergeTemplateForSignature(templateId, relatedRecordId);
-            String docXml = (String) mergeData.get('combinedDocumentXml');
-            if (String.isBlank(docXml)) {
-                docXml = (String) mergeData.get('documentXml');
-            }
             Map<String, String> pdfImageMap = (Map<String, String>) mergeData.get('pdfImageMap');
-            DocGenService.applyWatermarkOverride(templateId);
-            String html = DocGenHtmlRenderer.convertToHtml(docXml, pdfImageMap);
+            String html = renderMergedSignatureHtml(mergeData, templateId, pdfImageMap);
             html = injectPlacementSpans(html);
             return injectPreviewWatermarkOverlay(html, templateId);
         } catch (Exception e) {
@@ -1688,6 +1673,25 @@ public with sharing class DocGenSignatureSenderController {
 
     private static Blob buildDocumentPreviewPdfBlob(Id templateId, String relatedRecordId) {
         Map<String, Object> mergeData = DocGenService.mergeTemplateForSignature(templateId, relatedRecordId);
+        Map<String, String> pdfImageMap = (Map<String, String>) mergeData.get('pdfImageMap');
+        String html = renderMergedSignatureHtml(mergeData, templateId, pdfImageMap);
+        if (String.isBlank(html)) {
+            return null;
+        }
+        html = injectPlacementSpans(html);
+
+        return Test.isRunningTest() ? Blob.valueOf('test-preview-pdf') : Blob.toPdf(html);
+    }
+
+    @TestVisible
+    private static String renderMergedSignatureHtml(
+        Map<String, Object> mergeData,
+        Id templateId,
+        Map<String, String> imageMap
+    ) {
+        if (mergeData == null) {
+            return null;
+        }
         String docXml = (String) mergeData.get('combinedDocumentXml');
         if (String.isBlank(docXml)) {
             docXml = (String) mergeData.get('documentXml');
@@ -1696,12 +1700,12 @@ public with sharing class DocGenSignatureSenderController {
             return null;
         }
 
-        Map<String, String> pdfImageMap = (Map<String, String>) mergeData.get('pdfImageMap');
-        DocGenService.applyWatermarkOverride(templateId);
-        String html = DocGenHtmlRenderer.convertToHtml(docXml, pdfImageMap);
-        html = injectPlacementSpans(html);
+        if ((String) mergeData.get('templateType') == 'HTML') {
+            return docXml;
+        }
 
-        return Test.isRunningTest() ? Blob.valueOf('test-preview-pdf') : Blob.toPdf(html);
+        DocGenService.applyWatermarkOverride(templateId);
+        return DocGenHtmlRenderer.convertToHtml(docXml, imageMap);
     }
 
     public static String getSigningPagePath() {

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -534,31 +534,11 @@ public with sharing class DocGenSignatureSenderController {
             Map<String, Object> mergeData = DocGenService.mergeTemplateForSignature(templateId, relatedRecordId);
             Map<String, String> pdfImageMap = (Map<String, String>) mergeData.get('pdfImageMap');
 
-            // Build preview HTML with public URLs for images (not data URIs — keeps size small).
-            // Create ContentDistributions for each template image so guest browser can load them.
-            Map<String, String> previewImageMap = new Map<String, String>();
-            for (String relId : pdfImageMap.keySet()) {
-                String url = pdfImageMap.get(relId);
-                if (url != null && url.contains('/version/download/')) {
-                    String cvId = url.substringAfterLast('/');
-                    try {
-                        ContentDistribution dist = new ContentDistribution();
-                        dist.Name = 'sig_preview_' + relId;
-                        dist.ContentVersionId = cvId;
-                        dist.PreferencesAllowViewInBrowser = true;
-                        dist.PreferencesLinkLatestVersion = false;
-                        dist.PreferencesExpires = false;
-                        Database.insert(dist, AccessLevel.USER_MODE);
-                        dist = [SELECT ContentDownloadUrl FROM ContentDistribution WHERE Id = :dist.Id WITH USER_MODE];
-                        previewImageMap.put(relId, dist.ContentDownloadUrl);
-                    } catch (Exception e) {
-                        System.debug(
-                            LoggingLevel.WARN,
-                            'DocGen: Could not create public link for ' + relId + ': ' + e.getMessage()
-                        );
-                    }
-                }
+            String mergedHtml = (String) mergeData.get('combinedDocumentXml');
+            if (String.isBlank(mergedHtml)) {
+                mergedHtml = (String) mergeData.get('documentXml');
             }
+            Map<String, String> previewImageMap = buildSignaturePreviewImageMap(pdfImageMap, mergedHtml);
 
             // Render preview HTML using public URLs (small, no base64 bloat)
             String previewHtml = renderMergedSignatureHtml(mergeData, templateId, previewImageMap);
@@ -695,32 +675,11 @@ public with sharing class DocGenSignatureSenderController {
                 Map<String, String> pdfImageMap = (Map<String, String>) mergeData.get('pdfImageMap');
                 combinedPdfImageMap.putAll(pdfImageMap);
 
-                // Build preview HTML for this document
-                Map<String, String> previewImageMap = new Map<String, String>();
-                for (String relId : pdfImageMap.keySet()) {
-                    String url = pdfImageMap.get(relId);
-                    if (url != null && url.contains('/version/download/')) {
-                        String cvId = url.substringAfterLast('/');
-                        try {
-                            ContentDistribution dist = new ContentDistribution();
-                            dist.Name = 'sig_preview_' + relId;
-                            dist.ContentVersionId = cvId;
-                            dist.PreferencesAllowViewInBrowser = true;
-                            dist.PreferencesLinkLatestVersion = false;
-                            dist.PreferencesExpires = false;
-                            Database.insert(dist, AccessLevel.USER_MODE);
-                            dist = [
-                                SELECT ContentDownloadUrl
-                                FROM ContentDistribution
-                                WHERE Id = :dist.Id
-                                WITH USER_MODE
-                            ];
-                            previewImageMap.put(relId, dist.ContentDownloadUrl);
-                        } catch (Exception e) {
-                            System.debug(LoggingLevel.WARN, 'DocGen: Could not create public link for ' + relId);
-                        }
-                    }
+                String mergedHtml = (String) mergeData.get('combinedDocumentXml');
+                if (String.isBlank(mergedHtml)) {
+                    mergedHtml = (String) mergeData.get('documentXml');
                 }
+                Map<String, String> previewImageMap = buildSignaturePreviewImageMap(pdfImageMap, mergedHtml);
 
                 String docHtml = renderMergedSignatureHtml(mergeData, tid, previewImageMap);
                 docHtml = injectPlacementSpans(docHtml);
@@ -1701,11 +1660,136 @@ public with sharing class DocGenSignatureSenderController {
         }
 
         if ((String) mergeData.get('templateType') == 'HTML') {
-            return docXml;
+            return rewriteHtmlImageSources(docXml, imageMap);
         }
 
         DocGenService.applyWatermarkOverride(templateId);
         return DocGenHtmlRenderer.convertToHtml(docXml, imageMap);
+    }
+
+    @TestVisible
+    private static Map<String, String> buildSignaturePreviewImageMap(Map<String, String> pdfImageMap, String html) {
+        Map<String, String> previewImageMap = new Map<String, String>();
+        if (pdfImageMap != null) {
+            for (String relId : pdfImageMap.keySet()) {
+                addSignaturePreviewImage(previewImageMap, relId, pdfImageMap.get(relId));
+            }
+        }
+        for (String src : extractHtmlImageSources(html)) {
+            addSignaturePreviewImage(previewImageMap, src, src);
+        }
+        return previewImageMap;
+    }
+
+    private static void addSignaturePreviewImage(Map<String, String> previewImageMap, String key, String sourceUrl) {
+        String cvId = extractContentVersionIdFromImageUrl(sourceUrl);
+        if (String.isBlank(cvId)) {
+            return;
+        }
+        if (previewImageMap.containsKey(cvId)) {
+            if (String.isNotBlank(key)) {
+                previewImageMap.put(key, previewImageMap.get(cvId));
+            }
+            previewImageMap.put('/sfc/servlet.shepherd/version/download/' + cvId, previewImageMap.get(cvId));
+            return;
+        }
+        try {
+            ContentDistribution dist = new ContentDistribution();
+            dist.Name = 'sig_preview_' + (String.isBlank(key) ? cvId : key).left(80);
+            dist.ContentVersionId = cvId;
+            dist.PreferencesAllowViewInBrowser = true;
+            dist.PreferencesLinkLatestVersion = false;
+            dist.PreferencesExpires = false;
+            Database.insert(dist, AccessLevel.USER_MODE);
+            dist = [SELECT ContentDownloadUrl FROM ContentDistribution WHERE Id = :dist.Id WITH USER_MODE];
+            if (String.isNotBlank(key)) {
+                previewImageMap.put(key, dist.ContentDownloadUrl);
+            }
+            previewImageMap.put(cvId, dist.ContentDownloadUrl);
+            previewImageMap.put('/sfc/servlet.shepherd/version/download/' + cvId, dist.ContentDownloadUrl);
+        } catch (Exception e) {
+            System.debug(
+                LoggingLevel.WARN,
+                'DocGen: Could not create public signature preview image link for ' + cvId + ': ' + e.getMessage()
+            );
+        }
+    }
+
+    @TestVisible
+    private static String rewriteHtmlImageSources(String html, Map<String, String> imageMap) {
+        if (String.isBlank(html) || imageMap == null || imageMap.isEmpty()) {
+            return html;
+        }
+
+        String rewritten = html;
+        for (String src : extractHtmlImageSources(html)) {
+            String replacement = imageMap.get(src);
+            if (String.isBlank(replacement)) {
+                replacement = imageMap.get(extractContentVersionIdFromImageUrl(src));
+            }
+            if (String.isBlank(replacement)) {
+                continue;
+            }
+            rewritten = rewritten.replace('"' + src + '"', '"' + replacement.escapeHtml4() + '"');
+            rewritten = rewritten.replace('\'' + src + '\'', '\'' + replacement.escapeHtml4() + '\'');
+        }
+        return rewritten;
+    }
+
+    private static List<String> extractHtmlImageSources(String html) {
+        List<String> sources = new List<String>();
+        if (String.isBlank(html) || !html.containsIgnoreCase('<img')) {
+            return sources;
+        }
+        String lower = html.toLowerCase();
+        Integer cursor = 0;
+        while (cursor < html.length()) {
+            Integer imgStart = lower.indexOf('<img', cursor);
+            if (imgStart == -1) {
+                break;
+            }
+            Integer imgEnd = html.indexOf('>', imgStart);
+            if (imgEnd == -1) {
+                break;
+            }
+            Integer srcIdx = lower.indexOf('src=', imgStart);
+            if (srcIdx == -1 || srcIdx > imgEnd) {
+                cursor = imgEnd + 1;
+                continue;
+            }
+            srcIdx += 4;
+            while (srcIdx < imgEnd && html.substring(srcIdx, srcIdx + 1) == ' ') {
+                srcIdx++;
+            }
+            if (srcIdx >= imgEnd) {
+                cursor = imgEnd + 1;
+                continue;
+            }
+            String quoteChar = html.substring(srcIdx, srcIdx + 1);
+            if (quoteChar != '"' && quoteChar != '\'') {
+                cursor = imgEnd + 1;
+                continue;
+            }
+            Integer valueStart = srcIdx + 1;
+            Integer valueEnd = html.indexOf(quoteChar, valueStart);
+            if (valueEnd != -1 && valueEnd <= imgEnd) {
+                String src = html.substring(valueStart, valueEnd);
+                if (String.isNotBlank(src)) {
+                    sources.add(src.replace('&amp;', '&'));
+                }
+            }
+            cursor = imgEnd + 1;
+        }
+        return sources;
+    }
+
+    private static String extractContentVersionIdFromImageUrl(String url) {
+        if (String.isBlank(url) || !url.contains('/version/download/')) {
+            return null;
+        }
+        String cvId = url.substringAfterLast('/version/download/');
+        cvId = cvId.substringBefore('?').substringBefore('#');
+        return cvId.startsWith('068') ? cvId : null;
     }
 
     public static String getSigningPagePath() {

--- a/force-app/main/default/classes/DocGenSignatureService.cls
+++ b/force-app/main/default/classes/DocGenSignatureService.cls
@@ -238,13 +238,43 @@ public without sharing class DocGenSignatureService {
             String verifyPage = (String.isNotBlank(ns) && ns != 'DocGenSignatureService')
                 ? '/apex/' + ns + '__DocGenVerify'
                 : '/apex/DocGenVerify';
-            String verifyUrl = siteUrl + verifyPage + '?id=' + String.valueOf(requestId);
-            html += 'Verify at: ' + verifyUrl.escapeHtml4();
+            // SECURITY: the verification link carries the request's unguessable
+            // Secure_Token__c, not the enumerable record Id. The endpoint
+            // (verifyByRequestId) requires this 64-hex token before returning any
+            // signer audit data. Only emit the link when the token is present.
+            String verifyToken = lookupRequestVerificationToken(requestId);
+            if (String.isNotBlank(verifyToken)) {
+                String verifyUrl = siteUrl + verifyPage + '?token=' + verifyToken;
+                html += 'Verify at: ' + verifyUrl.escapeHtml4();
+            }
         }
         html += '</td></tr>';
 
         html += '</table></div>';
         return html;
+    }
+
+    /**
+     * Returns the request's unguessable verification token (Secure_Token__c) used
+     * as the capability on the certificate verify link. Runs in the async
+     * (Automated Process) finalize context, so SYSTEM_MODE is required. Returns
+     * null when absent (e.g. legacy requests created before this hotfix) — the
+     * caller then omits the link, leaving document-upload verification intact.
+     */
+    private static String lookupRequestVerificationToken(Id requestId) {
+        if (requestId == null) {
+            return null;
+        }
+        DocGenFlsGuard.assertAccessible(DocGen_Signature_Request__c.sObjectType, new Set<String>{ 'Secure_Token__c' });
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        List<DocGen_Signature_Request__c> reqs = [
+            SELECT Secure_Token__c
+            FROM DocGen_Signature_Request__c
+            WHERE Id = :requestId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        return reqs.isEmpty() ? null : reqs[0].Secure_Token__c;
     }
 
     /**

--- a/force-app/main/default/classes/DocGenSignatureService.cls
+++ b/force-app/main/default/classes/DocGenSignatureService.cls
@@ -325,6 +325,23 @@ public without sharing class DocGenSignatureService {
         return new StampResult(documentXml, relsXml, contentTypesXml, signatureImageUrls);
     }
 
+    @TestVisible
+    private static String stampSignaturesInHtml(String html, List<DocGen_Signature_Placement__c> placements) {
+        if (String.isBlank(html) || placements == null || placements.isEmpty()) {
+            return html;
+        }
+
+        for (DocGen_Signature_Placement__c plc : placements) {
+            if (plc.Status__c != 'Signed' || String.isBlank(plc.Tag_Text__c))
+                continue;
+
+            if (html.contains(plc.Tag_Text__c)) {
+                html = html.replaceFirst(Pattern.quote(plc.Tag_Text__c), buildPlacementText(plc).escapeHtml4());
+            }
+        }
+        return html;
+    }
+
     /**
      * Builds the replacement text for a signed placement based on its type.
      */
@@ -929,6 +946,7 @@ public without sharing class DocGenSignatureService {
             String relsXml = (String) mergeData.get('relsXml');
             String contentTypesXml = (String) mergeData.get('contentTypesXml');
             Map<String, String> pdfImageMap = (Map<String, String>) mergeData.get('pdfImageMap');
+            String templateType = (String) mergeData.get('templateType');
 
             // Use pre-computed image map from request creation
             DocGenFlsGuard.assertAccessible(
@@ -1045,16 +1063,27 @@ public without sharing class DocGenSignatureService {
                 ORDER BY Document_Index__c ASC, Sequence_Order__c ASC
             ]; // NOPMD ApexCRUDViolation - package-internal custom object; CRUD controlled by DocGen permission sets
 
-            // Stamp typed-name signatures into merged XML
-            StampResult stamped = stampSignaturesInXml(documentXml, relsXml, contentTypesXml, signerImages, placements);
+            String html;
+            if (templateType == 'HTML') {
+                html = stampSignaturesInHtml(documentXml, placements);
+            } else {
+                // Stamp typed-name signatures into merged XML
+                StampResult stamped = stampSignaturesInXml(
+                    documentXml,
+                    relsXml,
+                    contentTypesXml,
+                    signerImages,
+                    placements
+                );
 
-            // Re-prime the HTML renderer context immediately before convertToHtml.
-            DocGenHtmlRenderer.stylesXml = (String) mergeData.get('stylesXml');
-            DocGenHtmlRenderer.numberingXml = (String) mergeData.get('numberingXml');
-            DocGenService.applyWatermarkOverride(templateId);
+                // Re-prime the HTML renderer context immediately before convertToHtml.
+                DocGenHtmlRenderer.stylesXml = (String) mergeData.get('stylesXml');
+                DocGenHtmlRenderer.numberingXml = (String) mergeData.get('numberingXml');
+                DocGenService.applyWatermarkOverride(templateId);
 
-            // Render PDF with template images only (no signature images needed)
-            String html = DocGenHtmlRenderer.convertToHtml(stamped.documentXml, pdfImageMap);
+                // Render PDF with template images only (no signature images needed)
+                html = DocGenHtmlRenderer.convertToHtml(stamped.documentXml, pdfImageMap);
+            }
 
             // Append verification certificate block before closing body
             DocGenFlsGuard.assertAccessible(
@@ -1201,6 +1230,7 @@ public without sharing class DocGenSignatureService {
                 String relsXml = (String) mergeData.get('relsXml');
                 String contentTypesXml = (String) mergeData.get('contentTypesXml');
                 Map<String, String> pdfImageMap = (Map<String, String>) mergeData.get('pdfImageMap');
+                String templateType = (String) mergeData.get('templateType');
                 pdfImageMap.putAll(cachedImageMap);
 
                 // Filter placements for this document
@@ -1210,19 +1240,24 @@ public without sharing class DocGenSignatureService {
                         docPlacements.add(p);
                 }
 
-                StampResult stamped = stampSignaturesInXml(
-                    documentXml,
-                    relsXml,
-                    contentTypesXml,
-                    signerImages,
-                    docPlacements
-                );
-                // Re-prime renderer context for this document (see #28 — statics don't survive
-                // intermediate calls reliably in async context).
-                DocGenHtmlRenderer.stylesXml = (String) mergeData.get('stylesXml');
-                DocGenHtmlRenderer.numberingXml = (String) mergeData.get('numberingXml');
-                DocGenService.applyWatermarkOverride(tid);
-                String docHtml = DocGenHtmlRenderer.convertToHtml(stamped.documentXml, pdfImageMap);
+                String docHtml;
+                if (templateType == 'HTML') {
+                    docHtml = stampSignaturesInHtml(documentXml, docPlacements);
+                } else {
+                    StampResult stamped = stampSignaturesInXml(
+                        documentXml,
+                        relsXml,
+                        contentTypesXml,
+                        signerImages,
+                        docPlacements
+                    );
+                    // Re-prime renderer context for this document (see #28 — statics don't survive
+                    // intermediate calls reliably in async context).
+                    DocGenHtmlRenderer.stylesXml = (String) mergeData.get('stylesXml');
+                    DocGenHtmlRenderer.numberingXml = (String) mergeData.get('numberingXml');
+                    DocGenService.applyWatermarkOverride(tid);
+                    docHtml = DocGenHtmlRenderer.convertToHtml(stamped.documentXml, pdfImageMap);
+                }
 
                 if (docIdx > 0) {
                     htmlParts.add('<div style="page-break-before:always"></div>');

--- a/force-app/main/default/classes/DocGenSignatureTests.cls
+++ b/force-app/main/default/classes/DocGenSignatureTests.cls
@@ -1143,8 +1143,9 @@ private class DocGenSignatureTests {
         );
         Database.insert(audit, AccessLevel.SYSTEM_MODE);
         Test.startTest();
+        // Capability is the request's unguessable Secure_Token__c, not the raw Id.
         List<DocGenAuthenticatorController.VerificationResult> results = DocGenAuthenticatorController.verifyByRequestId(
-            req.Id
+            req.Secure_Token__c
         );
         Test.stopTest();
 
@@ -1157,8 +1158,9 @@ private class DocGenSignatureTests {
     @isTest
     static void testVerifyByRequestId_noAudits() {
         Test.startTest();
+        // 64-hex token that matches no request → empty
         List<DocGenAuthenticatorController.VerificationResult> results = DocGenAuthenticatorController.verifyByRequestId(
-            '001000000000000AAA'
+            '00000000000000000000000000000000000000000000000000000000000000aa'
         );
         Test.stopTest();
         System.assertEquals(0, results.size());

--- a/force-app/main/default/classes/DocGenSignatureTests.cls
+++ b/force-app/main/default/classes/DocGenSignatureTests.cls
@@ -5005,6 +5005,49 @@ private class DocGenSignatureTests {
         System.assertEquals('Full', seller.placementType, 'v3 type captured');
     }
 
+    @isTest
+    static void testGetTemplateSignaturePlacements_htmlTemplateBody() {
+        DocGen_Template__c tmpl = new DocGen_Template__c(
+            Name = 'HTML Signature Template',
+            Base_Object_API__c = 'Account',
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF'
+        );
+        insert tmpl;
+
+        String html =
+            '<table class="sig-table"><tr>' +
+            '<td><div class="sig-line">{@Signature_Customer}</div></td>' +
+            '<td><div class="sig-line">{@Signature_Customer:1:Date}</div></td>' +
+            '</tr></table>';
+        ContentVersion bodyCv = new ContentVersion(
+            Title = 'docgen_html_body_test',
+            PathOnClient = 'template.html',
+            VersionData = Blob.valueOf(html),
+            FirstPublishLocationId = tmpl.Id
+        );
+        insert bodyCv;
+
+        DocGen_Template_Version__c ver = new DocGen_Template_Version__c(
+            Template__c = tmpl.Id,
+            Is_Active__c = true,
+            Content_Version_Id__c = bodyCv.Id
+        );
+        Database.insert(ver, AccessLevel.SYSTEM_MODE);
+
+        Test.startTest();
+        List<DocGenSignatureSenderController.PlacementInfo> placements = DocGenSignatureSenderController.getTemplateSignaturePlacements(
+            tmpl.Id
+        );
+        Test.stopTest();
+
+        System.assertEquals(2, placements.size(), 'HTML body signature tags should be detected');
+        System.assertEquals('Customer', placements[0].role, 'Bare HTML role parsed');
+        System.assertEquals('Full', placements[0].placementType, 'Bare HTML tag defaults to Full');
+        System.assertEquals('Customer', placements[1].role, 'Date HTML role parsed');
+        System.assertEquals('Date', placements[1].placementType, 'Date HTML tag parsed');
+    }
+
     // =========================================================================
     // Trigger coverage: exercise all platform event trigger paths
     // =========================================================================

--- a/force-app/main/default/classes/DocGenSignatureTests.cls
+++ b/force-app/main/default/classes/DocGenSignatureTests.cls
@@ -5093,6 +5093,79 @@ private class DocGenSignatureTests {
     }
 
     @isTest
+    static void testRenderMergedSignatureHtml_htmlTemplateRewritesImageSources() {
+        String cvId = '068000000000001AAA';
+        String sourceUrl = '/sfc/servlet.shepherd/version/download/' + cvId;
+        String publicUrl = 'https://example.file.force.com/sfc/dist/version/download/' + cvId;
+        Map<String, Object> mergeData = new Map<String, Object>{
+            'templateType' => 'HTML',
+            'combinedDocumentXml' => '<html><body><img src="' +
+            sourceUrl +
+            '"/><div>{@Signature_Customer}</div></body></html>'
+        };
+
+        Test.startTest();
+        String html = DocGenSignatureSenderController.renderMergedSignatureHtml(
+            mergeData,
+            null,
+            new Map<String, String>{ sourceUrl => publicUrl }
+        );
+        Test.stopTest();
+
+        System.assert(html.contains('src="' + publicUrl + '"'), 'HTML signature preview should use public image URLs');
+        System.assert(!html.contains('src="' + sourceUrl + '"'), 'Raw /sfc image URL should be rewritten for preview');
+        System.assert(html.contains('{@Signature_Customer}'), 'Signature tag should remain for placement injection');
+    }
+
+    @isTest
+    static void testRewriteHtmlImageSources_matchesContentVersionIdFallback() {
+        String cvId = '068000000000002AAA';
+        String sourceUrl = '/sfc/servlet.shepherd/version/download/' + cvId + '?operationContext=S1';
+        String publicUrl = 'https://example.file.force.com/sfc/dist/version/download/' + cvId;
+
+        Test.startTest();
+        String html = DocGenSignatureSenderController.rewriteHtmlImageSources(
+            '<html><body><img alt="Logo" src="' + sourceUrl + '"/></body></html>',
+            new Map<String, String>{ cvId => publicUrl }
+        );
+        Test.stopTest();
+
+        System.assert(html.contains('src="' + publicUrl + '"'), 'CV-id keyed preview map should rewrite HTML img src');
+        System.assert(!html.contains(sourceUrl), 'Original private image src should not remain in signer preview HTML');
+    }
+
+    @isTest
+    static void testBuildSignaturePreviewImageMap_createsPublicLinkForHtmlImageSource() {
+        String tinyPngB64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+        ContentVersion imgCv = new ContentVersion(
+            Title = 'html_signature_logo',
+            PathOnClient = 'logo.png',
+            VersionData = EncodingUtil.base64Decode(tinyPngB64)
+        );
+        insert imgCv;
+        imgCv = [SELECT Id FROM ContentVersion WHERE Id = :imgCv.Id LIMIT 1];
+        String sourceUrl = '/sfc/servlet.shepherd/version/download/' + imgCv.Id;
+
+        Test.startTest();
+        Map<String, String> previewMap = DocGenSignatureSenderController.buildSignaturePreviewImageMap(
+            new Map<String, String>(),
+            '<html><body><img src="' + sourceUrl + '"/>{@Signature_Customer}</body></html>'
+        );
+        Test.stopTest();
+
+        System.assert(previewMap.containsKey(sourceUrl), 'HTML image source should be mapped for signer preview');
+        System.assert(
+            String.isNotBlank(previewMap.get(sourceUrl)) && previewMap.get(sourceUrl).startsWith('http'),
+            'Signer preview image should use a public ContentDistribution URL'
+        );
+        System.assertEquals(
+            1,
+            [SELECT COUNT() FROM ContentDistribution WHERE ContentVersionId = :imgCv.Id],
+            'A public distribution should be created for the HTML template image'
+        );
+    }
+
+    @isTest
     static void testGetDocumentPreviewPdfBase64_htmlTemplateDoesNotBlank() {
         Account acc = [SELECT Id FROM Account LIMIT 1];
         Id tmplId = createHtmlSignatureTemplate(

--- a/force-app/main/default/classes/DocGenSignatureTests.cls
+++ b/force-app/main/default/classes/DocGenSignatureTests.cls
@@ -68,6 +68,33 @@ private class DocGenSignatureTests {
         return [SELECT Id, Status__c, Secure_Token__c FROM DocGen_Signature_Request__c LIMIT 1];
     }
 
+    private static Id createHtmlSignatureTemplate(String bodyHtml) {
+        DocGen_Template__c tmpl = new DocGen_Template__c(
+            Name = 'HTML Signature Template ' + Datetime.now().getTime(),
+            Base_Object_API__c = 'Account',
+            Query_Config__c = 'Name, Industry',
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF'
+        );
+        insert tmpl;
+
+        ContentVersion bodyCv = new ContentVersion(
+            Title = tmpl.Name + ' Body',
+            PathOnClient = 'template.html',
+            VersionData = Blob.valueOf(bodyHtml),
+            FirstPublishLocationId = tmpl.Id
+        );
+        insert bodyCv;
+        bodyCv = [SELECT Id FROM ContentVersion WHERE Id = :bodyCv.Id LIMIT 1];
+
+        insert new DocGen_Template_Version__c(
+            Template__c = tmpl.Id,
+            Is_Active__c = true,
+            Content_Version_Id__c = bodyCv.Id
+        );
+        return tmpl.Id;
+    }
+
     // =========================================================================
     // Token Validation
     // =========================================================================
@@ -5007,37 +5034,16 @@ private class DocGenSignatureTests {
 
     @isTest
     static void testGetTemplateSignaturePlacements_htmlTemplateBody() {
-        DocGen_Template__c tmpl = new DocGen_Template__c(
-            Name = 'HTML Signature Template',
-            Base_Object_API__c = 'Account',
-            Type__c = 'HTML',
-            Output_Format__c = 'PDF'
-        );
-        insert tmpl;
-
         String html =
             '<table class="sig-table"><tr>' +
             '<td><div class="sig-line">{@Signature_Customer}</div></td>' +
             '<td><div class="sig-line">{@Signature_Customer:1:Date}</div></td>' +
             '</tr></table>';
-        ContentVersion bodyCv = new ContentVersion(
-            Title = 'docgen_html_body_test',
-            PathOnClient = 'template.html',
-            VersionData = Blob.valueOf(html),
-            FirstPublishLocationId = tmpl.Id
-        );
-        insert bodyCv;
-
-        DocGen_Template_Version__c ver = new DocGen_Template_Version__c(
-            Template__c = tmpl.Id,
-            Is_Active__c = true,
-            Content_Version_Id__c = bodyCv.Id
-        );
-        Database.insert(ver, AccessLevel.SYSTEM_MODE);
+        Id tmplId = createHtmlSignatureTemplate(html);
 
         Test.startTest();
         List<DocGenSignatureSenderController.PlacementInfo> placements = DocGenSignatureSenderController.getTemplateSignaturePlacements(
-            tmpl.Id
+            tmplId
         );
         Test.stopTest();
 
@@ -5046,6 +5052,89 @@ private class DocGenSignatureTests {
         System.assertEquals('Full', placements[0].placementType, 'Bare HTML tag defaults to Full');
         System.assertEquals('Customer', placements[1].role, 'Date HTML role parsed');
         System.assertEquals('Date', placements[1].placementType, 'Date HTML tag parsed');
+    }
+
+    @isTest
+    static void testMergeTemplateForSignature_htmlTemplateReturnsReadyHtml() {
+        Account acc = [SELECT Id, Name FROM Account LIMIT 1];
+        Id tmplId = createHtmlSignatureTemplate(
+            '<html><body><h1>{Name}</h1><div>{@Signature_Customer}</div></body></html>'
+        );
+
+        Test.startTest();
+        Map<String, Object> result = DocGenService.mergeTemplateForSignature(tmplId, acc.Id);
+        Test.stopTest();
+
+        System.assertEquals('HTML', result.get('templateType'), 'Signature merge should retain HTML template type');
+        String combinedHtml = (String) result.get('combinedDocumentXml');
+        System.assertNotEquals(null, combinedHtml, 'HTML signature merge should return rendered HTML');
+        System.assert(combinedHtml.contains('<html'), 'HTML signature merge should not be converted as DOCX XML');
+        System.assert(combinedHtml.contains(acc.Name), 'HTML signature merge should resolve merge fields');
+        System.assert(
+            combinedHtml.contains('{@Signature_Customer}'),
+            'HTML signature merge should preserve signature tags for preview/final stamping'
+        );
+    }
+
+    @isTest
+    static void testGetDocumentPreviewHtml_htmlTemplateDoesNotBlank() {
+        Account acc = [SELECT Id, Name FROM Account LIMIT 1];
+        Id tmplId = createHtmlSignatureTemplate(
+            '<html><body><p>Agreement for {Name}</p><div>{@Signature_Customer}</div></body></html>'
+        );
+
+        Test.startTest();
+        String html = DocGenSignatureSenderController.getDocumentPreviewHtml(tmplId, acc.Id);
+        Test.stopTest();
+
+        System.assertNotEquals(null, html, 'HTML signature preview should not render blank');
+        System.assert(html.contains(acc.Name), 'HTML signature preview should contain merged record data');
+        System.assert(html.contains('docgen-sig'), 'HTML signature preview should inject placement spans');
+    }
+
+    @isTest
+    static void testGetDocumentPreviewPdfBase64_htmlTemplateDoesNotBlank() {
+        Account acc = [SELECT Id FROM Account LIMIT 1];
+        Id tmplId = createHtmlSignatureTemplate(
+            '<html><body><p>Preview PDF</p><div>{@Signature_Customer:1:Date}</div></body></html>'
+        );
+
+        Test.startTest();
+        String pdfBase64 = DocGenSignatureSenderController.getDocumentPreviewPdfBase64(tmplId, acc.Id);
+        Test.stopTest();
+
+        System.assertEquals(
+            EncodingUtil.base64Encode(Blob.valueOf('test-preview-pdf')),
+            pdfBase64,
+            'HTML signature PDF preview should return a base64 PDF payload'
+        );
+    }
+
+    @isTest
+    static void testStampSignaturesInHtml_escapesSignedValue() {
+        DocGen_Signer__c signer = getTestSigner();
+        DocGen_Signature_Request__c req = getTestRequest();
+        DocGen_Signature_Placement__c plc = new DocGen_Signature_Placement__c(
+            Signer__c = signer.Id,
+            Signature_Request__c = req.Id,
+            Placement_Type__c = 'Full',
+            Status__c = 'Signed',
+            Signed_Value__c = 'Jane <Doe>',
+            Signed_At__c = Datetime.newInstance(2026, 6, 11, 10, 0, 0),
+            Tag_Text__c = '{@Signature_Customer}'
+        );
+        insert plc;
+
+        Test.startTest();
+        String html = DocGenSignatureService.stampSignaturesInHtml(
+            '<html><body><div>{@Signature_Customer}</div></body></html>',
+            new List<DocGen_Signature_Placement__c>{ plc }
+        );
+        Test.stopTest();
+
+        System.assert(!html.contains('{@Signature_Customer}'), 'HTML signature tag should be replaced');
+        System.assert(html.contains('Jane &lt;Doe&gt;'), 'Signed value should be HTML escaped');
+        System.assert(html.contains('Electronically signed by'), 'Full placement should include legal text');
     }
 
     // =========================================================================

--- a/force-app/main/default/lwc/docGenAuthenticator/docGenAuthenticator.js
+++ b/force-app/main/default/lwc/docGenAuthenticator/docGenAuthenticator.js
@@ -9,20 +9,22 @@ export default class DocGenAuthenticator extends LightningElement {
     @track hasRequestId = false;
 
     connectedCallback() {
-        // Check URL for request ID parameter
+        // Check URL for the verification token. The certificate link now carries
+        // an unguessable 64-hex token (?token=) instead of the enumerable record
+        // Id — see DocGenAuthenticatorController.verifyByRequestId.
         const params = new URLSearchParams(window.location.search);
-        const reqId = params.get('id');
-        // CxSAST: DOM XSS mitigation — validate ID matches Salesforce ID pattern before use
-        if (reqId && /^[a-zA-Z0-9]{15,18}$/.test(reqId)) {
+        const token = params.get('token');
+        // DOM XSS mitigation — validate the token is a 64-char hex string before use.
+        if (token && /^[a-fA-F0-9]{64}$/.test(token)) {
             this.hasRequestId = true;
-            this.loadRequestAudit(reqId);
+            this.loadRequestAudit(token);
         }
     }
 
-    async loadRequestAudit(requestId) {
+    async loadRequestAudit(requestToken) {
         this.isProcessing = true;
         try {
-            this.requestResults = await verifyByRequestId({ requestId });
+            this.requestResults = await verifyByRequestId({ requestToken });
         } catch (error) {
             this.requestResults = [];
             this.result = {

--- a/force-app/main/default/pages/DocGenVerify.page
+++ b/force-app/main/default/pages/DocGenVerify.page
@@ -293,15 +293,17 @@
                         }
                     }
 
-                    // Check for request ID in URL
+                    // Check for the verification token in the URL. The certificate
+                    // link now carries an unguessable 64-hex token (?token=) instead
+                    // of the enumerable record Id.
                     var params = new URLSearchParams(window.location.search);
-                    var reqId = params.get('id');
+                    var verifyToken = params.get('token');
 
-                    // CxSAST: DOM XSS mitigation — validate ID matches Salesforce ID pattern before use
-                    if (reqId && /^[a-zA-Z0-9]{15,18}$/.test(reqId)) {
+                    // DOM XSS mitigation — validate the token is a 64-char hex string before use
+                    if (verifyToken && /^[a-fA-F0-9]{64}$/.test(verifyToken)) {
                         Visualforce.remoting.Manager.invokeAction(
                             '{!$RemoteAction.DocGenAuthenticatorController.verifyByRequestId}',
-                            reqId,
+                            verifyToken,
                             function (results, event) {
                                 var container = document.getElementById('request-results');
                                 clearNode(container);

--- a/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
@@ -731,7 +731,7 @@
         <readable>true</readable>
     </fieldPermissions>
     <hasActivationRequired>false</hasActivationRequired>
-    <label>DocGen Admin</label>
+    <label>Portwood DocGen Admin</label>
     <pageAccesses>
         <apexPage>DocGenGuide</apexPage>
         <enabled>true</enabled>

--- a/force-app/main/default/permissionsets/DocGen_Guest_Runner.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Guest_Runner.permissionset-meta.xml
@@ -3,5 +3,5 @@
     <description
     >Deprecated. The Experience Cloud guest render path has been removed from DocGen; this permission set is retained only for upgrade compatibility and grants no access. Safe to unassign from site guest users.</description>
     <hasActivationRequired>false</hasActivationRequired>
-    <label>DocGen Guest Runner (deprecated)</label>
+    <label>Portwood DocGen Guest Runner (deprecated)</label>
 </PermissionSet>

--- a/force-app/main/default/permissionsets/DocGen_Guest_Signature.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Guest_Signature.permissionset-meta.xml
@@ -285,7 +285,7 @@
         <apexPage>DocGenVerify</apexPage>
         <enabled>true</enabled>
     </pageAccesses>
-    <label>DocGen Guest Signature</label>
+    <label>Portwood DocGen Guest Signature</label>
     <objectPermissions>
         <allowCreate>true</allowCreate>
         <allowDelete>false</allowDelete>

--- a/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
@@ -133,7 +133,7 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>DocGen_Job__c.Giant_Query_Config__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -153,7 +153,7 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>DocGen_Job__c.Parent_Record_Id__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
@@ -629,7 +629,7 @@
         <readable>true</readable>
     </fieldPermissions>
     <hasActivationRequired>false</hasActivationRequired>
-    <label>DocGen User</label>
+    <label>Portwood DocGen User</label>
     <pageAccesses>
         <apexPage>DocGenGuide</apexPage>
         <enabled>true</enabled>

--- a/scripts/e2e-06-signatures.apex
+++ b/scripts/e2e-06-signatures.apex
@@ -11,6 +11,7 @@ Id tmplId;
 Id sigReqId;
 Id signerId;
 String signerToken;
+String requestToken;
 
 // ===== Look up test data =====
 try {
@@ -48,10 +49,14 @@ if (acctId == null || tmplId == null) {
 // ===== Create Signature Request =====
 try {
     signerToken = EncodingUtil.convertToHex(Crypto.generateAesKey(256));
+    // Request-level verification token — the capability for verifyByRequestId
+    // (the certificate verify link now carries ?token= this value, not the Id).
+    requestToken = EncodingUtil.convertToHex(Crypto.generateDigest('SHA-256', Crypto.generateAesKey(256)));
     DocGen_Signature_Request__c sr = new DocGen_Signature_Request__c(
         Status__c = 'Sent',
         Related_Record_Id__c = acctId,
         Template__c = tmplId,
+        Secure_Token__c = requestToken,
         Signer_Name__c = 'Alice Johnson',
         Signer_Email__c = 'alice@e2etest.example.com'
     );
@@ -172,14 +177,14 @@ try {
     System.debug('AUDIT RECORD: FAIL — ' + e.getMessage());
 }
 
-// ===== Verify By Request ID =====
+// ===== Verify By Request Token (capability = unguessable Secure_Token__c) =====
 try {
     List<DocGenAuthenticatorController.VerificationResult> vrs = DocGenAuthenticatorController.verifyByRequestId(
-        String.valueOf(sigReqId)
+        requestToken
     );
     if (vrs != null && !vrs.isEmpty()) {
         pass++;
-        System.debug('VERIFY BY REQUEST ID: PASS — ' + vrs.size() + ' results');
+        System.debug('VERIFY BY REQUEST TOKEN: PASS — ' + vrs.size() + ' results');
         // Check first result has expected data
         DocGenAuthenticatorController.VerificationResult vr = vrs[0];
         if (vr.signerName == 'Alice Johnson') {
@@ -191,11 +196,24 @@ try {
         }
     } else {
         fail++;
-        System.debug('VERIFY BY REQUEST ID: FAIL — empty or null');
+        System.debug('VERIFY BY REQUEST TOKEN: FAIL — empty or null');
+    }
+
+    // SECURITY REGRESSION GUARD: a raw record Id must NOT disclose signer data
+    // (the closed IDOR). Passing the request Id returns empty.
+    List<DocGenAuthenticatorController.VerificationResult> byId = DocGenAuthenticatorController.verifyByRequestId(
+        String.valueOf(sigReqId)
+    );
+    if (byId == null || byId.isEmpty()) {
+        pass++;
+        System.debug('VERIFY REJECTS RAW ID (IDOR closed): PASS');
+    } else {
+        fail++;
+        System.debug('VERIFY REJECTS RAW ID (IDOR closed): FAIL — leaked ' + byId.size() + ' results');
     }
 } catch (Exception e) {
     fail++;
-    System.debug('VERIFY BY REQUEST ID: FAIL — ' + e.getMessage());
+    System.debug('VERIFY BY REQUEST TOKEN: FAIL — ' + e.getMessage());
 }
 
 // ===== Settings: getSettings =====

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,14 +1,14 @@
 {
   "packageDirectories": [
     {
-      "versionName": "v3.05.0 — Signature Template Fidelity",
-      "versionNumber": "3.5.0.NEXT",
-      "ancestorId": "04tVx000000nGZtIAM",
+      "versionName": "v3.06.0 — HTML Signature Placement Detection",
+      "versionNumber": "3.6.0.NEXT",
+      "ancestorId": "04tVx000000nI5RIAU",
       "path": "force-app",
       "default": true,
       "definitionFile": "config/build-def.json",
       "package": "Portwood DocGen Managed",
-      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v3.05 improves e-signature document fidelity so Word template headers, footers, and branding are preserved through preview, sending, and final signed PDFs, with updated permission sets for signature Flow and reminder features. Free for all users."
+      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v3.06 fixes e-signature setup for HTML templates so signature fields are detected correctly when sending documents for signature. Free for all users."
     }
   ],
   "name": "Portwood DocGen",
@@ -166,6 +166,7 @@
     "Portwood DocGen Managed@3.2.0-1": "04tVx000000muJFIAY",
     "Portwood DocGen Managed@3.3.0-1": "04tVx000000nEHxIAM",
     "Portwood DocGen Managed@3.4.0-1": "04tVx000000nGZtIAM",
-    "Portwood DocGen Managed@3.5.0-1": "04tVx000000nI5RIAU"
+    "Portwood DocGen Managed@3.5.0-1": "04tVx000000nI5RIAU",
+    "Portwood DocGen Managed@3.6.0-1": "04tVx000000nIv4IAE"
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,14 +1,14 @@
 {
   "packageDirectories": [
     {
-      "versionName": "v3.10.0 — Large-template Snapshot Fidelity",
-      "versionNumber": "3.10.0.NEXT",
-      "ancestorId": "04tVx000000nOdtIAE",
+      "versionName": "v3.11.0 — Shared Template Image Rendering",
+      "versionNumber": "3.11.0.NEXT",
+      "ancestorId": "04tVx000000nOh7IAE",
       "path": "force-app",
       "default": true,
       "definitionFile": "config/build-def.json",
       "package": "Portwood DocGen Managed",
-      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v3.10 improves large-template rendering fidelity for non-admin users, preserving template headers, footers, and embedded images. Free for all users."
+      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v3.11 improves image rendering for shared templates so non-admin users can generate PDFs with embedded template images intact. Free for all users."
     }
   ],
   "name": "Portwood DocGen",
@@ -171,6 +171,7 @@
     "Portwood DocGen Managed@3.7.0-1": "04tVx000000nLOHIA2",
     "Portwood DocGen Managed@3.8.0-1": "04tVx000000nOFhIAM",
     "Portwood DocGen Managed@3.9.0-1": "04tVx000000nOdtIAE",
-    "Portwood DocGen Managed@3.10.0-1": "04tVx000000nOh7IAE"
+    "Portwood DocGen Managed@3.10.0-1": "04tVx000000nOh7IAE",
+    "Portwood DocGen Managed@3.11.0-1": "04tVx000000nPGbIAM"
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,14 +1,14 @@
 {
   "packageDirectories": [
     {
-      "versionName": "v3.07.0 — HTML Signature Rendering",
-      "versionNumber": "3.7.0.NEXT",
-      "ancestorId": "04tVx000000nIv4IAE",
+      "versionName": "v3.08.0 — Signature Images and Generation Access",
+      "versionNumber": "3.8.0.NEXT",
+      "ancestorId": "04tVx000000nLOHIA2",
       "path": "force-app",
       "default": true,
       "definitionFile": "config/build-def.json",
       "package": "Portwood DocGen Managed",
-      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v3.07 fixes e-signature previews and completed signed PDFs for HTML templates. Free for all users."
+      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v3.08 improves HTML e-signature image rendering and fixes non-admin generation access for large templates. Free for all users."
     }
   ],
   "name": "Portwood DocGen",
@@ -168,6 +168,7 @@
     "Portwood DocGen Managed@3.4.0-1": "04tVx000000nGZtIAM",
     "Portwood DocGen Managed@3.5.0-1": "04tVx000000nI5RIAU",
     "Portwood DocGen Managed@3.6.0-1": "04tVx000000nIv4IAE",
-    "Portwood DocGen Managed@3.7.0-1": "04tVx000000nLOHIA2"
+    "Portwood DocGen Managed@3.7.0-1": "04tVx000000nLOHIA2",
+    "Portwood DocGen Managed@3.8.0-1": "04tVx000000nOFhIAM"
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,14 +1,14 @@
 {
   "packageDirectories": [
     {
-      "versionName": "v3.09.0 — Non-admin Large-template Access",
-      "versionNumber": "3.9.0.NEXT",
-      "ancestorId": "04tVx000000nOFhIAM",
+      "versionName": "v3.10.0 — Large-template Snapshot Fidelity",
+      "versionNumber": "3.10.0.NEXT",
+      "ancestorId": "04tVx000000nOdtIAE",
       "path": "force-app",
       "default": true,
       "definitionFile": "config/build-def.json",
       "package": "Portwood DocGen Managed",
-      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v3.09 improves non-admin access for large-template generation and keeps HTML e-signature rendering reliable. Free for all users."
+      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v3.10 improves large-template rendering fidelity for non-admin users, preserving template headers, footers, and embedded images. Free for all users."
     }
   ],
   "name": "Portwood DocGen",
@@ -170,6 +170,7 @@
     "Portwood DocGen Managed@3.6.0-1": "04tVx000000nIv4IAE",
     "Portwood DocGen Managed@3.7.0-1": "04tVx000000nLOHIA2",
     "Portwood DocGen Managed@3.8.0-1": "04tVx000000nOFhIAM",
-    "Portwood DocGen Managed@3.9.0-1": "04tVx000000nOdtIAE"
+    "Portwood DocGen Managed@3.9.0-1": "04tVx000000nOdtIAE",
+    "Portwood DocGen Managed@3.10.0-1": "04tVx000000nOh7IAE"
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,14 +1,14 @@
 {
   "packageDirectories": [
     {
-      "versionName": "v3.08.0 — Signature Images and Generation Access",
-      "versionNumber": "3.8.0.NEXT",
-      "ancestorId": "04tVx000000nLOHIA2",
+      "versionName": "v3.09.0 — Non-admin Large-template Access",
+      "versionNumber": "3.9.0.NEXT",
+      "ancestorId": "04tVx000000nOFhIAM",
       "path": "force-app",
       "default": true,
       "definitionFile": "config/build-def.json",
       "package": "Portwood DocGen Managed",
-      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v3.08 improves HTML e-signature image rendering and fixes non-admin generation access for large templates. Free for all users."
+      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v3.09 improves non-admin access for large-template generation and keeps HTML e-signature rendering reliable. Free for all users."
     }
   ],
   "name": "Portwood DocGen",
@@ -169,6 +169,7 @@
     "Portwood DocGen Managed@3.5.0-1": "04tVx000000nI5RIAU",
     "Portwood DocGen Managed@3.6.0-1": "04tVx000000nIv4IAE",
     "Portwood DocGen Managed@3.7.0-1": "04tVx000000nLOHIA2",
-    "Portwood DocGen Managed@3.8.0-1": "04tVx000000nOFhIAM"
+    "Portwood DocGen Managed@3.8.0-1": "04tVx000000nOFhIAM",
+    "Portwood DocGen Managed@3.9.0-1": "04tVx000000nOdtIAE"
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,14 +1,14 @@
 {
   "packageDirectories": [
     {
-      "versionName": "v3.06.0 — HTML Signature Placement Detection",
-      "versionNumber": "3.6.0.NEXT",
-      "ancestorId": "04tVx000000nI5RIAU",
+      "versionName": "v3.07.0 — HTML Signature Rendering",
+      "versionNumber": "3.7.0.NEXT",
+      "ancestorId": "04tVx000000nIv4IAE",
       "path": "force-app",
       "default": true,
       "definitionFile": "config/build-def.json",
       "package": "Portwood DocGen Managed",
-      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v3.06 fixes e-signature setup for HTML templates so signature fields are detected correctly when sending documents for signature. Free for all users."
+      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v3.07 fixes e-signature previews and completed signed PDFs for HTML templates. Free for all users."
     }
   ],
   "name": "Portwood DocGen",
@@ -167,6 +167,7 @@
     "Portwood DocGen Managed@3.3.0-1": "04tVx000000nEHxIAM",
     "Portwood DocGen Managed@3.4.0-1": "04tVx000000nGZtIAM",
     "Portwood DocGen Managed@3.5.0-1": "04tVx000000nI5RIAU",
-    "Portwood DocGen Managed@3.6.0-1": "04tVx000000nIv4IAE"
+    "Portwood DocGen Managed@3.6.0-1": "04tVx000000nIv4IAE",
+    "Portwood DocGen Managed@3.7.0-1": "04tVx000000nLOHIA2"
   }
 }


### PR DESCRIPTION
## Summary
Closes an unauthenticated PII-disclosure (IDOR) on the guest-reachable signature verifier, and removes a client-controlled audit IP.

### IDOR (High) — `verifyByRequestId`
`@AuraEnabled @RemoteAction`, `without sharing`, granted to anonymous guests via `DocGen_Guest_Signature`. It returned every signer's name/email/IP for any **guessable** `Signature_Request__c` Id (record Ids are enumerable). The capability is now the request's unguessable 64-hex `Secure_Token__c`:
- `verifyByRequestId` requires a 64-hex token and resolves audits via `Signature_Request__r.Secure_Token__c`.
- The certificate verify link emits `?token=` (not `?id=`); `docGenAuthenticator` LWC + `DocGenVerify` page read/validate the token.
- Template/packet request creation populates `req.Secure_Token__c` (no signing-token conflation — those paths previously left it null).
- Legacy `?id=` links fail closed (15/18-char ≠ 64-hex); those docs remain verifiable by upload (`verifyDocument`).

### Audit IP (Medium)
`resolveClientIp` no longer lets a client-supplied `ipAddress` argument override the server-observed IP — a signer can't forge the IP on their own tamper-evident audit. (Residual `X-Forwarded-For` hop-selection noted in code for a follow-up that needs a live Experience Cloud test.)

## Tests
- `DocGenAuthenticatorControllerTest` + `DocGenSignatureTests` updated, incl. an **IDOR regression guard** (raw Id returns empty).
- `e2e-06` adds the same guard (`VERIFY REJECTS RAW ID (IDOR closed): PASS`).
- Validated on a fresh scratch org: RunLocalTests pass, org-wide coverage 76%, code-analyzer 0, e2e-06 24/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)