### PR TITLE
[WIP] Generation consolidation — one deterministic path for every entry point

### DIFF
--- a/force-app/main/default/classes/DocGenBatch.cls
+++ b/force-app/main/default/classes/DocGenBatch.cls
@@ -91,7 +91,11 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
             throw new DocGenException('Invalid object: ' + baseObject);
         }
 
-        String sanitizedCondition = sanitizeCondition(condition);
+        // Consolidated: both bulk entry paths (controller + batch) validate filters
+        // through ONE sanitizer so behavior is identical. The shared version also
+        // normalizes whitespace before keyword matching, closing a tab/newline
+        // bypass (e.g. "SELECT\t") that this class's former local copy missed.
+        String sanitizedCondition = DocGenBulkController.sanitizeCondition(condition);
         String query = 'SELECT Id FROM ' + baseObject;
         if (String.isNotBlank(sanitizedCondition)) {
             query += ' WHERE ' + sanitizedCondition;
@@ -186,42 +190,6 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
             dataCacheCvId = null;
             cachedDataJson = null;
         }
-    }
-
-    /**
-     * Basic sanitization of dynamic WHERE conditions to prevent SOQL injection.
-     */
-    private static String sanitizeCondition(String condition) {
-        if (String.isBlank(condition)) {
-            return condition;
-        }
-        // Reject dangerous characters (statement termination, comments)
-        if (condition.contains(';') || condition.contains('--') || condition.contains('/*')) {
-            throw new DocGenException('Invalid filter condition.');
-        }
-        String upper = condition.toUpperCase().trim();
-        List<String> disallowed = new List<String>{
-            'SELECT ',
-            'INSERT ',
-            'UPDATE ',
-            'DELETE ',
-            'MERGE ',
-            'UNDELETE ',
-            'WITH ',
-            'GROUP BY ',
-            'ORDER BY ',
-            'LIMIT ',
-            'OFFSET ',
-            'FOR UPDATE',
-            'HAVING ',
-            'TYPEOF '
-        };
-        for (String keyword : disallowed) {
-            if (upper.contains(keyword)) {
-                throw new DocGenException('Invalid filter condition.');
-            }
-        }
-        return condition;
     }
 
     /**

--- a/force-app/main/default/classes/DocGenBatchErrorLogTest.cls
+++ b/force-app/main/default/classes/DocGenBatchErrorLogTest.cls
@@ -79,4 +79,25 @@ private class DocGenBatchErrorLogTest {
         DocGenBatch batch = new DocGenBatch(jobId);
         System.assertEquals(null, batch.buildErrorLog(), 'No failures → null (Error_Log__c stays empty)');
     }
+
+    @isTest
+    static void consolidatedSanitizerClosesTabBypass() {
+        // The bulk batch now validates filters through DocGenBulkController.sanitizeCondition
+        // (one shared sanitizer for both bulk entry paths). It normalizes whitespace, so a
+        // keyword smuggled past the old batch copy with a tab ("SELECT\t") is now rejected.
+        Boolean rejected = false;
+        try {
+            DocGenBulkController.sanitizeCondition('Name != null AND\tSELECT\tId');
+        } catch (Exception e) {
+            rejected = true;
+        }
+        System.assert(rejected, 'Tab-separated SELECT must be rejected by the shared sanitizer');
+
+        // A clean filter still passes through unchanged.
+        System.assertEquals(
+            'Industry = \'Tech\'',
+            DocGenBulkController.sanitizeCondition('Industry = \'Tech\''),
+            'A valid filter is returned unchanged'
+        );
+    }
 }


### PR DESCRIPTION
**Draft / in-progress.** Goal (per Dave): the runner, Flow action, "Generate sample" on template edit, and bulk should all run the **same generation path**, so the output for a given template + record is deterministic regardless of how it's triggered.

## The determinism gap (mapped)
Two independent sources of divergence today:

**1. The sync-vs-giant DISPATCH is duplicated and inconsistent per entry point.**
| Entry point | Generate call | Giant (>2000 rows) handling |
|---|---|---|
| Runner (`docGenRunner`) | `generatePdf` / `generateDocumentParts` | Client re-calls `generateDocumentGiantQuery` on heap signal |
| Generate Sample (`docGenAdmin`) | `generatePdf` | **No giant fallback imported** → differs from runner |
| Flow (`DocGenFlowAction`) | `generateDocument` / `…FromData` | Separate `DocGenGiantQueryFlowAction` |
| Bulk (`DocGenBatch`) | `generateDocument` | **None** (fails on big records — see #155) |

**2. The giant path uses a DIFFERENT tag resolver.** `DocGenGiantQueryAssembler` reimplements parent/aggregate resolution and **leaks** `{#section}`, `{^inverse}`, `{:else}`, nested `{#child}` loops, and `{*barcode}` as raw text (the normal path resolves them in `processXml`). So a doc that crosses the 2000-row threshold renders differently.

## Target architecture
- **One Router** — `scout child counts → {sync | giant:relationship}` — called by *every* entry point, so the dispatch decision is identical everywhere (move it server-side out of the runner LWC).
- **One Resolver** — the giant path routes its parent-level XML through `processXml` (the seam: after the `{ROWS}` placeholder is installed, feed the surrounding HTML + a parent-only data map to `processXmlForTest`). Fixes all five leaks at once and makes giant output match sync output.
- Entry points become thin adapters over the Router; bulk/Flow/sample/runner all converge.

## Landed in this branch
- ✅ **Consolidated bulk filter sanitization** to one shared `DocGenBulkController.sanitizeCondition` (also closes a `SELECT\t` injection bypass the batch copy had). First safe step.

## Sequenced plan (remaining)
1. **Parent-XML through `processXml` in the giant path** (highest value; fixes the documented leaks → deterministic output across the threshold). **Riskiest change in the codebase** — guard with new `e2e-07-syntax` assertions feeding `{#bool}{:else}`, `{^bool}`, nested `{#child}`, `{*barcode}` through the giant shape and asserting none leak. Do as a focused, isolated run.
2. **Shared Router** — extract the scout→sync|giant decision into one class; route runner + sample + Flow + bulk through it (bulk's deferred giant pass = #155).
3. **DRY remaining twins** — `sanitizeWhereClause` (DocGenGiantQueryBatch vs DocGenDataRetriever), the three `{TODAY}/{NOW}/:format` copies.

## Validation so far
Affected suites green on a fresh scratch org (bulk 60/60). Each step will re-run RunLocalTests + e2e-07 + code-analyzer.

Tracked follow-ups: #155 (bulk→giant deferred), #156 (chunked snapshot storage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)