### PR TITLE
 feat(signatures): PDF-viewer e-signature flow — in-browser signing, snapshot re-render onto record, {#Signatures} loop block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v3.06.0 — HTML Signature Placement Detection (`04tVx000000nIv4IAE`, build `3.6.0-1`, promoted 2026-06-11)
+
+This release fixes HTML-template signature sending. HTML templates that contained valid signature tags such as `{@Signature_Customer}` or `{@Signature_Customer:1:Date}` could render the tag text in generated output but still show **No Signature Placements Found** in the signature sender component.
+
+Related: [#152](https://github.com/Portwood-Global-Solutions/DocGen/issues/152)
+
+### 1. HTML signature tags are detected by the sender
+
+Signature placement discovery now reads the active HTML template body when the template type is HTML. Word templates continue to use the existing pre-decomposed `word/document.xml` path.
+
+The parser behavior is unchanged: bare tags like `{@Signature_Customer}` still default to a full-signature placement, and v3 tags like `{@Signature_Customer:1:Date}` keep their explicit order/type.
+
+### Release validation
+
+- Package version create: validated build, `ValidationSkipped = false`
+- Promoted package: `04tVx000000nIv4IAE` · [Install URL](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nIv4IAE)
+- Package build coverage: 76%, code coverage check passed
+- Focused Apex validation in `triage-sumit-footer`: `DocGenSignatureTests`, 270/270 tests passed
+- Full e2e suite on `triage-sumit-footer`: PASS/FAIL0 across `e2e-01` through `e2e-08`
+- Full Apex suite: `RunLocalTests`, 1465 tests, 100% pass rate, 76% org-wide coverage
+- `sf code-analyzer` Security + AppExchange: 0 violations; SFGE printed internal timeout diagnostics on existing large controller/service paths before returning a clean summary
+- `npm run format:check`: pass
+- `git diff --check`
+
 ## v3.05.0 — Signature Template Fidelity (`04tVx000000nI5RIAU`, build `3.5.0-1`, promoted 2026-06-11)
 
 This release tightens the e-signature path so Word-authored template branding survives from preview through the final signed PDF, and updates the bundled permission sets for signature Flow and reminder features.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v3.08.0 — Signature Images and Generation Access (`04tVx000000nOFhIAM`, build `3.8.0-1`, promoted 2026-06-11)
+
+This release closes two field-reported support issues: HTML e-signature templates with embedded Salesforce Files images now render those images in signer-facing previews, and non-admin users who can access a template can generate large/giant-query documents without needing DocGen Admin just to read DocGen's internal generated parts.
+
+Related: [#152](https://github.com/Portwood-Global-Solutions/DocGen/issues/152), [#154](https://github.com/Portwood-Global-Solutions/DocGen/issues/154)
+
+### 1. HTML signature previews can render template images
+
+HTML signature preview generation now creates public distribution URLs for Salesforce Files images referenced by HTML template bodies. The cached signer preview HTML rewrites `/sfc/servlet.shepherd/version/download/068...` image sources to those distribution URLs so signer-facing browser previews can load the images, while final PDF rendering keeps the relative `/sfc/...` path required by Salesforce's PDF renderer.
+
+### 2. Non-admin users can generate large templates when internal parts are private
+
+Giant-query generation now reads DocGen-managed internal `docgen_%` / `docgen_giant_%` ContentVersion artifacts with the established FLS guard + `SYSTEM_MODE` pattern after the user's template/job access has already been gated. This fixes the support-thread symptom where a non-admin could see a shared template but generation failed with "Pre-decomposed template parts not found", while admins could generate the same document.
+
+### Release validation
+
+- Package version create: `08cVx000000iKvtIAE` succeeded; package coverage 76%; subscriber package `04tVx000000nOFhIAM`
+- Promoted package: `04tVx000000nOFhIAM` · [Install URL](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOFhIAM) · [Sandbox Install URL](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOFhIAM)
+- Full e2e suite in `triage-sumit-footer`: e2e-01 through e2e-08 PASS/FAIL0
+- Full Apex validation in `triage-sumit-footer`: `RunLocalTests` 1487/1487, org coverage 76% (`707cf00000zNB7s`)
+- Code Analyzer: Security + AppExchange selectors, 0 violations
+- Focused proof in `triage-sumit-footer`: `DocGenSignatureTests` HTML image assertions + giant-query internal content guard passed (`707cf00000zMYTW`)
+- Broader focused Apex validation in `triage-sumit-footer`: `DocGenSignatureTests` 277/277, `DocGenGiantQueryTest` 46/46, `DocGenControllerTests` 223/223
+
 ## v3.07.0 — HTML Signature Rendering (`04tVx000000nLOHIA2`, build `3.7.0-1`, promoted 2026-06-11)
 
 This release completes HTML-template e-signature support. v3.06 fixed sender-side signature placement detection, but HTML signature previews and completed signed PDFs could still render blank because the signing flow sent already-rendered HTML through the Word-to-HTML renderer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v3.07.0 — HTML Signature Rendering (`04tVx000000nLOHIA2`, build `3.7.0-1`, promoted 2026-06-11)
+
+This release completes HTML-template e-signature support. v3.06 fixed sender-side signature placement detection, but HTML signature previews and completed signed PDFs could still render blank because the signing flow sent already-rendered HTML through the Word-to-HTML renderer.
+
+Related: [#152](https://github.com/Portwood-Global-Solutions/DocGen/issues/152)
+
+### 1. HTML signature previews render the merged HTML directly
+
+Signature preview generation now carries the template type through the merge result. HTML templates use the merged HTML body directly, while Word templates continue through the existing DOCX XML renderer with header/footer handling.
+
+### 2. Completed HTML signature PDFs stamp tags in HTML
+
+Final signed PDF rendering now uses an HTML-safe stamping path for HTML templates and keeps the existing XML-safe stamping path for Word templates. Signed values are HTML-escaped before replacement.
+
+### Release validation
+
+- Package version create: validated build, `ValidationSkipped = false`
+- Promoted package: `04tVx000000nLOHIA2` · [Install URL](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nLOHIA2)
+- Package build coverage: 76%, code coverage check passed
+- Focused Apex validation in `triage-sumit-footer`: `DocGenSignatureTests`, 274/274 tests passed
+- Visual E2E in `triage-sumit-footer`: sender LWC PDF preview, signer preview, completed signed PDF, and verification certificate all rendered successfully for an HTML signature template
+- Full e2e suite on `triage-sumit-footer`: PASS/FAIL0 across `e2e-01` through `e2e-08`
+- Full Apex suite: `RunLocalTests`, 1469 tests, 100% pass rate, 76% org-wide coverage
+- `sf code-analyzer` Security + AppExchange: 0 violations; SFGE printed internal timeout diagnostics on existing large controller paths before returning a clean summary
+
 ## v3.06.0 — HTML Signature Placement Detection (`04tVx000000nIv4IAE`, build `3.6.0-1`, promoted 2026-06-11)
 
 This release fixes HTML-template signature sending. HTML templates that contained valid signature tags such as `{@Signature_Customer}` or `{@Signature_Customer:1:Date}` could render the tag text in generated output but still show **No Signature Placements Found** in the signature sender component.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## Unreleased — PDF-viewer e-signature flow
+
+A new, opt-in signing experience that renders the **real generated PDF** in the signer's browser and pushes the completed document back onto the record. Purely additive — the existing typed-name signing flow, `{@Signature_Role}` role tags, and all current templates are unchanged. Reached via the new Flow action **"DocGen: Send Existing Document for Signature"** (`DocGenSignaturePdfFlowAction`); the legacy page remains the default for the bundled send component.
+
+### 1. In-browser PDF-viewer signing page
+
+New guest-facing Visualforce page `DocGenSignaturePdf` renders the actual PDF (not a typed-name placement page) and guides the signer through a modal: token/PIN verification → review the PDF → consent → sign. IDOR-safe — the signer's token resolves only its own bound document; guest reads use the established `DocGenFlsGuard` + `WITH SYSTEM_MODE` pattern.
+
+### 2. Signed document + certificate attached to the record (snapshot re-render)
+
+On a template-snapshot send, DocGen captures the record's merge data **at send-time** as a JSON snapshot. On completion it re-renders the document from that snapshot — so the signed output reflects the data as it was when sent, immune to later record edits — appends a signing-certificate page (signer names, roles, IPs, timestamps, consent), and attaches the combined PDF to the related record with a SHA-256 hash written to the audit record. The certificate shows the name each signer **typed** at signing.
+
+### 3. `{#Signatures}` signature loop block (variable signer count)
+
+Authors can wrap one signature layout in `{#Signatures}...{/Signatures}` anywhere in a template; it renders once per signer, for any signer count — no per-count templates and no orphaned role tags. Per-row fields: `{Name}` (typed e-signature, falling back to the invited name), `{RegisteredName}`, `{Role}`, `{Email}`, `{SignedDate}`, `{Status}`. Backwards-compatible: a template without the block renders identically to before, and role tags still work for fixed-position signatures.
+
+### 4. New Flow action
+
+`DocGenSignaturePdfFlowAction` ("DocGen: Send Existing Document for Signature") is the supported entry point, with two modes: **Template Id** (snapshot re-render onto the record, supports `{#Signatures}`) or **Content Version Id** (send an already-generated document as-is). See UserGuide §11.7.
+
+### Validation
+
+- `RunLocalTests` 1515/1515 (100%), org-wide coverage 76%
+- Live end-to-end: two-signer snapshot send signed in-browser → re-rendered document with two `{#Signatures}` blocks + certificate page attached to the record
+
 ## v3.08.0 — Signature Images and Generation Access (`04tVx000000nOFhIAM`, build `3.8.0-1`, promoted 2026-06-11)
 
 This release closes two field-reported support issues: HTML e-signature templates with embedded Salesforce Files images now render those images in signer-facing previews, and non-admin users who can access a template can generate large/giant-query documents without needing DocGen Admin just to read DocGen's internal generated parts.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 
 [Join the Community Channel](https://portwood.dev/community) | [Website](https://portwood.dev) | [Roadmap](https://portwood.dev/roadmap)
 
-[![Version](https://img.shields.io/badge/version-3.05.0-blue.svg)](#install)
+[![Version](https://img.shields.io/badge/version-3.06.0-blue.svg)](#install)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Salesforce-00A1E0.svg)](https://www.salesforce.com)
 [![Namespace](https://img.shields.io/badge/namespace-portwoodglobal-purple.svg)](#install)
@@ -18,10 +18,10 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 ## Install
 
 ```bash
-sf package install --package 04tVx000000nI5RIAU --wait 10 --target-org <your-org>
+sf package install --package 04tVx000000nIv4IAE --wait 10 --target-org <your-org>
 ```
 
-[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nI5RIAU) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nI5RIAU)
+[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nIv4IAE) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nIv4IAE)
 
 **Then:** Assign **DocGen Admin** permission set | Enable **Blob.toPdf() Release Update** | Open the **DocGen** app
 
@@ -371,7 +371,7 @@ Decompress → Merge XML tags → Recompress
 
 ## Releases
 
-DocGen ships on a **biweekly release cycle**. Latest release: **v3.05.0 — Signature Template Fidelity**.
+DocGen ships on a **biweekly release cycle**. Latest release: **v3.06.0 — HTML Signature Placement Detection**.
 
 See [CHANGELOG.md](CHANGELOG.md) for full version history.
 
@@ -444,7 +444,8 @@ Found a vulnerability? See [SECURITY.md](SECURITY.md).
 
 | Version | Channel                                 | Package ID           |
 | ------- | --------------------------------------- | -------------------- |
-| v3.05.0 | **Latest (Released)**                   | `04tVx000000nI5RIAU` |
+| v3.06.0 | **Latest (Released)**                   | `04tVx000000nIv4IAE` |
+| v3.05.0 | Previous                                | `04tVx000000nI5RIAU` |
 | v3.04.0 | Previous                                | `04tVx000000nGZtIAM` |
 | v3.03.0 | Previous                                | `04tVx000000nEHxIAM` |
 | v3.02.0 | Previous                                | `04tVx000000muJFIAY` |

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 
 [Join the Community Channel](https://portwood.dev/community) | [Website](https://portwood.dev) | [Roadmap](https://portwood.dev/roadmap)
 
-[![Version](https://img.shields.io/badge/version-3.06.0-blue.svg)](#install)
+[![Version](https://img.shields.io/badge/version-3.07.0-blue.svg)](#install)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Salesforce-00A1E0.svg)](https://www.salesforce.com)
 [![Namespace](https://img.shields.io/badge/namespace-portwoodglobal-purple.svg)](#install)
-[![Apex Tests](https://img.shields.io/badge/Apex_Tests-1478%2F1478_passing-brightgreen)](#code-quality)
+[![Apex Tests](https://img.shields.io/badge/Apex_Tests-1469%2F1469_passing-brightgreen)](#code-quality)
 [![Coverage](https://img.shields.io/badge/Coverage-76%25-brightgreen)](#code-quality)
 [![Security](https://img.shields.io/badge/Code_Analyzer-0%2F0%2F0-brightgreen)](#security)
 [![Website](https://img.shields.io/badge/website-portwood.dev-blue)](https://portwood.dev)
@@ -18,10 +18,10 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 ## Install
 
 ```bash
-sf package install --package 04tVx000000nIv4IAE --wait 10 --target-org <your-org>
+sf package install --package 04tVx000000nLOHIA2 --wait 10 --target-org <your-org>
 ```
 
-[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nIv4IAE) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nIv4IAE)
+[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nLOHIA2) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nLOHIA2)
 
 **Then:** Assign **DocGen Admin** permission set | Enable **Blob.toPdf() Release Update** | Open the **DocGen** app
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 
 [Join the Community Channel](https://portwood.dev/community) | [Website](https://portwood.dev) | [Roadmap](https://portwood.dev/roadmap)
 
-[![Version](https://img.shields.io/badge/version-3.07.0-blue.svg)](#install)
+[![Version](https://img.shields.io/badge/version-3.08.0-blue.svg)](#install)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Salesforce-00A1E0.svg)](https://www.salesforce.com)
 [![Namespace](https://img.shields.io/badge/namespace-portwoodglobal-purple.svg)](#install)
-[![Apex Tests](https://img.shields.io/badge/Apex_Tests-1469%2F1469_passing-brightgreen)](#code-quality)
+[![Apex Tests](https://img.shields.io/badge/Apex_Tests-1487%2F1487_passing-brightgreen)](#code-quality)
 [![Coverage](https://img.shields.io/badge/Coverage-76%25-brightgreen)](#code-quality)
 [![Security](https://img.shields.io/badge/Code_Analyzer-0%2F0%2F0-brightgreen)](#security)
 [![Website](https://img.shields.io/badge/website-portwood.dev-blue)](https://portwood.dev)
@@ -18,10 +18,10 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 ## Install
 
 ```bash
-sf package install --package 04tVx000000nLOHIA2 --wait 10 --target-org <your-org>
+sf package install --package 04tVx000000nOFhIAM --wait 10 --target-org <your-org>
 ```
 
-[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nLOHIA2) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nLOHIA2)
+[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOFhIAM) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nOFhIAM)
 
 **Then:** Assign **DocGen Admin** permission set | Enable **Blob.toPdf() Release Update** | Open the **DocGen** app
 
@@ -371,7 +371,7 @@ Decompress → Merge XML tags → Recompress
 
 ## Releases
 
-DocGen ships on a **biweekly release cycle**. Latest release: **v3.06.0 — HTML Signature Placement Detection**.
+DocGen ships on a **biweekly release cycle**. Latest release: **v3.08.0 — Signature Images and Generation Access**.
 
 See [CHANGELOG.md](CHANGELOG.md) for full version history.
 
@@ -444,7 +444,9 @@ Found a vulnerability? See [SECURITY.md](SECURITY.md).
 
 | Version | Channel                                 | Package ID           |
 | ------- | --------------------------------------- | -------------------- |
-| v3.06.0 | **Latest (Released)**                   | `04tVx000000nIv4IAE` |
+| v3.08.0 | **Latest (Released)**                   | `04tVx000000nOFhIAM` |
+| v3.07.0 | Previous                                | `04tVx000000nLOHIA2` |
+| v3.06.0 | Previous                                | `04tVx000000nIv4IAE` |
 | v3.05.0 | Previous                                | `04tVx000000nI5RIAU` |
 | v3.04.0 | Previous                                | `04tVx000000nGZtIAM` |
 | v3.03.0 | Previous                                | `04tVx000000nEHxIAM` |

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -1689,6 +1689,40 @@ See [§10](#10-e-signatures-v3) for the full signature feature. Tag syntax:
 
 Pre-signing, tags are preserved in the output (not replaced). Post-signing, they're stamped with the signer's typed name or signed date + a subtle "Electronically signed by X on DATE" verification line.
 
+#### Signature loop block — `{#Signatures}` (variable signer count)
+
+Role tags above pin each signer to a **fixed spot** — perfect when you know the parties (Buyer + Seller). But when the **number of signers varies** (a quote signed by one person today, three next week), you'd otherwise need a separate template per count, and any unused role tag leaks as literal text.
+
+The `{#Signatures}` loop block solves this: author **one** signature layout and it repeats **once per signer**, for any count, wherever you place it in the document.
+
+```
+{#Signatures}
+  ______________________________
+  {Name}
+  Electronically signed on {SignedDate}
+  {Role} · {Email}
+{/Signatures}
+```
+
+Per-row fields available inside the block:
+
+| Field              | Value                                                                                           |
+| ------------------ | ----------------------------------------------------------------------------------------------- |
+| `{Name}`           | The name the signer typed at signing (their e-signature); the invited name if none was captured |
+| `{RegisteredName}` | The name the signer was invited under                                                           |
+| `{Role}`           | The signer's role (defaults to `Signer`)                                                        |
+| `{Email}`          | The signer's email                                                                              |
+| `{SignedDate}`     | The date they signed (blank before signing)                                                     |
+| `{Status}`         | `Pending` before signing, `Signed` after                                                        |
+
+**Styling is yours.** The block is plain template content, so style `{Name}` however you like — a cursive web font for a handwritten look, a bordered box, a two-column table of signers, etc. (HTML templates have full CSS control within the Flying Saucer CSS 2.1 subset; Word templates can style the line too.)
+
+Notes:
+
+- **Backwards-compatible and additive.** Role tags (`{@Signature_Role}`) are unchanged and continue to work exactly as before — use them when you want signatures in fixed, scattered positions. A template **without** a `{#Signatures}` block renders identically to previous releases. You can even combine both in one template.
+- **Where it applies.** The loop is populated by the snapshot/PDF-viewer signing flow (the flow that re-renders the document from a send-time data snapshot and attaches the completed PDF + certificate to the record). Before signing, the block previews the invited signers with a `Pending` status; on completion it shows each signer's typed signature and signed date.
+- **Typed-name signatures** today (drawn-signature images are a planned future enhancement; the loop already supports per-row image fields for when that lands).
+
 ### 7.10 Rich text fields
 
 When a field value contains HTML (`<p>`, `<div>`, `<br>`, `<b>`, `<i>`, `<u>`, `<strong>`, `<em>`, `<span>`, `<img>`, `<a>`), DocGen preserves the formatting in the output — paragraphs, line breaks, bold/italic/underline, hyperlinks, and embedded images all carry through. Works in **Word templates** (DOCX or PDF output) and **HTML templates** (PDF output). PowerPoint strips HTML to plain text.

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -2090,6 +2090,11 @@ Guided, mobile-friendly. States: PIN verify → signing → review → submit.
 - Before final submit, a consent checkbox.
 - Alternative: **Decline** with optional reason.
 
+**Two signing-page experiences.** DocGen ships two signer-facing pages, and which one a signer lands on is determined by the action that created the request — they coexist, with no org-wide switch:
+
+- **Typed-name page** (`DocGenSignature`, the default) — the placement-driven experience described above, used by the **Create Signature Request** action and the bundled "Send for Signature" component. Signatures are stamped at `{@Signature_Role}` tag positions.
+- **PDF-viewer page** (`DocGenSignaturePdf`) — renders the **real generated PDF** in the browser and guides the signer through a modal. Used by the **Send Existing Document for Signature** action (see [§11.7](#117-recipe--send-a-document-for-signature-on-the-pdf-viewer-page)). On a template-snapshot send it also supports the [`{#Signatures}` loop block](#signature-loop-block--signatures-variable-signer-count) and, on completion, re-renders the document from the send-time data snapshot, appends the certificate page, and attaches the signed PDF to the related record.
+
 ### 10.8 Reminders
 
 Enable in signature settings. A scheduled job runs hourly and sends one reminder to any pending signer whose request is older than the configured threshold (`Signature_Reminder_Hours__c`, default 24h).
@@ -2132,7 +2137,7 @@ Before signatures work in production, complete the checklist in **Signature Sett
 - ✅ Active Salesforce Site exists
 - ✅ Org-Wide Email Address configured + verified (green checkmark)
 - ✅ Guest permission set assigned to the Site's guest user
-- ✅ Signature VF pages deployed (`DocGenSignature`, `DocGenVerify`, `DocGenSign`)
+- ✅ Signature VF pages deployed (`DocGenSignature`, `DocGenSignaturePdf`, `DocGenVerify`, `DocGenSign`)
 
 The Settings panel shows each check as pass/fail with a fix link.
 
@@ -2161,7 +2166,7 @@ Branding applies to all signature emails (invitations, reminders, completion, de
 
 ## 11. Flow automation cookbook
 
-DocGen ships four Flow invocable actions plus two helpers for custom signing UIs. Each one fits a different job-to-be-done. Below: which to pick, plus a worked recipe for each.
+DocGen ships five Flow invocable actions plus three helpers for custom signing UIs. Each one fits a different job-to-be-done. Below: which to pick, plus a worked recipe for each.
 
 ### 11.1 Picking the right action
 
@@ -2171,6 +2176,7 @@ DocGen ships four Flow invocable actions plus two helpers for custom signing UIs
 | Auto-detect "is this dataset big enough to need async?" and route accordingly | **DocGen — Generate Document (Auto Giant Query)** |
 | Run a template against many records in one batch                              | **DocGen — Generate Bulk Documents**              |
 | Email a document for typed-name signature                                     | **DocGen: Create Signature Request**              |
+| Send a generated document for signature on the in-browser PDF viewer          | **DocGen: Send Existing Document for Signature**  |
 
 The first is the workhorse. The other three exist because Flow can't always tell at design time whether a dataset will be small (sync) or huge (async), and bulk + signatures need different inputs.
 
@@ -2283,7 +2289,33 @@ Only **`name`** and **`email`** are required. Add the populated record into your
 
 For multi-signer flows (parallel: legal + executive sign together; sequential: employee → manager → VP → CFO), add one Signer entry per person and pick **Parallel** or **Sequential** as the signing order.
 
-### 11.7 Recipe — Pass pre-built JSON data instead of querying
+### 11.7 Recipe — Send a document for signature on the PDF viewer page
+
+Use **DocGen: Send Existing Document for Signature** (`DocGenSignaturePdfFlowAction`) when you want the signer to review the **real, fully rendered PDF in the browser** (rather than the typed-name placement page) and have the completed document land back on the record. The action has **two modes** — pass exactly one of the first two inputs:
+
+- **Snapshot mode (recommended)** — pass a **Template Id**. DocGen snapshots the record's merge data at send-time and, on completion, re-renders the document from that snapshot (immune to later record edits), appends a signing-certificate page, and attaches the signed PDF to the related record's Files. This mode supports the [`{#Signatures}` loop block](#signature-loop-block--signatures-variable-signer-count) — one signature layout that repeats per signer. The template must have a **Base Object** and **Query Config** set.
+- **Existing-document mode** — pass a **Content Version Id** (`068…`) of a document you already generated. The signer sees that exact PDF as-is. On this path the signed document is not auto-attached to the record (audit + status are still recorded).
+
+**Trigger:** any Flow (record-triggered, screen, or scheduled). Build the `signers` collection exactly as in [§11.6](#116-recipe--send-a-contract-for-signature-on-opportunity-approval) (an Apex-Defined `DocGenSigner` collection — `name` + `email` required; `role`, `contactId` optional).
+
+**Step — DocGen: Send Existing Document for Signature.**
+
+| Input                 | Value                                                                     |
+| --------------------- | ------------------------------------------------------------------------- |
+| Template Id           | `{!$Label.AgreementTemplateId}` _(snapshot mode — OR Content Version Id)_ |
+| Content Version Id    | _(existing-document mode — OR Template Id; leave one blank)_              |
+| Related Record ID     | `{!$Record.Id}`                                                           |
+| Signers               | `{!signers}`                                                              |
+| Signing Order         | `Parallel` or `Sequential`                                                |
+| Document Title Format | _(optional — overrides the title shown on the signing page)_              |
+
+**Outputs:** `success`, `signatureRequestId`, `signerUrls` (per-signer links, 48-hour validity, in signer order), `signerNames` / `signerEmails` / `signerRoles`, and `errorMessage` when `success` is `false`.
+
+**Result:** each signer gets a link to the **PDF-viewer signing page**, reviews the real PDF, and signs through a guided modal. In snapshot mode, once everyone signs, the re-rendered document + certificate page is attached to the related record automatically.
+
+> **Which signature action?** Use **Create Signature Request** ([§11.6](#116-recipe--send-a-contract-for-signature-on-opportunity-approval)) for the classic typed-name placement page driven by `{@Signature_Role}` tags. Use **Send Existing Document for Signature** (this recipe) when you want the in-browser PDF viewer, snapshot re-render onto the record, and/or the `{#Signatures}` loop block.
+
+### 11.8 Recipe — Pass pre-built JSON data instead of querying
 
 The **Generate Document** action accepts an optional **JSON Data** input. When present, DocGen skips its own SOQL retrieval and uses the supplied JSON directly. Use cases:
 
@@ -2306,7 +2338,7 @@ The **Generate Document** action accepts an optional **JSON Data** input. When p
 
 Wire this to a Flow Text Variable populated upstream — typically by an Apex action that calls an external API and returns a JSON string. The merge tags in your template (`{Name}`, `{Amount:currency}`, `{#Items}…{/Items}`) resolve against the JSON instead of a Salesforce record.
 
-### 11.8 Recipe — Custom signing UI (advanced)
+### 11.9 Recipe — Custom signing UI (advanced)
 
 Three helper actions exist for orgs that want to build their own signing experience instead of using the bundled Visualforce pages — for example, an embedded signature pad inside an existing customer portal. **These require package v2.6.0 or later** (earlier versions shipped them but they weren't exposed to subscriber Flows). In Flow Builder, search "DocGen" and pick the action by its label:
 
@@ -2323,7 +2355,7 @@ A typical custom-screen Flow:
 
 Most customers don't need this. Use the bundled Visualforce signing pages unless you have a specific reason to embed.
 
-### 11.9 Polling an async job from a screen Flow
+### 11.10 Polling an async job from a screen Flow
 
 Bulk and Giant Query actions return a `jobId`. To poll inside a screen Flow:
 
@@ -2334,7 +2366,7 @@ Bulk and Giant Query actions return a `jobId`. To poll inside a screen Flow:
 
 Or call `DocGenBulkController.getJobStatus(jobId)` directly from Apex — see [§12.3](#123-docgenbulkcontroller--bulk-generation).
 
-### 11.10 Error handling
+### 11.11 Error handling
 
 Every action returns:
 
@@ -2428,12 +2460,13 @@ import generatePdf from '@salesforce/apex/portwoodglobal.DocGenController.genera
 
 Usable from Flow Builder and from Apex via `Invocable.Action.createCustomAction(...)`:
 
-| Action                               | Class                        | Input                                                                                                           | Output                                                                       |
-| ------------------------------------ | ---------------------------- | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| Generate Document                    | `DocGenFlowAction`           | `templateId`, `recordId`, `saveToRecord`, `documentTitle`, `outputFormatOverride`, `jsonData`                   | `contentDocumentId`, `contentVersionId`, `success`, `errorMessage`           |
-| Generate Bulk Documents              | `DocGenBulkFlowAction`       | `templateId`, `queryCondition`, `recordIds`, `jobLabel`, `combinedPdfOnly`, `keepIndividualFiles`, `batchSize`  | `jobId`, `success`, `errorMessage`                                           |
-| Generate Document (Auto Giant Query) | `DocGenGiantQueryFlowAction` | `templateId`, `recordId`                                                                                        | `contentDocumentId` (small) OR `jobId` (giant)                               |
-| Create Signature Request             | `DocGenSignatureFlowAction`  | `templateId`, `relatedRecordId`, `signers` (List<Signer>: `name`, `email`, `role`, `contactId`), `signingOrder` | `success`, `signatureRequestId`, `signerUrls`, `emailStatus`, `errorMessage` |
+| Action                               | Class                          | Input                                                                                                                                                                                                                 | Output                                                                                                      |
+| ------------------------------------ | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Generate Document                    | `DocGenFlowAction`             | `templateId`, `recordId`, `saveToRecord`, `documentTitle`, `outputFormatOverride`, `jsonData`                                                                                                                         | `contentDocumentId`, `contentVersionId`, `success`, `errorMessage`                                          |
+| Generate Bulk Documents              | `DocGenBulkFlowAction`         | `templateId`, `queryCondition`, `recordIds`, `jobLabel`, `combinedPdfOnly`, `keepIndividualFiles`, `batchSize`                                                                                                        | `jobId`, `success`, `errorMessage`                                                                          |
+| Generate Document (Auto Giant Query) | `DocGenGiantQueryFlowAction`   | `templateId`, `recordId`                                                                                                                                                                                              | `contentDocumentId` (small) OR `jobId` (giant)                                                              |
+| Create Signature Request             | `DocGenSignatureFlowAction`    | `templateId`, `relatedRecordId`, `signers` (List<Signer>: `name`, `email`, `role`, `contactId`), `signingOrder`                                                                                                       | `success`, `signatureRequestId`, `signerUrls`, `emailStatus`, `errorMessage`                                |
+| Send Existing Document for Signature | `DocGenSignaturePdfFlowAction` | `templateId` (snapshot mode) **or** `contentVersionId` (existing-document mode), `relatedRecordId`, `signerRecords` (List<DocGenSigner>: `name`, `email`, `role`, `contactId`), `signingOrder`, `documentTitleFormat` | `success`, `signatureRequestId`, `signerUrls`, `signerNames`, `signerEmails`, `signerRoles`, `errorMessage` |
 
 ### 12.5 `DocGenDataProvider` interface — custom data source
 

--- a/docs/vf-pdf-viewer-signing-plan.md
+++ b/docs/vf-pdf-viewer-signing-plan.md
@@ -1,0 +1,129 @@
+# VF PDF-Viewer Signing — Implementation Plan & Agent Runbook
+
+> **Branch:** `feat/vf-pdf-viewer` (off tag `v3.08.0`)
+> **Milestone 1 goal:** A new guest signing page that renders the **real generated PDF** and captures a guided, modal-based signature (name + consent → audit + `Status='Signed'`). No in-document stamping/positioning yet.
+> **How to use this doc:** Each task has a checkbox. Work top-to-bottom within a workstream; respect the cross-workstream dependencies in §6. Tick boxes as you go and leave a one-line note on anything you changed from this plan.
+
+---
+
+## 1. Context — why we're building this
+
+The current signing page (`DocGenSignature.page`) never shows a real PDF: it renders a lossy DOCX→HTML snapshot (`fetchDocumentData` → `templateBase64`) and stamps signatures into **DOCX XML** (`DocGenSignatureService.stampSignaturesInXml`). We want a different flow:
+
+1. **Generate a real document first** (existing `DocGenFlowAction.generateDocument`) → get `ContentDocumentId` + `ContentVersionId`.
+2. **Send that already-generated file** for signature via a **new "send existing ContentVersion" entry point** that stores the CV id on the envelope.
+3. **Render the actual PDF** to the signer in a new VF page.
+4. Guide signing in a **button-launched modal** instead of inline. Templates carry **no `{@Signature_...}` tags** for now (positioning is a later milestone).
+
+## 2. Locked design decisions
+
+| #   | Decision          | Choice                                                                                                                             |
+| --- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Signed output     | **Append a certificate/audit page** to the original PDF (pages otherwise untouched). **Deferred to Milestone 2.**                  |
+| 2   | Wiring            | **Two-step.** Generate → then a **new** "send existing CV" entry point creates the envelope with `Source_Document_Id__c = <cvId>`. |
+| 3   | Milestone 1 scope | **Skeleton:** render real PDF + modal capture (name/consent) → audit + `Status='Signed'`. No stamping/positioning.                 |
+| 4   | Render tech       | **Hybrid** — native `<iframe>` blob render now, behind a thin **swappable viewer module** so PDF.js drops in later untouched.      |
+
+## 3. Key facts that ground the design (read before coding)
+
+- **Envelope already supports this.** `DocGen_Signature_Request__c.Source_Document_Id__c` (Text 18) holds a `ContentVersion.Id` of a pre-generated doc; it's the path used when `Template__c` is null. **No new field needed.**
+- **Guest PDF serving has a proven pattern.** Guests can't hit file URLs; the page already serves images as base64 via token-gated `@RemoteAction` (`getImageBase64`, ~`DocGenSignatureController.cls:1939`) with IDOR protection (`isAuthorizedSignatureImage`) that **already allowlists the request's `Source_Document_Id__c`**.
+- **No-tags is safe.** With `Template__c` null / no tags, `createPlacementsForSigners` early-returns (no placements); the page tolerates zero placements. Nothing breaks.
+- **Do NOT reuse `saveSignature` for the PDF path.** It publishes `DocGen_Signature_PDF__e`, which kicks the **DOCX-XML** stamping queueable — wrong for a flat PDF. Milestone 1 uses a dedicated save that records audit + status only.
+- **Reuse the security plumbing.** `validateToken`, `DocGenSignatureGuestSecurity.assertSignerReadable`, `DocGenFlsGuard.guestAssert*`, `WITH SYSTEM_MODE`, the IDOR allowlist. This is an AppExchange-reviewed package — match existing patterns exactly.
+
+## 4. Files
+
+**Create**
+
+- `force-app/main/default/pages/DocGenSignaturePdf.page` (+ `.page-meta.xml`, apiVersion 66.0)
+- `force-app/main/default/classes/DocGenSignaturePdfFlowAction.cls` (+ meta) — `global` invocable wrapper
+
+**Modify**
+
+- `force-app/main/default/classes/DocGenSignatureController.cls` — add 2 remote actions
+- `force-app/main/default/classes/DocGenSignatureSenderController.cls` — add `createRequestFromContentVersion`
+
+**Config (org, may be UI not source)**
+
+- Site enabled-pages + path alias (e.g. `/signaturepdf`); guest profile / permission set VF access
+
+---
+
+## 5. Task checklist
+
+### Workstream A — Apex backend (controller + sender + invocable)
+
+- [ ] **A1.** `DocGenSignatureController.getSourcePdfBase64(String token)` — `@AuraEnabled @RemoteAction`. Validate token via existing path; resolve signer→request; read `ContentVersion.VersionData` for the request's `Source_Document_Id__c` **only** (no CV param → no IDOR surface); return `{ base64, fileName, mimeType:'application/pdf' }`. Use `DocGenSignatureGuestSecurity.assertSignerReadable` + `DocGenFlsGuard.guestAssertAccessible(ContentVersion, {'VersionData','Title'})` + `WITH SYSTEM_MODE`.
+- [ ] **A2.** `DocGenSignatureController.savePdfSignature(String token, String typedName, Boolean consentGiven, String ip, String ua)` — `@AuraEnabled @RemoteAction`. Validate token; insert `DocGen_Signature_Audit__c` (reuse the audit-insert block from `saveSignature` ~`:951`); set signer `Status='Signed'` + `Consent_Captured__c`; if all signers signed, set request `Status='Signed'`. **No platform event, no stamping.** Return `{ success, isComplete, remaining }`.
+- [ ] **A3.** `DocGenSignatureSenderController.createRequestFromContentVersion(Id contentVersionId, String relatedRecordId, String signersJson, String signingOrder, String documentTitleFormat)` — `@AuraEnabled`. Insert `DocGen_Signature_Request__c` (`Source_Document_Id__c=contentVersionId`, `Template__c=null`, `Status='Sent'`, related record, signing order, title format) SYSTEM_MODE; call existing `createSignersAndNotify(...)`; build signer URLs to the **new page path** (see C-config), not `/signature`.
+- [ ] **A4.** `DocGenSignaturePdfFlowAction.cls` — `global` class, `@InvocableMethod` label **"DocGen: Send Existing Document for Signature"**, wrapping A3. Inputs: ContentVersion Id, Related Record Id, `List<DocGenSigner>` (reuse existing Apex-Defined type), signing order. Outputs: request Id, signer URLs, success/error. Remember: **`global` + `@InvocableMethod`** for subscriber visibility.
+- [ ] **A5.** Confirm `createSignersAndNotify` / `createPlacementsForSigners` behave correctly with `Template__c=null` (placements skip cleanly). Add a guard/comment if needed.
+
+### Workstream B — Visualforce page + JS (viewer + modal UX)
+
+- [ ] **B1.** Scaffold `DocGenSignaturePdf.page` from `DocGenSignature.page`: keep token read, IP capture (`~:944-957`), and the show/hide state machine; **remove** the HTML-snapshot preview and the guided/legacy full-screen states. `controller="DocGenSignatureController"`.
+- [ ] **B2.** **Viewer abstraction** — single JS module `DocGenPdfViewer.render(base64, containerEl)`. Impl A (now): base64 → `Uint8Array` → `Blob([bytes],{type:'application/pdf'})` → `URL.createObjectURL` → `<iframe>` src. **This module is the only place that knows the render engine.** Document the contract in a header comment so the PDF.js swap is mechanical.
+- [ ] **B3.** On load: `validateToken` → if `requiresPin`, reuse existing `sendPin`/`verifyPin` flow; then call `getSourcePdfBase64` → `DocGenPdfViewer.render(...)`.
+- [ ] **B4.** Main layout: PDF viewer area + a prominent **"Sign" button**.
+- [ ] **B5.** **Signing modal** (SLDS modal markup): confirm name (prefill `signerName`), consent checkbox (required), **Sign** button disabled until consent checked. On submit → capture IP → `savePdfSignature` → success state (and `waiting` state if `isComplete=false` for multi-signer).
+- [ ] **B6.** Error/declined/expired states reuse existing copy/markup patterns.
+
+### Workstream C — Config & deploy enablement
+
+- [~] **C1.** URL builder DONE in source (`DocGenSignatureSenderController.getSigningPdfPagePath()` → `/apex/[ns__]DocGenSignaturePdf`, wired into `createRequestFromContentVersion`). **ORG-UI-ONLY, NOT in source / NOT done:** registering the page on the Site's Enabled Visualforce Pages + setting a path alias must be done in Setup → Sites (or by adding the page to the Site's `.site-meta.xml` — note: there is **no `sites/` or `network/` metadata in this repo at all**, so this is entirely manual org config on `portwood-staging`). Note: the URL builder emits `/apex/DocGenSignaturePdf`, NOT the `/signaturepdf` alias from the plan — if you want the friendly alias the builder must change OR rely on the raw `/apex/` path (which works without an alias).
+- [x] **C2.** DONE in source: added `DocGenSignaturePdf` to `pageAccesses` in `force-app/main/default/permissionsets/DocGen_Guest_Signature.permissionset-meta.xml`. Deploys with the package; assign that permset to the Site guest user (org step) and guest VF access is granted.
+- [ ] **C3.** **ORG-UI-ONLY, NOT verified here:** Site CSP / Trusted URLs for the blob iframe. No `cspTrustedSites/` metadata in this repo. For M1 the render uses `URL.createObjectURL` (a `blob:` same-origin URL in a same-origin `<iframe>`), which is generally allowed by default Salesforce Site CSP — but this MUST be confirmed on `portwood-staging` during the C6/D6 manual walkthrough. It will definitely matter when the PDF.js worker (separate script/worker origin) arrives in M3.
+
+### Workstream D — Tests & validation
+
+- [x] **D1.** DONE: `DocGenSignaturePdfTests.testGetSourcePdf_success / _invalidTokenShape / _foreignTokenServesOnlyOwnDoc / _expiredToken`. IDOR test asserts the foreign token resolves ONLY its own bound doc (server resolves CV from the token's request — no client CV id), and the expired-token test backdates `CreatedDate` past the 48h window. Delivered by Workstream A.
+- [x] **D2.** DONE: `testSavePdfSignature_success` (audit row + signer `Signed` + request `Signed`, no `Document_Hash_SHA256__c`) and `testSavePdfSignature_noStampingEvent` (asserts `Limits.getAsyncCalls() == 0` — proves no `DocGen_Signature_PDF__e` publish / no stamping queueable).
+- [x] **D3.** DONE: `testCreateRequestFromContentVersion` asserts `Template__c == null`, `Source_Document_Id__c == cv.Id`, `Status == 'Sent'`, a 64-char token issued, and the signer URL targets `DocGenSignaturePdf`.
+- [x] **D4.** DONE: added "Send Existing ContentVersion" block to `scripts/e2e-06-signatures.apex` — `createRequestFromContentVersion` → asserts PDF-page signer URL + Template-null request + `getSourcePdfBase64` round-trips the bound bytes; cleans up after itself. File is 17,957 chars (< 18,000 limit). prettier-clean.
+- [~] **D5.** Release gate — **CANNOT be fully run in QA's current environment; MUST be run on `portwood-staging` before merge.** Status per check: (a) `npm run format:check` — **PASS, clean** (prettier installed via `npm install`; ran `npm run format`). (b) `e2e-06` + `RunLocalTests` — **NOT RUN**: no authenticated org has the DocGen package — `docgen-test` returns `Invalid type: Schema.DocGen_Signer__c` even on untouched lines (confirmed); no `portwood-staging` org is authenticated here. (c) `sf code-analyzer` Security+AppExchange — **NOT RUN**: no Java runtime installed (`spawn java ENOENT`) so PMD/CPD/sfge engines can't start; only the Java-free regex/retire-js engines ran → 0 violations on the 4 new files, but that does NOT cover the PMD Security rules or the sfge AppExchange data-flow rules. Also the installed plugin (5.2.2) predates the `rules.*.disabled` schema in `code-analyzer.yml` (needs ≥5.13.0). **Gate is NOT green — do not merge on this run.**
+- [ ] **D6.** Manual guest walkthrough on staging (see §7) — blocked on C1 org config + a staging deploy.
+
+### Workstream E — Security review (gate before merge)
+
+- [ ] **E1.** Audit both new remote actions for guest/IDOR: token format check, token→CV binding, no CV id accepted from the client, FLS guards present, SYSTEM_MODE justified inline.
+- [ ] **E2.** Confirm no new `WITH USER_MODE` gaps and no `VersionData` leak beyond the authorized source doc.
+- [ ] **E3.** Sign off that the new invocable is `global` and exposes no sensitive internals.
+
+---
+
+## 6. Sequencing & dependencies
+
+```
+A3 ─┬─> A4            (invocable wraps creation)
+A1,A2 ──> B3,B5       (page calls the remote actions)
+B2 ──> B3             (viewer before wiring render)
+C1 ──> A3 URL builder + D6
+A* + B* ──> D1..D4 ──> D5 ──> E1..E3 ──> merge
+```
+
+- Backend (A1–A3) and the viewer module (B2) can start **in parallel** day one.
+- Page wiring (B3–B6) needs A1/A2 signatures finalized.
+- Config (C1) unblocks the URL builder and end-to-end test.
+- Security (E) is the final gate; D5 must be green first.
+
+## 7. End-to-end verification (manual)
+
+1. Deploy to the `--no-namespace` staging org; assign `DocGen_Admin`; enable the new page on the Site + guest access (C1/C2).
+2. Generate a PDF via `DocGenFlowAction.generateDocument` → capture `contentVersionId`.
+3. Call `createRequestFromContentVersion(cvId, recordId, signersJson, 'Parallel', null)` → get a signer URL.
+4. Open `/signaturepdf?token=...` as a guest → **the real PDF renders** in the iframe.
+5. Click **Sign** → complete the modal (name + consent) → submit → confirm `DocGen_Signature_Audit__c` created, signer + request `Status='Signed'`, and **no** stamping/PDF event fired.
+
+## 8. Out of scope (later milestones)
+
+- **M2 — Signed-output certificate page:** append an audit page (name, timestamp, IP, consent, SHA-256) to the PDF.
+- **M3 — Sign-spot positioning:** visible in-page anchors + coordinate capture. **This is the trigger to swap the viewer module's internals from native iframe to PDF.js** (also fixes mobile-inline rendering).
+
+---
+
+## 9. Open risks / watch-list
+
+- **iOS Safari** may not render a blob PDF inline in an iframe — acceptable for M1 (desktop-first), resolved by the PDF.js swap in M3.
+- **Site/guest config** is the fiddly part and may be UI-only — budget time, don't assume it's pure source.
+- **Managed-package visibility** — new subscriber-facing Apex must be `global`; verify in a real subscriber/scratch, not just the no-namespace staging org.

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -643,7 +643,7 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 SELECT Id, VersionData
                 FROM ContentVersion
                 WHERE Id = :contentVersionId AND Title LIKE 'docgen_%'
-                WITH USER_MODE
+                WITH SYSTEM_MODE
                 LIMIT 1
             ];
         } else if (safeFields == 'Id, ContentSize') {
@@ -651,7 +651,7 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 SELECT Id, ContentSize
                 FROM ContentVersion
                 WHERE Id = :contentVersionId AND Title LIKE 'docgen_%'
-                WITH USER_MODE
+                WITH SYSTEM_MODE
                 LIMIT 1
             ];
         } else {
@@ -659,7 +659,7 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 SELECT Id, ContentDocumentId
                 FROM ContentVersion
                 WHERE Id = :contentVersionId AND Title LIKE 'docgen_%'
-                WITH USER_MODE
+                WITH SYSTEM_MODE
                 LIMIT 1
             ];
         }
@@ -1005,12 +1005,13 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 // already been rewritten at upload time (image src → /sfc/ URLs).
                 if (!activeVersions.isEmpty() && String.isNotBlank(activeVersions[0].Content_Version_Id__c)) {
                     Id bodyCvId = (Id) activeVersions[0].Content_Version_Id__c;
+                    DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'VersionData' });
                     /* code-analyzer-suppress ApexFlsViolation */
                     List<ContentVersion> htmlCvs = [
                         SELECT VersionData
                         FROM ContentVersion
                         WHERE Id = :bodyCvId
-                        WITH USER_MODE
+                        WITH SYSTEM_MODE
                         LIMIT 1
                     ];
                     if (!htmlCvs.isEmpty()) {
@@ -1185,11 +1186,13 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
     public static Map<String, Object> getGiantQueryFragments(Id jobId) {
         String prefix = 'docgen_giant_' + jobId + '_';
         String shellTitle = 'docgen_giant_' + jobId + '_shell';
+        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title' });
+        /* code-analyzer-suppress ApexFlsViolation */
         List<ContentVersion> fragments = [
             SELECT Id, Title
             FROM ContentVersion
             WHERE Title LIKE :(prefix + '%') AND Title != :shellTitle
-            WITH USER_MODE
+            WITH SYSTEM_MODE
             ORDER BY Title // NOPMD — internal fragment lookup
         ];
         List<String> fragmentIds = new List<String>();
@@ -1226,11 +1229,13 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
         if (finalCvId == null) {
             // Legacy lookup: title pattern (pre-v1.90 jobs)
             String finalTitle = 'docgen_giant_' + jobId + '_final';
+            DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title' });
+            /* code-analyzer-suppress ApexFlsViolation */
             List<ContentVersion> finalCvs = [
                 SELECT Id
                 FROM ContentVersion
                 WHERE Title = :finalTitle
-                WITH USER_MODE
+                WITH SYSTEM_MODE
                 LIMIT 1 // NOPMD — internal lookup
             ];
             if (!finalCvs.isEmpty()) {
@@ -1240,11 +1245,13 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
 
         // Look up PDF parts if multiple chunks were rendered
         String partPrefix = 'docgen_giant_' + jobId + '_part_';
+        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title' });
+        /* code-analyzer-suppress ApexFlsViolation */
         List<ContentVersion> partCvs = [
             SELECT Id
             FROM ContentVersion
             WHERE Title LIKE :(partPrefix + '%')
-            WITH USER_MODE
+            WITH SYSTEM_MODE
             ORDER BY Title // NOPMD
         ];
         List<String> partIds = new List<String>();
@@ -1302,19 +1309,21 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
     public static void cleanupGiantQueryFragments(Id jobId) {
         String prefix = 'docgen_giant_' + jobId + '_';
         Set<Id> docIds = new Set<Id>();
+        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'ContentDocumentId', 'Title' });
+        /* code-analyzer-suppress ApexFlsViolation */
         for (ContentVersion cv : [
             SELECT ContentDocumentId
             FROM ContentVersion
             WHERE Title LIKE :(prefix + '%')
-            WITH USER_MODE // NOPMD — internal fragment cleanup
+            WITH SYSTEM_MODE // NOPMD — internal fragment cleanup
         ]) {
             docIds.add(cv.ContentDocumentId);
         }
         if (!docIds.isEmpty()) {
             Database.delete(
-                [SELECT Id FROM ContentDocument WHERE Id IN :docIds WITH USER_MODE],
+                [SELECT Id FROM ContentDocument WHERE Id IN :docIds WITH SYSTEM_MODE],
                 true,
-                AccessLevel.USER_MODE
+                AccessLevel.SYSTEM_MODE
             );
         }
     }

--- a/force-app/main/default/classes/DocGenGiantQueryAssembler.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryAssembler.cls
@@ -66,10 +66,16 @@ public with sharing class DocGenGiantQueryAssembler implements Queueable {
             String allRows = '';
             Set<Id> fragDocIds = new Set<Id>();
 
+            DocGenFlsGuard.assertAccessible(
+                ContentVersion.sObjectType,
+                new Set<String>{ 'Title', 'VersionData', 'ContentDocumentId' }
+            );
+            /* code-analyzer-suppress ApexFlsViolation */
             List<ContentVersion> frags = [
                 SELECT Title, VersionData, ContentDocumentId
                 FROM ContentVersion
                 WHERE Title LIKE :(prefix + '%') AND Title != :finalExclude AND (NOT Title LIKE :partExclude)
+                WITH SYSTEM_MODE
                 ORDER BY Title
                 LIMIT 10000 // NOPMD — need all fragments for assembly
             ];

--- a/force-app/main/default/classes/DocGenGiantQueryStitchJob.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryStitchJob.cls
@@ -64,7 +64,14 @@ public with sharing class DocGenGiantQueryStitchJob implements Database.Batchabl
         this.templateName = tmpl.Name;
 
         String prefix = 'docgen_giant_' + jobId + '_';
-        Integer fragmentCount = [SELECT COUNT() FROM ContentVersion WHERE Title LIKE :(prefix + '%') WITH USER_MODE];
+        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title' });
+        /* code-analyzer-suppress ApexFlsViolation */
+        Integer fragmentCount = [
+            SELECT COUNT()
+            FROM ContentVersion
+            WHERE Title LIKE :(prefix + '%')
+            WITH SYSTEM_MODE
+        ];
 
         if (fragmentCount == 0) {
             update new DocGen_Job__c(Id = jobId, Status__c = 'Failed', Label__c = 'No fragments found'); // NOPMD ApexCRUDViolation — package-internal; CRUD controlled by permission sets
@@ -87,11 +94,13 @@ public with sharing class DocGenGiantQueryStitchJob implements Database.Batchabl
             Integer groupIdx = Integer.valueOf(groupDescriptor.substringAfter(':'));
 
             String prefix = 'docgen_giant_' + jobId + '_';
+            DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title' });
+            /* code-analyzer-suppress ApexFlsViolation */
             List<ContentVersion> allHeaders = [
                 SELECT Id, Title
                 FROM ContentVersion
                 WHERE Title LIKE :(prefix + '%')
-                WITH USER_MODE
+                WITH SYSTEM_MODE
                 ORDER BY Title
             ];
 
@@ -105,11 +114,13 @@ public with sharing class DocGenGiantQueryStitchJob implements Database.Batchabl
             }
 
             String combinedHtml = '';
+            DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'VersionData', 'Title' });
+            /* code-analyzer-suppress ApexFlsViolation */
             for (ContentVersion cv : [
                 SELECT VersionData, Title
                 FROM ContentVersion
                 WHERE Id IN :groupIds
-                WITH USER_MODE
+                WITH SYSTEM_MODE
                 ORDER BY Title
             ]) {
                 combinedHtml += cv.VersionData.toString();
@@ -166,11 +177,16 @@ public with sharing class DocGenGiantQueryStitchJob implements Database.Batchabl
             // Clean up HTML fragments (no longer needed)
             String fragPrefix = 'docgen_giant_' + jobId + '_';
             Set<Id> fragmentDocIds = new Set<Id>();
+            DocGenFlsGuard.assertAccessible(
+                ContentVersion.sObjectType,
+                new Set<String>{ 'ContentDocumentId', 'Title' }
+            );
+            /* code-analyzer-suppress ApexFlsViolation */
             for (ContentVersion cv : [
                 SELECT ContentDocumentId
                 FROM ContentVersion
                 WHERE Title LIKE :(fragPrefix + '%')
-                WITH USER_MODE
+                WITH SYSTEM_MODE
             ]) {
                 fragmentDocIds.add(cv.ContentDocumentId);
             }
@@ -180,11 +196,16 @@ public with sharing class DocGenGiantQueryStitchJob implements Database.Batchabl
 
             // Load all part PDFs — ~15KB each, 20 parts = ~300KB total, trivially within heap
             String partPrefix = 'docgen_part_' + jobId + '_';
+            DocGenFlsGuard.assertAccessible(
+                ContentVersion.sObjectType,
+                new Set<String>{ 'VersionData', 'ContentDocumentId', 'Title' }
+            );
+            /* code-analyzer-suppress ApexFlsViolation */
             List<ContentVersion> parts = [
                 SELECT Id, VersionData, ContentDocumentId
                 FROM ContentVersion
                 WHERE Title LIKE :(partPrefix + '%')
-                WITH USER_MODE
+                WITH SYSTEM_MODE
                 ORDER BY Title
             ];
 

--- a/force-app/main/default/classes/DocGenMiscTests.cls
+++ b/force-app/main/default/classes/DocGenMiscTests.cls
@@ -9303,4 +9303,112 @@ private class DocGenMiscTests {
             );
         }
     }
+
+    @IsTest
+    static void testGiantQueryInternalContentReadsUseSystemMode() {
+        Map<String, ApexClass> classesByName = new Map<String, ApexClass>();
+        for (ApexClass ac : [
+            SELECT Name, Body
+            FROM ApexClass
+            WHERE Name IN ('DocGenController', 'DocGenGiantQueryAssembler', 'DocGenGiantQueryStitchJob')
+        ]) {
+            classesByName.put(ac.Name, ac);
+        }
+
+        String assemblerBody = classesByName.get('DocGenGiantQueryAssembler').Body;
+        Integer giantPrefixIdx = assemblerBody.indexOf('String prefix = \'docgen_giant_\' + jobId + \'_\';');
+        Integer assemblerLoopIdx = assemblerBody.indexOf('for (ContentVersion cv : frags)', giantPrefixIdx);
+        System.assert(giantPrefixIdx >= 0 && assemblerLoopIdx > giantPrefixIdx, 'Assembler fragment lookup moved.');
+        String assemblerSlice = assemblerBody.substring(giantPrefixIdx, assemblerLoopIdx);
+        System.assert(
+            assemblerSlice.contains('WITH SYSTEM_MODE'),
+            'DocGenGiantQueryAssembler must read internal docgen_giant_ fragments WITH SYSTEM_MODE.'
+        );
+        System.assert(
+            !assemblerSlice.contains('WITH USER_MODE'),
+            'DocGenGiantQueryAssembler must not read internal docgen_giant_ fragments WITH USER_MODE.'
+        );
+
+        String controllerBody = classesByName.get('DocGenController').Body;
+        Integer htmlBodyIdx = controllerBody.indexOf('Id bodyCvId = (Id) activeVersions[0].Content_Version_Id__c;');
+        Integer htmlMissingIdx = controllerBody.indexOf('HTML template has no active version body.', htmlBodyIdx);
+        System.assert(htmlBodyIdx >= 0 && htmlMissingIdx > htmlBodyIdx, 'Giant HTML launch body lookup moved.');
+        String htmlBodySlice = controllerBody.substring(htmlBodyIdx, htmlMissingIdx);
+        System.assert(
+            htmlBodySlice.contains('WITH SYSTEM_MODE'),
+            'Giant-query HTML launch must read the active template body ContentVersion WITH SYSTEM_MODE.'
+        );
+        System.assert(
+            !htmlBodySlice.contains('WITH USER_MODE'),
+            'Giant-query HTML launch must not read the active template body ContentVersion WITH USER_MODE.'
+        );
+
+        Integer managedFallbackIdx = controllerBody.indexOf('WHERE Id = :contentVersionId AND Title LIKE \'docgen_%\'');
+        Integer managedFallbackEnd = controllerBody.indexOf(
+            'throw DocGenService.ahe(\'Access denied or content not found.\');'
+        );
+        System.assert(
+            managedFallbackIdx >= 0 && managedFallbackEnd > managedFallbackIdx,
+            'Managed ContentVersion fallback lookup moved.'
+        );
+        String managedFallbackSlice = controllerBody.substring(managedFallbackIdx, managedFallbackEnd);
+        System.assert(
+            managedFallbackSlice.contains('WITH SYSTEM_MODE'),
+            'Managed docgen_% ContentVersion fallback must use SYSTEM_MODE after the USER_MODE sharing check fails.'
+        );
+        System.assert(
+            !managedFallbackSlice.contains('WITH USER_MODE'),
+            'Managed docgen_% ContentVersion fallback must not keep using USER_MODE after sharing access fails.'
+        );
+
+        String stitchBody = classesByName.get('DocGenGiantQueryStitchJob').Body;
+        assertInternalContentQueryUsesSystemMode(
+            stitchBody,
+            'DocGenGiantQueryStitchJob',
+            'docgen_giant_',
+            'FRAGMENTS_PER_PDF'
+        );
+        assertInternalContentQueryUsesSystemMode(
+            stitchBody,
+            'DocGenGiantQueryStitchJob',
+            'docgen_part_',
+            'No PDF parts found'
+        );
+    }
+
+    private static void assertInternalContentQueryUsesSystemMode(
+        String body,
+        String className,
+        String titlePrefix,
+        String afterMarker
+    ) {
+        Integer cursor = 0;
+        Integer hits = 0;
+        while (true) {
+            Integer idx = body.indexOf(titlePrefix, cursor);
+            if (idx == -1) {
+                break;
+            }
+            Integer close = body.indexOf(afterMarker, idx);
+            if (close == -1) {
+                close = body.indexOf('];', idx);
+            }
+            if (close != -1) {
+                String slice = body.substring(idx, close);
+                if (slice.contains('FROM ContentVersion')) {
+                    hits++;
+                    System.assert(
+                        slice.contains('WITH SYSTEM_MODE'),
+                        className + ' must read internal ' + titlePrefix + ' ContentVersion rows WITH SYSTEM_MODE.'
+                    );
+                    System.assert(
+                        !slice.contains('WITH USER_MODE'),
+                        className + ' must not read internal ' + titlePrefix + ' ContentVersion rows WITH USER_MODE.'
+                    );
+                }
+            }
+            cursor = idx + titlePrefix.length();
+        }
+        System.assert(hits > 0, 'Sanity: expected internal ' + titlePrefix + ' ContentVersion reads in ' + className);
+    }
 }

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -7446,7 +7446,7 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         MergeResult mr = mergeTemplate(templateId, recordIdStr, null, 'PDF');
 
         if (mr.templateType == 'PowerPoint') {
-            throw new DocGenException('Signature PDF generation is only supported for Word templates.');
+            throw new DocGenException('Signature PDF generation is only supported for Word and HTML templates.');
         }
 
         Map<String, String> pdfImages = buildPdfImageMap(mr, templateId);
@@ -7470,7 +7470,8 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
 
         return new Map<String, Object>{
             'documentXml' => mr.documentXml,
-            'combinedDocumentXml' => combineXmlWithHeadersFooters(mr),
+            'combinedDocumentXml' => mr.templateType == 'HTML' ? mr.documentXml : combineXmlWithHeadersFooters(mr),
+            'templateType' => mr.templateType,
             'relsXml' => mr.relsXml,
             'contentTypesXml' => mr.contentTypesXml,
             'pdfImageMap' => pdfImages,

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -7481,6 +7481,22 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         };
     }
 
+    /**
+     * Same as mergeTemplateForSignature but renders from a caller-supplied data
+     * snapshot instead of querying the live record. Used by the M2 signature
+     * finalizer so the signed PDF re-renders from the send-time snapshot (immune
+     * to record edits between send and sign). Mirrors generatePdfBlobFromData's
+     * preloadedRecordDataOverride pattern.
+     */
+    public static Map<String, Object> mergeTemplateForSignatureFromData(Id templateId, Map<String, Object> dataMap) {
+        if (dataMap == null) {
+            throw new DocGenException('dataMap cannot be null for snapshot signature render.');
+        }
+        preloadedRecordDataOverride = dataMap;
+        // recordId is null — the override short-circuits SOQL retrieval (see line ~406).
+        return mergeTemplateForSignature(templateId, null);
+    }
+
     // ──────────────────────────────────────────────────────────────────────────
     // Giant Query helpers — extract, render, and inject pre-rendered loop content
     // ──────────────────────────────────────────────────────────────────────────

--- a/force-app/main/default/classes/DocGenSignatureController.cls
+++ b/force-app/main/default/classes/DocGenSignatureController.cls
@@ -834,8 +834,13 @@ public without sharing class DocGenSignatureController {
                 }
                 Map<String, String> pdfImageMap = (Map<String, String>) mergeData.get('pdfImageMap');
                 if (String.isNotBlank(docXml)) {
-                    DocGenService.applyWatermarkOverride(templateId);
-                    String liveHtml = DocGenHtmlRenderer.convertToHtml(docXml, pdfImageMap);
+                    String liveHtml;
+                    if ((String) mergeData.get('templateType') == 'HTML') {
+                        liveHtml = docXml;
+                    } else {
+                        DocGenService.applyWatermarkOverride(templateId);
+                        liveHtml = DocGenHtmlRenderer.convertToHtml(docXml, pdfImageMap);
+                    }
                     liveHtml = DocGenSignatureSenderController.injectPreviewWatermarkOverlay(liveHtml, templateId);
                     res.templateBase64 = prepareSigningPreviewHtml(liveHtml);
                     return res;

--- a/force-app/main/default/classes/DocGenSignatureController.cls
+++ b/force-app/main/default/classes/DocGenSignatureController.cls
@@ -2361,19 +2361,44 @@ public without sharing class DocGenSignatureController {
         result.remaining = remaining;
         result.isComplete = (remaining == 0);
 
+        // M2: snapshot-backed requests (Template__c set) finalize a signed document +
+        // certificate page server-side. Detect via the parent request's Template__c.
+        DocGenFlsGuard.guestAssertAccessible(DocGen_Signature_Request__c.sObjectType, new Set<String>{ 'Template__c' });
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        List<DocGen_Signature_Request__c> parentReqs = [
+            SELECT Template__c
+            FROM DocGen_Signature_Request__c
+            WHERE Id = :signer.Signature_Request__c
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        Boolean snapshotBacked = !parentReqs.isEmpty() && parentReqs[0].Template__c != null;
+
         // CxSAST: FLS enforced by DocGen permission sets; package-internal custom objects
-        // Update parent request status — 'Signed' once every signer is done, else 'In Progress'.
         DocGen_Signature_Request__c parentReq = new DocGen_Signature_Request__c(Id = signer.Signature_Request__c);
-        parentReq.Status__c = result.isComplete ? 'Signed' : 'In Progress';
+        if (snapshotBacked) {
+            // Leave 'In Progress' so the platform-event trigger enqueues the finalizer,
+            // which produces the document + certificate PDF and then sets 'Signed'.
+            // (Setting 'Signed' here would make the trigger skip the finalize step.)
+            parentReq.Status__c = 'In Progress';
+        } else {
+            // M1 flat-PDF path: no template to re-render — record status only.
+            parentReq.Status__c = result.isComplete ? 'Signed' : 'In Progress';
+        }
         // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Update").
         DocGenFlsGuard.guestAssertUpdateable(parentReq, new Set<String>{ 'Status__c' });
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
         Database.update(parentReq, false, AccessLevel.SYSTEM_MODE);
 
-        // INTENTIONALLY NO DocGen_Signature_PDF__e publish and NO stamping here.
-        // The flat-PDF path records audit + status and STOPS. Publishing the event
-        // would enqueue the DOCX-XML stamping queueable — wrong for a flat PDF.
-        // Stamping / certificate page is Milestone 2 (out of scope).
+        // M2: publish the platform event so DocGenSignaturePdfTrigger enqueues the
+        // finalizer (it gates on remaining==0 and Template__c) to produce the signed
+        // document + certificate PDF on the related record. The M1 flat-PDF path has no
+        // template to re-render, so it records audit + status only and never publishes.
+        if (snapshotBacked) {
+            DocGen_Signature_PDF__e pdfEvent = new DocGen_Signature_PDF__e();
+            pdfEvent.Request_Id__c = signer.Signature_Request__c;
+            EventBus.publish(pdfEvent);
+        }
 
         result.success = true;
         return result;

--- a/force-app/main/default/classes/DocGenSignatureController.cls
+++ b/force-app/main/default/classes/DocGenSignatureController.cls
@@ -42,6 +42,22 @@ public without sharing class DocGenSignatureController {
     }
 
     /**
+     * Result for the flat-PDF signing path (savePdfSignature). Mirrors
+     * SaveSignatureResult but carries an explicit `success` flag — the PDF page's
+     * modal needs an unambiguous success signal that does not depend on
+     * isComplete (a single-signer of a multi-signer envelope succeeds with
+     * isComplete=false).
+     */
+    public class SavePdfSignatureResult {
+        @AuraEnabled
+        public Boolean success;
+        @AuraEnabled
+        public Boolean isComplete;
+        @AuraEnabled
+        public Integer remaining;
+    }
+
+    /**
      * Prefers the client-supplied IP (browser fetched it from a public service)
      * over header inspection. The client path is more reliable for guest signers
      * because Sites/Site CDNs don't always set X-Forwarded-For consistently.
@@ -578,7 +594,14 @@ public without sharing class DocGenSignatureController {
             ];
             if (!cvs.isEmpty()) {
                 res.documentTitle = cvs[0].Title;
-                res.documentUrl = getOrCreatePublicLink(cvs[0]);
+                // The PDF signing flow renders the document via getSourcePdfBase64, so this
+                // public preview link is optional. ContentDistribution creation is not permitted
+                // in guest context, so never let it break token validation.
+                try {
+                    res.documentUrl = getOrCreatePublicLink(cvs[0]);
+                } catch (Exception e) {
+                    System.debug(LoggingLevel.WARN, 'DocGen: public preview link unavailable — ' + e.getMessage());
+                }
             } else {
                 res.documentTitle = 'Confidential Document';
             }
@@ -2100,5 +2123,259 @@ public without sharing class DocGenSignatureController {
     public static void finishSignatureUpload(String token, String base64Pdf, String fileName) {
         // PDF is now generated and saved server-side in stampAndReturnSource.
         // This method is retained as a no-op for backward compatibility with the VF page flow.
+    }
+
+    /**
+     * Milestone 1 — flat-PDF signing page (DocGenSignaturePdf.page).
+     *
+     * Returns the request's pre-generated source PDF as base64 so the guest VF
+     * page can render the REAL document in an iframe/blob (guests can't hit
+     * /sfc/servlet.shepherd/ file URLs). The ContentVersion is resolved
+     * server-side from the token-bound request's Source_Document_Id__c — NO CV
+     * id is accepted from the client, so there is no IDOR surface (unlike
+     * getImageBase64, which takes a CV id and must gate it via
+     * isAuthorizedSignatureImage). Mirrors the getImageBase64 security pattern:
+     * token format check → assertSignerReadable → per-field FLS guard →
+     * WITH SYSTEM_MODE.
+     */
+    @AuraEnabled
+    @RemoteAction
+    public static Map<String, String> getSourcePdfBase64(String token) {
+        Map<String, String> result = new Map<String, String>();
+
+        if (String.isBlank(token) || token.length() != 64 || !Pattern.matches('[a-fA-F0-9]{64}', token)) {
+            result.put('error', 'Invalid token');
+            return result;
+        }
+
+        // Guest CRUD/FLS gate — read scope on DocGen_Signer__c + token-scoped
+        // request lookup. The CV served is bound to this token's request, so
+        // no client-supplied CV id (and thus no IDOR check) is needed here.
+        DocGenSignatureGuestSecurity.assertSignerReadable(token);
+
+        DocGenFlsGuard.guestAssertAccessible(
+            DocGen_Signer__c.sObjectType,
+            new Set<String>{ 'CreatedDate', 'Signature_Request__c', 'Secure_Token__c' }
+        );
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        List<DocGen_Signer__c> signers = [
+            SELECT Id, CreatedDate, Signature_Request__r.Source_Document_Id__c
+            FROM DocGen_Signer__c
+            WHERE Secure_Token__c = :token
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+
+        if (signers.isEmpty() || signers[0].CreatedDate.addHours(TOKEN_EXPIRATION_HOURS) < System.now()) {
+            result.put('error', 'Invalid or expired token');
+            return result;
+        }
+
+        Id sourceDocId = signers[0].Signature_Request__r != null
+            ? signers[0].Signature_Request__r.Source_Document_Id__c
+            : null;
+        if (sourceDocId == null) {
+            result.put('error', 'No source document for this signing session');
+            return result;
+        }
+
+        try {
+            // SYSTEM_MODE required: guest profile has no DocGen/ContentVersion CRUD by
+            // design; access is gated by the token-bound Source_Document_Id__c above.
+            DocGenFlsGuard.guestAssertAccessible(ContentVersion.sObjectType, new Set<String>{ 'VersionData', 'Title' });
+            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+            ContentVersion cv = [
+                SELECT VersionData, Title
+                FROM ContentVersion
+                WHERE Id = :sourceDocId
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ]; // NOPMD ApexCRUDViolation - ContentVersion accessed for token-bound signature document render
+
+            result.put('base64', EncodingUtil.base64Encode(cv.VersionData));
+            result.put('fileName', String.isNotBlank(cv.Title) ? cv.Title : 'Document');
+            result.put('mimeType', 'application/pdf');
+        } catch (Exception e) {
+            result.put('error', 'Document not found');
+        }
+
+        return result;
+    }
+
+    /**
+     * Milestone 1 — flat-PDF signing page save path.
+     *
+     * Records the signature audit row + flips signer/request status only. This
+     * is the dedicated PDF-path save: it does NOT reuse saveSignature (which
+     * publishes DocGen_Signature_PDF__e and kicks the DOCX-XML stamping
+     * queueable — wrong for a flat PDF). NO platform event, NO stamping; the
+     * certificate/audit page is Milestone 2 and out of scope here.
+     *
+     * Returns { success, isComplete, remaining }.
+     */
+    @AuraEnabled
+    @RemoteAction
+    public static SavePdfSignatureResult savePdfSignature(
+        String token,
+        String typedName,
+        Boolean consentGiven,
+        String ipAddress,
+        String userAgent
+    ) {
+        SavePdfSignatureResult result = new SavePdfSignatureResult();
+        result.success = false;
+
+        // Validate token format
+        if (String.isBlank(token) || token.length() != 64 || !Pattern.matches('[a-fA-F0-9]{64}', token)) {
+            throw new AuraHandledException('Invalid security token.');
+        }
+
+        if (String.isBlank(typedName)) {
+            throw new AuraHandledException('Please type your name to sign.');
+        }
+
+        if (consentGiven != true) {
+            throw new AuraHandledException('You must agree to sign electronically.');
+        }
+
+        // Guest CRUD/FLS gate — write allowlist (Signer.Status__c,
+        // Signer.Signature_Data__c) + audit creation. See guard helper.
+        DocGenSignatureGuestSecurity.assertSignerWritableFields(token);
+        DocGenSignatureGuestSecurity.assertAuditCreateable(token);
+
+        DocGenFlsGuard.guestAssertAccessible(
+            DocGen_Signer__c.sObjectType,
+            new Set<String>{
+                'Status__c',
+                'Signer_Name__c',
+                'Signer_Email__c',
+                'Signature_Request__c',
+                'Role_Name__c',
+                'Contact__c',
+                'CreatedDate',
+                'PIN_Verified_At__c',
+                'Consent_Captured__c',
+                'Secure_Token__c'
+            }
+        );
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        List<DocGen_Signer__c> signers = [
+            SELECT
+                Id,
+                Status__c,
+                Signer_Name__c,
+                Signer_Email__c,
+                Signature_Request__c,
+                Role_Name__c,
+                Contact__c,
+                CreatedDate,
+                PIN_Verified_At__c,
+                Consent_Captured__c
+            FROM DocGen_Signer__c
+            WHERE Secure_Token__c = :token
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+
+        if (signers.isEmpty()) {
+            throw new AuraHandledException('Signer not found.');
+        }
+
+        DocGen_Signer__c signer = signers[0];
+        if (signer.CreatedDate.addHours(TOKEN_EXPIRATION_HOURS) < System.now()) {
+            throw new AuraHandledException('This signature link has expired.');
+        }
+        if (signer.Status__c == 'Signed') {
+            throw new AuraHandledException('You have already signed this document.');
+        }
+
+        // Require PIN verification before allowing signature
+        if (signer.PIN_Verified_At__c == null) {
+            throw new AuraHandledException('Email verification is required before signing.');
+        }
+
+        // CxSAST: FLS enforced by DocGen permission sets; package-internal custom objects
+        // Store typed name and mark as signed
+        signer.Signature_Data__c = typedName;
+        signer.Status__c = 'Signed';
+        signer.Consent_Captured__c = true;
+        // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Update").
+        DocGenFlsGuard.guestAssertUpdateable(
+            signer,
+            new Set<String>{ 'Signature_Data__c', 'Status__c', 'Consent_Captured__c' }
+        );
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        Database.update(signer, false, AccessLevel.SYSTEM_MODE);
+
+        // Create audit trail immediately with all available data (mirrors saveSignature)
+        DocGen_Signature_Audit__c audit = new DocGen_Signature_Audit__c();
+        audit.Signature_Request__c = signer.Signature_Request__c;
+        audit.Signer__c = signer.Id;
+        audit.Signer_Name__c = signer.Signer_Name__c;
+        audit.Signer_Email__c = signer.Signer_Email__c;
+        audit.Contact__c = signer.Contact__c;
+        audit.Signed_Date__c = System.now();
+        audit.IP_Address__c = resolveClientIp(ipAddress);
+        audit.User_Agent__c = String.isNotBlank(userAgent) ? userAgent.left(255) : 'Unknown';
+        audit.Consent_Captured__c = true;
+        audit.PIN_Verified_At__c = signer.PIN_Verified_At__c;
+        // No Document_Hash_SHA256__c — there is no stamped output in Milestone 1.
+        // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Create").
+        DocGenFlsGuard.guestAssertCreateable(
+            audit,
+            new Set<String>{
+                'Signature_Request__c',
+                'Signer__c',
+                'Signer_Name__c',
+                'Signer_Email__c',
+                'Contact__c',
+                'Signed_Date__c',
+                'IP_Address__c',
+                'User_Agent__c',
+                'Consent_Captured__c',
+                'PIN_Verified_At__c'
+            }
+        );
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        Database.insert(new List<DocGen_Signature_Audit__c>{ audit }, false, AccessLevel.SYSTEM_MODE);
+
+        // Check if all signers are now complete
+        DocGenFlsGuard.guestAssertAccessible(
+            DocGen_Signer__c.sObjectType,
+            new Set<String>{ 'Status__c', 'Signature_Request__c' }
+        );
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        List<DocGen_Signer__c> allSigners = [
+            SELECT Status__c
+            FROM DocGen_Signer__c
+            WHERE Signature_Request__c = :signer.Signature_Request__c
+            WITH SYSTEM_MODE
+        ];
+
+        Integer remaining = 0;
+        for (DocGen_Signer__c s : allSigners) {
+            if (s.Status__c != 'Signed')
+                remaining++;
+        }
+
+        result.remaining = remaining;
+        result.isComplete = (remaining == 0);
+
+        // CxSAST: FLS enforced by DocGen permission sets; package-internal custom objects
+        // Update parent request status — 'Signed' once every signer is done, else 'In Progress'.
+        DocGen_Signature_Request__c parentReq = new DocGen_Signature_Request__c(Id = signer.Signature_Request__c);
+        parentReq.Status__c = result.isComplete ? 'Signed' : 'In Progress';
+        // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Update").
+        DocGenFlsGuard.guestAssertUpdateable(parentReq, new Set<String>{ 'Status__c' });
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        Database.update(parentReq, false, AccessLevel.SYSTEM_MODE);
+
+        // INTENTIONALLY NO DocGen_Signature_PDF__e publish and NO stamping here.
+        // The flat-PDF path records audit + status and STOPS. Publishing the event
+        // would enqueue the DOCX-XML stamping queueable — wrong for a flat PDF.
+        // Stamping / certificate page is Milestone 2 (out of scope).
+
+        result.success = true;
+        return result;
     }
 }

--- a/force-app/main/default/classes/DocGenSignaturePdfFlowAction.cls
+++ b/force-app/main/default/classes/DocGenSignaturePdfFlowAction.cls
@@ -1,0 +1,226 @@
+/**
+ * Flow-invocable action to send an ALREADY-GENERATED document (a ContentVersion)
+ * for signature, using the Milestone 1 flat-PDF signing page.
+ *
+ * Two-step flow: generate the document first (DocGenFlowAction.generateDocument →
+ * ContentVersion Id), then pass that Id here. This creates a Template__c-null
+ * signature request bound to the CV (Source_Document_Id__c), renders the real
+ * PDF to each signer, and captures a name+consent signature → audit +
+ * Status='Signed'. No template merge, no placements, no DOCX-XML stamping.
+ *
+ * PREREQUISITES:
+ * 1. A pre-generated document stored as a ContentVersion (e.g. via "DocGen: Generate Document")
+ * 2. An Org-Wide Email Address configured in DocGen > Signatures settings (for branded emails)
+ * 3. A Salesforce Site configured for the flat-PDF signing page
+ *
+ * QUICK START:
+ * 1. Generate a PDF and capture its ContentVersion Id
+ * 2. Build a collection of DocGen Signers (Name + Email + optional Role/Contact Id)
+ * 3. Drag "DocGen: Send Existing Document for Signature" into your Flow
+ * 4. Set Content Version Id, Related Record Id, and the Signers collection
+ * 5. The action returns signing URLs and a request Id for downstream automation
+ */
+global with sharing class DocGenSignaturePdfFlowAction { // NOPMD AvoidGlobalModifier - required for @InvocableMethod visibility in subscriber orgs
+    global class Request {
+        @InvocableVariable(
+            required=true
+            label='Content Version Id'
+            description='The Id of the ContentVersion (068...) to send for signature. This is the already-generated document the signer will see. Example: capture it from the "DocGen: Generate Document" action output.'
+        )
+        global Id contentVersionId;
+
+        @InvocableVariable(
+            required=true
+            label='Related Record Id'
+            description='The record this signature request is for. In a record-triggered Flow, use {!$Record.Id}.'
+        )
+        global Id relatedRecordId;
+
+        @InvocableVariable(
+            label='Signers'
+            description='A collection of DocGen Signers. Create an Apex-Defined variable of type DocGenSigner (Name + Email required; Role and Contact Id optional), add each to a collection with an Assignment element, and pass it here.'
+        )
+        global List<DocGenSigner> signerRecords;
+
+        @InvocableVariable(
+            label='Signing Order'
+            description='Enter "Parallel" (default) to email all signers at once, or "Sequential" to send one at a time — each signer is emailed only after the previous one completes.'
+        )
+        global String signingOrder;
+
+        @InvocableVariable(
+            label='Document Title Format'
+            description='Optional. Overrides the title shown on the signing page and signed-document records. Leave blank to use the source document title.'
+        )
+        global String documentTitleFormat;
+    }
+
+    global class Result {
+        @InvocableVariable(
+            label='Signature Request Id'
+            description='The Id of the created DocGen Signature Request record. Use this to track status or link in downstream Flow elements.'
+        )
+        global Id signatureRequestId;
+
+        @InvocableVariable(
+            label='Signer URLs'
+            description='A collection of unique signing URLs — one per signer, in the same order as the Signers input. Each URL is valid for 48 hours.'
+        )
+        global List<String> signerUrls;
+
+        @InvocableVariable(label='Signer Names' description='The resolved signer names, in order.')
+        global List<String> signerNames;
+
+        @InvocableVariable(label='Signer Emails' description='The resolved signer emails, in order.')
+        global List<String> signerEmails;
+
+        @InvocableVariable(
+            label='Signer Roles'
+            description='The resolved role names per signer. Shows "Signer" for any role not specified.'
+        )
+        global List<String> signerRoles;
+
+        @InvocableVariable(
+            label='Success'
+            description='TRUE if the signature request was created successfully. FALSE if there was an error — check Error Message.'
+        )
+        global Boolean success;
+
+        @InvocableVariable(
+            label='Error Message'
+            description='Error details if Success is FALSE. Common: missing document, missing signer data, or permission issues.'
+        )
+        global String errorMessage;
+    }
+
+    @InvocableMethod(
+        label='DocGen: Send Existing Document for Signature'
+        description='Sends an already-generated document (a ContentVersion) for signature on the flat-PDF signing page. Pass the Content Version Id and a collection of Signers. Returns signing URLs.'
+        category='Document Generation'
+    )
+    global static List<Result> send(List<Request> requests) {
+        List<Result> results = new List<Result>();
+        if (requests == null)
+            return results;
+        for (Request req : requests) {
+            results.add(processOne(req));
+        }
+        return results;
+    }
+
+    private static Result processOne(Request req) {
+        Result r = new Result();
+        r.success = false;
+        r.signerUrls = new List<String>();
+        r.signerNames = new List<String>();
+        r.signerEmails = new List<String>();
+        r.signerRoles = new List<String>();
+
+        // Validation throws (preserves existing Flow behavior where bad input stops the Flow)
+        if (req == null) {
+            throw new DocGenException('Request is null');
+        }
+        if (req.contentVersionId == null) {
+            throw new DocGenException(
+                'Content Version Id is required — pass the Id of an already-generated document (068...).'
+            );
+        }
+        if (req.relatedRecordId == null) {
+            throw new DocGenException('Related Record Id is required — pass the record this signature is for.');
+        }
+
+        // Build signer inputs from the standalone DocGenSigner collection — the only
+        // signer type Flow can expose as an Apex-Defined variable (inner classes never appear).
+        List<Map<String, Object>> signerInputs = buildSignerInputs(req);
+        if (signerInputs.isEmpty()) {
+            throw new DocGenException('At least one signer is required. Pass a Signers collection.');
+        }
+
+        // Runtime errors (DML failures, deleted CV) are caught and returned in Result
+        try {
+            String signingOrder = String.isNotBlank(req.signingOrder) ? req.signingOrder : 'Parallel';
+            if (signingOrder != 'Parallel' && signingOrder != 'Sequential') {
+                signingOrder = 'Parallel';
+            }
+
+            String signersJson = JSON.serialize(signerInputs);
+            List<DocGenSignatureSenderController.SignerResult> signerResults = DocGenSignatureSenderController.createRequestFromContentVersion(
+                req.contentVersionId,
+                req.relatedRecordId,
+                signersJson,
+                signingOrder,
+                req.documentTitleFormat
+            );
+
+            // Resolve the created request Id from the first signer
+            if (!signerResults.isEmpty()) {
+                String firstEmail = (String) signerInputs[0].get('signerEmail');
+                // v2.0.1 — per-field FLS enforcement on SOQL reads. SYSTEM_MODE sidesteps
+                // the package-build @TestSetup FLS-propagation issue (see DocGenFlsGuard.cls).
+                DocGenFlsGuard.assertAccessible(
+                    DocGen_Signer__c.sObjectType,
+                    new Set<String>{ 'Signature_Request__c', 'Signer_Email__c' }
+                );
+                /* code-analyzer-suppress ApexFlsViolation */
+                List<DocGen_Signer__c> createdSigners = [
+                    SELECT Signature_Request__c
+                    FROM DocGen_Signer__c
+                    WHERE
+                        Signer_Email__c = :firstEmail
+                        AND Signature_Request__r.Source_Document_Id__c = :req.contentVersionId
+                        AND Signature_Request__r.Related_Record_Id__c = :req.relatedRecordId
+                    WITH SYSTEM_MODE
+                    ORDER BY CreatedDate DESC
+                    LIMIT 1
+                ]; // NOPMD ApexCRUDViolation - package-internal
+                if (!createdSigners.isEmpty()) {
+                    r.signatureRequestId = createdSigners[0].Signature_Request__c;
+                }
+            }
+
+            // Populate result
+            for (DocGenSignatureSenderController.SignerResult sr : signerResults) {
+                r.signerUrls.add(sr.signerUrl);
+                r.signerNames.add(sr.signerName);
+                r.signerEmails.add(sr.signerEmail);
+                r.signerRoles.add(sr.roleName);
+            }
+
+            r.success = true;
+        } catch (Exception e) {
+            r.errorMessage = e.getMessage();
+            r.success = false;
+        }
+
+        return r;
+    }
+
+    /**
+     * Builds signer input maps from the standalone DocGenSigner collection.
+     */
+    private static List<Map<String, Object>> buildSignerInputs(Request req) {
+        List<Map<String, Object>> inputs = new List<Map<String, Object>>();
+        if (req.signerRecords == null || req.signerRecords.isEmpty()) {
+            return inputs;
+        }
+        for (DocGenSigner s : req.signerRecords) {
+            if (String.isBlank(s.name)) {
+                throw new DocGenException('Each signer must have a Name.');
+            }
+            if (String.isBlank(s.email)) {
+                throw new DocGenException(
+                    'Each signer must have an Email. Signer "' + s.name + '" is missing an email.'
+                );
+            }
+            inputs.add(
+                new Map<String, Object>{
+                    'signerName' => s.name,
+                    'signerEmail' => s.email,
+                    'roleName' => String.isNotBlank(s.role) ? s.role : 'Signer',
+                    'contactId' => s.contactId
+                }
+            );
+        }
+        return inputs;
+    }
+}

--- a/force-app/main/default/classes/DocGenSignaturePdfFlowAction.cls
+++ b/force-app/main/default/classes/DocGenSignaturePdfFlowAction.cls
@@ -23,9 +23,14 @@
 global with sharing class DocGenSignaturePdfFlowAction { // NOPMD AvoidGlobalModifier - required for @InvocableMethod visibility in subscriber orgs
     global class Request {
         @InvocableVariable(
-            required=true
+            label='Template Id'
+            description='Snapshot signing (recommended): the DocGen Template Id to send. DocGen snapshots the record data at send-time and, on completion, re-renders the document from that snapshot and appends a signing-certificate page to the related record\'s Files. Provide EITHER Template Id (with Related Record Id) OR Content Version Id.'
+        )
+        global Id templateId;
+
+        @InvocableVariable(
             label='Content Version Id'
-            description='The Id of the ContentVersion (068...) to send for signature. This is the already-generated document the signer will see. Example: capture it from the "DocGen: Generate Document" action output.'
+            description='Send-existing-document path: the Id of an already-generated ContentVersion (068...) the signer will see. Provide this OR Template Id. On this path the signed document is not auto-attached to the record (records audit + status only).'
         )
         global Id contentVersionId;
 
@@ -120,9 +125,9 @@ global with sharing class DocGenSignaturePdfFlowAction { // NOPMD AvoidGlobalMod
         if (req == null) {
             throw new DocGenException('Request is null');
         }
-        if (req.contentVersionId == null) {
+        if (req.templateId == null && req.contentVersionId == null) {
             throw new DocGenException(
-                'Content Version Id is required — pass the Id of an already-generated document (068...).'
+                'Provide either a Template Id (snapshot signing) or a Content Version Id (send existing document).'
             );
         }
         if (req.relatedRecordId == null) {
@@ -144,33 +149,42 @@ global with sharing class DocGenSignaturePdfFlowAction { // NOPMD AvoidGlobalMod
             }
 
             String signersJson = JSON.serialize(signerInputs);
-            List<DocGenSignatureSenderController.SignerResult> signerResults = DocGenSignatureSenderController.createRequestFromContentVersion(
-                req.contentVersionId,
-                req.relatedRecordId,
-                signersJson,
-                signingOrder,
-                req.documentTitleFormat
-            );
+            List<DocGenSignatureSenderController.SignerResult> signerResults;
+            if (req.templateId != null) {
+                // Snapshot signing: snapshot the record data + re-render with a
+                // certificate page on completion (Milestone 2).
+                signerResults = DocGenSignatureSenderController.createTemplateSnapshotRequest(
+                    req.templateId,
+                    req.relatedRecordId,
+                    signersJson,
+                    signingOrder,
+                    req.documentTitleFormat
+                );
+            } else {
+                // Send an already-generated document (Milestone 1).
+                signerResults = DocGenSignatureSenderController.createRequestFromContentVersion(
+                    req.contentVersionId,
+                    req.relatedRecordId,
+                    signersJson,
+                    signingOrder,
+                    req.documentTitleFormat
+                );
+            }
 
-            // Resolve the created request Id from the first signer
-            if (!signerResults.isEmpty()) {
-                String firstEmail = (String) signerInputs[0].get('signerEmail');
+            // Resolve the created request Id from the first signer (works for both paths).
+            if (!signerResults.isEmpty() && signerResults[0].signerId != null) {
                 // v2.0.1 — per-field FLS enforcement on SOQL reads. SYSTEM_MODE sidesteps
                 // the package-build @TestSetup FLS-propagation issue (see DocGenFlsGuard.cls).
                 DocGenFlsGuard.assertAccessible(
                     DocGen_Signer__c.sObjectType,
-                    new Set<String>{ 'Signature_Request__c', 'Signer_Email__c' }
+                    new Set<String>{ 'Signature_Request__c' }
                 );
                 /* code-analyzer-suppress ApexFlsViolation */
                 List<DocGen_Signer__c> createdSigners = [
                     SELECT Signature_Request__c
                     FROM DocGen_Signer__c
-                    WHERE
-                        Signer_Email__c = :firstEmail
-                        AND Signature_Request__r.Source_Document_Id__c = :req.contentVersionId
-                        AND Signature_Request__r.Related_Record_Id__c = :req.relatedRecordId
+                    WHERE Id = :signerResults[0].signerId
                     WITH SYSTEM_MODE
-                    ORDER BY CreatedDate DESC
                     LIMIT 1
                 ]; // NOPMD ApexCRUDViolation - package-internal
                 if (!createdSigners.isEmpty()) {

--- a/force-app/main/default/classes/DocGenSignaturePdfFlowAction.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenSignaturePdfFlowAction.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenSignaturePdfTests.cls
+++ b/force-app/main/default/classes/DocGenSignaturePdfTests.cls
@@ -76,6 +76,49 @@ private class DocGenSignaturePdfTests {
         ];
     }
 
+    /**
+     * An active Guest user to exercise true guest context, or null if the org
+     * has no Site (some package-build orgs). Callers fall back to the current
+     * user so the test never fails merely for lack of a guest user.
+     */
+    private static User getGuestUser() {
+        List<User> guests = [SELECT Id FROM User WHERE UserType = 'Guest' AND IsActive = TRUE LIMIT 1];
+        return guests.isEmpty() ? null : guests[0];
+    }
+
+    // =========================================================================
+    // Guest-context regression
+    // validateToken on the PDF (Source_Document_Id__c) path must NOT fail when
+    // the optional public preview link can't be created. getOrCreatePublicLink
+    // inserts a ContentDistribution, which a guest user cannot create — that's a
+    // user permission, NOT bypassed by SYSTEM_MODE. Before the validateSignerToken
+    // try/catch, this threw and surfaced as the page's "no longer active" error
+    // for every guest. Strongest where a real guest user exists (scratch/Site
+    // orgs); harmless where one doesn't.
+    // =========================================================================
+    @isTest
+    static void testGuestContext_validateToken_pdfPath_survivesPublicLinkFailure() {
+        DocGenSignatureController.SignatureInitResponse res;
+        User guest = getGuestUser();
+
+        Test.startTest();
+        if (guest != null) {
+            System.runAs(guest) {
+                res = DocGenSignatureController.validateToken(SIGNER_TOKEN);
+            }
+        } else {
+            res = DocGenSignatureController.validateToken(SIGNER_TOKEN);
+        }
+        Test.stopTest();
+
+        System.assertEquals(
+            true,
+            res.isValid,
+            'PDF-path token must validate even when the public preview link cannot be created (guest cannot insert ContentDistribution)'
+        );
+        System.assertEquals('Pat Signer', res.signerName);
+    }
+
     // =========================================================================
     // A1 — getSourcePdfBase64
     // =========================================================================

--- a/force-app/main/default/classes/DocGenSignaturePdfTests.cls
+++ b/force-app/main/default/classes/DocGenSignaturePdfTests.cls
@@ -1,0 +1,391 @@
+// CxSAST: Test class — SOQL/DML findings are test data operations, not production code paths
+@isTest
+private class DocGenSignaturePdfTests {
+    // 64-char hex tokens (the only valid Secure_Token__c shape).
+    private static final String SIGNER_TOKEN = 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+    private static final String FOREIGN_TOKEN = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+    @testSetup
+    static void setup() {
+        Account acc = new Account(Name = 'PDF Sign Test Co');
+        insert acc;
+
+        // The pre-generated document the signer will see (bound via Source_Document_Id__c).
+        ContentVersion pdfCv = new ContentVersion(
+            Title = 'Generated Agreement',
+            PathOnClient = 'agreement.pdf',
+            VersionData = Blob.valueOf('%PDF-1.7 fake pdf bytes')
+        );
+        insert pdfCv;
+        pdfCv = [SELECT Id FROM ContentVersion WHERE Id = :pdfCv.Id LIMIT 1];
+
+        // A SECOND, unrelated CV — used to prove the token cannot reach a foreign file.
+        ContentVersion foreignCv = new ContentVersion(
+            Title = 'Someone Elses File',
+            PathOnClient = 'secret.pdf',
+            VersionData = Blob.valueOf('%PDF-1.7 confidential')
+        );
+        insert foreignCv;
+        foreignCv = [SELECT Id FROM ContentVersion WHERE Id = :foreignCv.Id LIMIT 1];
+
+        // Template__c-null request bound to the generated PDF.
+        DocGen_Signature_Request__c req = new DocGen_Signature_Request__c(
+            Source_Document_Id__c = pdfCv.Id,
+            Related_Record_Id__c = acc.Id,
+            Status__c = 'Sent',
+            Signing_Order__c = 'Parallel'
+        );
+        Database.insert(req, AccessLevel.SYSTEM_MODE);
+
+        DocGen_Signer__c signer = new DocGen_Signer__c(
+            Signature_Request__c = req.Id,
+            Signer_Name__c = 'Pat Signer',
+            Signer_Email__c = 'pat@test.com',
+            Role_Name__c = 'Signer',
+            Secure_Token__c = SIGNER_TOKEN,
+            Status__c = 'Pending',
+            Sort_Order__c = 1
+        );
+        Database.insert(signer, AccessLevel.SYSTEM_MODE);
+
+        // A foreign request/signer bound to the foreign CV — its token must NOT be
+        // able to read this request's source PDF, and vice versa.
+        DocGen_Signature_Request__c foreignReq = new DocGen_Signature_Request__c(
+            Source_Document_Id__c = foreignCv.Id,
+            Related_Record_Id__c = acc.Id,
+            Status__c = 'Sent'
+        );
+        Database.insert(foreignReq, AccessLevel.SYSTEM_MODE);
+        DocGen_Signer__c foreignSigner = new DocGen_Signer__c(
+            Signature_Request__c = foreignReq.Id,
+            Signer_Name__c = 'Foreign Signer',
+            Signer_Email__c = 'foreign@test.com',
+            Secure_Token__c = FOREIGN_TOKEN,
+            Status__c = 'Pending',
+            Sort_Order__c = 1
+        );
+        Database.insert(foreignSigner, AccessLevel.SYSTEM_MODE);
+    }
+
+    private static DocGen_Signer__c getSigner(String token) {
+        return [
+            SELECT Id, Secure_Token__c, Status__c, Signature_Request__c, PIN_Verified_At__c
+            FROM DocGen_Signer__c
+            WHERE Secure_Token__c = :token
+            LIMIT 1
+        ];
+    }
+
+    // =========================================================================
+    // A1 — getSourcePdfBase64
+    // =========================================================================
+
+    @isTest
+    static void testGetSourcePdf_success() {
+        Test.startTest();
+        Map<String, String> result = DocGenSignatureController.getSourcePdfBase64(SIGNER_TOKEN);
+        Test.stopTest();
+
+        System.assertEquals(null, result.get('error'), 'Should not error for an authorized token');
+        System.assert(String.isNotBlank(result.get('base64')), 'Base64 PDF bytes expected');
+        System.assertEquals('application/pdf', result.get('mimeType'));
+        System.assertEquals('Generated Agreement', result.get('fileName'));
+        // Confirm it served the bound document, not the foreign one.
+        System.assertEquals(
+            EncodingUtil.base64Encode(Blob.valueOf('%PDF-1.7 fake pdf bytes')),
+            result.get('base64'),
+            'Must serve the request-bound source PDF'
+        );
+    }
+
+    @isTest
+    static void testGetSourcePdf_invalidTokenShape() {
+        Test.startTest();
+        Map<String, String> result = DocGenSignatureController.getSourcePdfBase64('not-a-token');
+        Test.stopTest();
+        System.assertEquals('Invalid token', result.get('error'));
+        System.assertEquals(null, result.get('base64'));
+    }
+
+    @isTest
+    static void testGetSourcePdf_foreignTokenServesOnlyOwnDoc() {
+        // IDOR: the foreign token must serve ITS OWN doc, never the first request's.
+        Test.startTest();
+        Map<String, String> result = DocGenSignatureController.getSourcePdfBase64(FOREIGN_TOKEN);
+        Test.stopTest();
+        System.assertEquals(
+            EncodingUtil.base64Encode(Blob.valueOf('%PDF-1.7 confidential')),
+            result.get('base64'),
+            'Foreign token must only resolve its own bound source document'
+        );
+        System.assertNotEquals(
+            EncodingUtil.base64Encode(Blob.valueOf('%PDF-1.7 fake pdf bytes')),
+            result.get('base64'),
+            'Foreign token must NOT reach the other request source PDF'
+        );
+    }
+
+    @isTest
+    static void testGetSourcePdf_expiredToken() {
+        // Backdate CreatedDate past the 48h expiry window via test setObjectField.
+        DocGen_Signer__c signer = getSigner(SIGNER_TOKEN);
+        Test.setCreatedDate(signer.Id, System.now().addHours(-49));
+        Test.startTest();
+        Map<String, String> result = DocGenSignatureController.getSourcePdfBase64(SIGNER_TOKEN);
+        Test.stopTest();
+        System.assertEquals('Invalid or expired token', result.get('error'));
+    }
+
+    // =========================================================================
+    // A2 — savePdfSignature
+    // =========================================================================
+
+    @isTest
+    static void testSavePdfSignature_success() {
+        DocGen_Signer__c signer = getSigner(SIGNER_TOKEN);
+        signer.PIN_Verified_At__c = System.now();
+        signer.Status__c = 'Viewed';
+        Database.update(signer, AccessLevel.SYSTEM_MODE);
+
+        Test.startTest();
+        DocGenSignatureController.SavePdfSignatureResult result = DocGenSignatureController.savePdfSignature(
+            SIGNER_TOKEN,
+            'Pat Signer',
+            true,
+            '203.0.113.7',
+            'Mozilla/5.0'
+        );
+        Test.stopTest();
+
+        System.assertEquals(true, result.success);
+        System.assertEquals(true, result.isComplete, 'Single signer → complete');
+        System.assertEquals(0, result.remaining);
+
+        signer = [
+            SELECT Status__c, Signature_Data__c, Consent_Captured__c, Signature_Request__c
+            FROM DocGen_Signer__c
+            WHERE Id = :signer.Id
+        ];
+        System.assertEquals('Signed', signer.Status__c);
+        System.assertEquals('Pat Signer', signer.Signature_Data__c);
+        System.assertEquals(true, signer.Consent_Captured__c);
+
+        DocGen_Signature_Request__c req = [
+            SELECT Status__c
+            FROM DocGen_Signature_Request__c
+            WHERE Id = :signer.Signature_Request__c
+        ];
+        System.assertEquals('Signed', req.Status__c, 'Request flips to Signed when all signers done');
+
+        List<DocGen_Signature_Audit__c> audits = [
+            SELECT Signer_Name__c, IP_Address__c, Consent_Captured__c, Document_Hash_SHA256__c
+            FROM DocGen_Signature_Audit__c
+            WHERE Signer__c = :signer.Id
+        ];
+        System.assertEquals(1, audits.size(), 'Audit row created');
+        System.assertEquals('Pat Signer', audits[0].Signer_Name__c);
+        System.assertEquals(true, audits[0].Consent_Captured__c);
+        System.assertEquals(null, audits[0].Document_Hash_SHA256__c, 'No hash — nothing was stamped in M1');
+    }
+
+    @isTest
+    static void testSavePdfSignature_noStampingEvent() {
+        // Proves the PDF path does NOT route through the DOCX-XML stamping queueable.
+        // saveSignature publishes DocGen_Signature_PDF__e which enqueues that queueable;
+        // savePdfSignature must NOT — so no async jobs should be enqueued.
+        DocGen_Signer__c signer = getSigner(SIGNER_TOKEN);
+        signer.PIN_Verified_At__c = System.now();
+        Database.update(signer, AccessLevel.SYSTEM_MODE);
+
+        Test.startTest();
+        DocGenSignatureController.savePdfSignature(SIGNER_TOKEN, 'Pat Signer', true, '203.0.113.7', 'UA');
+        Integer enqueued = Limits.getAsyncCalls();
+        Test.stopTest();
+
+        System.assertEquals(0, enqueued, 'savePdfSignature must not enqueue any stamping job');
+    }
+
+    @isTest
+    static void testSavePdfSignature_noConsent() {
+        DocGen_Signer__c signer = getSigner(SIGNER_TOKEN);
+        signer.PIN_Verified_At__c = System.now();
+        Database.update(signer, AccessLevel.SYSTEM_MODE);
+        Test.startTest();
+        try {
+            DocGenSignatureController.savePdfSignature(SIGNER_TOKEN, 'Pat Signer', false, '1.1.1.1', 'UA');
+            System.assert(false, 'Should have thrown without consent');
+        } catch (Exception e) {
+            // AuraHandledException
+        }
+        Test.stopTest();
+    }
+
+    @isTest
+    static void testSavePdfSignature_noPinVerification() {
+        Test.startTest();
+        try {
+            DocGenSignatureController.savePdfSignature(SIGNER_TOKEN, 'Pat Signer', true, '1.1.1.1', 'UA');
+            System.assert(false, 'Should have thrown — PIN not verified');
+        } catch (Exception e) {
+            // AuraHandledException
+        }
+        Test.stopTest();
+    }
+
+    @isTest
+    static void testSavePdfSignature_invalidToken() {
+        Test.startTest();
+        try {
+            DocGenSignatureController.savePdfSignature('bad', 'Name', true, '1.1.1.1', 'UA');
+            System.assert(false, 'Should have thrown');
+        } catch (Exception e) {
+            // AuraHandledException
+        }
+        Test.stopTest();
+    }
+
+    // =========================================================================
+    // A3 — createRequestFromContentVersion
+    // =========================================================================
+
+    @isTest
+    static void testCreateRequestFromContentVersion() {
+        Account acc = [SELECT Id FROM Account LIMIT 1];
+        ContentVersion cv = new ContentVersion(
+            Title = 'Fresh Generated Doc',
+            PathOnClient = 'fresh.pdf',
+            VersionData = Blob.valueOf('%PDF-1.7 fresh')
+        );
+        insert cv;
+        cv = [SELECT Id FROM ContentVersion WHERE Id = :cv.Id LIMIT 1];
+
+        String signersJson = '[{"signerName":"Sam Signer","signerEmail":"sam@test.com","roleName":"Signer","contactId":""}]';
+
+        Test.startTest();
+        List<DocGenSignatureSenderController.SignerResult> results = DocGenSignatureSenderController.createRequestFromContentVersion(
+            cv.Id,
+            acc.Id,
+            signersJson,
+            'Parallel',
+            null
+        );
+        Test.stopTest();
+
+        System.assertEquals(1, results.size());
+        System.assertEquals('Sam Signer', results[0].signerName);
+        System.assert(String.isNotBlank(results[0].signerUrl), 'Signer URL expected');
+        System.assert(results[0].signerUrl.contains('DocGenSignaturePdf'), 'URL must target the flat-PDF page');
+
+        // Verify a Template__c-null request was created with the source CV + a signer token.
+        DocGen_Signer__c created = [
+            SELECT
+                Secure_Token__c,
+                Signature_Request__r.Source_Document_Id__c,
+                Signature_Request__r.Template__c,
+                Signature_Request__r.Status__c
+            FROM DocGen_Signer__c
+            WHERE Signer_Email__c = 'sam@test.com'
+            LIMIT 1
+        ];
+        System.assertEquals(cv.Id, created.Signature_Request__r.Source_Document_Id__c);
+        System.assertEquals(null, created.Signature_Request__r.Template__c, 'Template must be null for the PDF path');
+        System.assertEquals('Sent', created.Signature_Request__r.Status__c);
+        System.assertEquals(64, created.Secure_Token__c.length(), 'A 64-char token must be issued');
+    }
+
+    @isTest
+    static void testCreateRequestFromContentVersion_nullCv() {
+        Test.startTest();
+        try {
+            DocGenSignatureSenderController.createRequestFromContentVersion(
+                null,
+                null,
+                '[{"signerName":"X","signerEmail":"x@test.com"}]',
+                'Parallel',
+                null
+            );
+            System.assert(false, 'Should have thrown for null CV');
+        } catch (Exception e) {
+            // AuraHandledException
+        }
+        Test.stopTest();
+    }
+
+    // =========================================================================
+    // A4 — DocGenSignaturePdfFlowAction invocable
+    // =========================================================================
+
+    @isTest
+    static void testPdfFlowAction_success() {
+        Account acc = [SELECT Id FROM Account LIMIT 1];
+        ContentVersion cv = new ContentVersion(
+            Title = 'Flow Generated Doc',
+            PathOnClient = 'flow.pdf',
+            VersionData = Blob.valueOf('%PDF-1.7 flow')
+        );
+        insert cv;
+        cv = [SELECT Id FROM ContentVersion WHERE Id = :cv.Id LIMIT 1];
+
+        DocGenSigner s = new DocGenSigner();
+        s.name = 'Flow Signer';
+        s.email = 'flow@test.com';
+        s.role = 'Signer';
+
+        DocGenSignaturePdfFlowAction.Request req = new DocGenSignaturePdfFlowAction.Request();
+        req.contentVersionId = cv.Id;
+        req.relatedRecordId = acc.Id;
+        req.signerRecords = new List<DocGenSigner>{ s };
+        req.signingOrder = 'Parallel';
+
+        Test.startTest();
+        List<DocGenSignaturePdfFlowAction.Result> results = DocGenSignaturePdfFlowAction.send(
+            new List<DocGenSignaturePdfFlowAction.Request>{ req }
+        );
+        Test.stopTest();
+
+        System.assertEquals(1, results.size());
+        DocGenSignaturePdfFlowAction.Result r = results[0];
+        System.assertEquals(true, r.success, 'Expected success; error=' + r.errorMessage);
+        System.assertNotEquals(null, r.signatureRequestId);
+        System.assertEquals(1, r.signerUrls.size());
+        System.assertEquals('Flow Signer', r.signerNames[0]);
+        System.assert(r.signerUrls[0].contains('DocGenSignaturePdf'), 'URL must target the flat-PDF page');
+    }
+
+    @isTest
+    static void testPdfFlowAction_missingEmail() {
+        Account acc = [SELECT Id FROM Account LIMIT 1];
+        ContentVersion cv = new ContentVersion(
+            Title = 'Flow Doc 2',
+            PathOnClient = 'flow2.pdf',
+            VersionData = Blob.valueOf('%PDF-1.7')
+        );
+        insert cv;
+        cv = [SELECT Id FROM ContentVersion WHERE Id = :cv.Id LIMIT 1];
+
+        DocGenSigner s = new DocGenSigner();
+        s.name = 'No Email Signer';
+
+        DocGenSignaturePdfFlowAction.Request req = new DocGenSignaturePdfFlowAction.Request();
+        req.contentVersionId = cv.Id;
+        req.relatedRecordId = acc.Id;
+        req.signerRecords = new List<DocGenSigner>{ s };
+
+        Test.startTest();
+        try {
+            DocGenSignaturePdfFlowAction.send(new List<DocGenSignaturePdfFlowAction.Request>{ req });
+            System.assert(false, 'Should have thrown on missing email');
+        } catch (Exception e) {
+            // DocGenException from validation
+        }
+        Test.stopTest();
+    }
+
+    @isTest
+    static void testPdfFlowAction_nullRequests() {
+        Test.startTest();
+        List<DocGenSignaturePdfFlowAction.Result> results = DocGenSignaturePdfFlowAction.send(null);
+        Test.stopTest();
+        System.assertEquals(0, results.size());
+    }
+}

--- a/force-app/main/default/classes/DocGenSignaturePdfTests.cls
+++ b/force-app/main/default/classes/DocGenSignaturePdfTests.cls
@@ -686,4 +686,146 @@ private class DocGenSignaturePdfTests {
             'Certificate shows the invited name as "Registered as" when the typed name differs'
         );
     }
+
+    // =========================================================================
+    // M3 — signature loop block ({#Signatures})
+    // =========================================================================
+
+    @isTest
+    static void testBuildSignerLoopData_oneRowPerSignerWithTypedName() {
+        Account acc = new Account(Name = 'Loop Co');
+        insert acc;
+        DocGen_Signature_Request__c req = new DocGen_Signature_Request__c(
+            Related_Record_Id__c = acc.Id,
+            Status__c = 'Signed'
+        );
+        Database.insert(req, AccessLevel.SYSTEM_MODE);
+        DocGen_Signer__c s1 = new DocGen_Signer__c(
+            Signature_Request__c = req.Id,
+            Signer_Name__c = 'Ada Buyer',
+            Signer_Email__c = 'ada@test.com',
+            Role_Name__c = 'Buyer',
+            Secure_Token__c = '4444444444444444444444444444444444444444444444444444444444444444',
+            Status__c = 'Signed',
+            Signature_Data__c = 'Ada B. Buyer', // typed e-signature differs from the invited name
+            Sort_Order__c = 1
+        );
+        DocGen_Signer__c s2 = new DocGen_Signer__c(
+            Signature_Request__c = req.Id,
+            Signer_Name__c = 'Ben Seller',
+            Signer_Email__c = 'ben@test.com',
+            Role_Name__c = 'Seller',
+            Secure_Token__c = '5555555555555555555555555555555555555555555555555555555555555555',
+            Status__c = 'Signed',
+            Sort_Order__c = 2 // no typed name → falls back to the invited name
+        );
+        Database.insert(new List<DocGen_Signer__c>{ s1, s2 }, AccessLevel.SYSTEM_MODE);
+        Database.insert(
+            new DocGen_Signature_Audit__c(
+                Signature_Request__c = req.Id,
+                Signer__c = s1.Id,
+                Signer_Name__c = 'Ada Buyer',
+                Signer_Email__c = 'ada@test.com',
+                Signed_Date__c = System.now()
+            ),
+            AccessLevel.SYSTEM_MODE
+        );
+
+        Test.startTest();
+        List<Map<String, Object>> rows = DocGenSignatureService.buildSignerLoopData(req.Id);
+        Test.stopTest();
+
+        System.assertEquals(2, rows.size(), 'One row per signer');
+        // Ordered by Sort_Order__c.
+        System.assertEquals('Ada B. Buyer', rows[0].get('Name'), 'Row 0 shows the typed e-signature');
+        System.assertEquals('Ada Buyer', rows[0].get('RegisteredName'), 'Row 0 keeps the invited name');
+        System.assertEquals('Buyer', rows[0].get('Role'));
+        System.assertEquals('ada@test.com', rows[0].get('Email'));
+        System.assert(
+            String.isNotBlank((String) rows[0].get('SignedDate')),
+            'Row 0 has a signed date from the audit record'
+        );
+        System.assertEquals(
+            'Ben Seller',
+            rows[1].get('Name'),
+            'Row 1 falls back to the invited name (no typed signature captured)'
+        );
+        System.assertEquals('Seller', rows[1].get('Role'));
+        System.assertEquals('', rows[1].get('SignedDate'), 'Row 1 has no audit → blank signed date');
+    }
+
+    @isTest
+    static void testSignaturesLoop_rendersOneBlockPerSigner() {
+        // The reserved {#Signatures} loop block renders once per injected signer row —
+        // one authored layout, any signer count, no per-count templates.
+        String template = '<w:t>{#Signatures}</w:t><w:t>Signed by {Name} ({Role})</w:t><w:t>{/Signatures}</w:t>';
+
+        List<Map<String, Object>> twoSigners = DocGenSignatureService.buildPendingSignerLoopData(
+            new List<Map<String, Object>>{
+                new Map<String, Object>{
+                    'signerName' => 'Ada Buyer',
+                    'signerEmail' => 'ada@test.com',
+                    'roleName' => 'Buyer'
+                },
+                new Map<String, Object>{
+                    'signerName' => 'Ben Seller',
+                    'signerEmail' => 'ben@test.com',
+                    'roleName' => 'Seller'
+                }
+            }
+        );
+        String two = DocGenService.processXmlForTest(template, new Map<String, Object>{ 'Signatures' => twoSigners });
+        System.assert(two.contains('Ada Buyer') && two.contains('(Buyer)'), 'First signer block rendered');
+        System.assert(two.contains('Ben Seller') && two.contains('(Seller)'), 'Second signer block rendered');
+
+        // Same template, a single signer → exactly one block.
+        List<Map<String, Object>> oneSigner = DocGenSignatureService.buildPendingSignerLoopData(
+            new List<Map<String, Object>>{
+                new Map<String, Object>{
+                    'signerName' => 'Solo Signer',
+                    'signerEmail' => 'solo@test.com',
+                    'roleName' => 'Signer'
+                }
+            }
+        );
+        String one = DocGenService.processXmlForTest(template, new Map<String, Object>{ 'Signatures' => oneSigner });
+        System.assert(one.contains('Solo Signer'), 'Single signer block rendered from the same template');
+        System.assert(!one.contains('Ada Buyer'), 'Only the one injected signer renders');
+    }
+
+    @isTest
+    static void testSignaturesLoop_backwardsCompatible() {
+        // Backwards-compat guarantee #1: a template with NO {#Signatures} marker renders
+        // exactly as before, even when a Signatures collection is present in the data map.
+        String plain = '<w:t>Agreement for {Name}</w:t>';
+        String out = DocGenService.processXmlForTest(
+            plain,
+            new Map<String, Object>{
+                'Name' => 'World',
+                'Signatures' => DocGenSignatureService.buildPendingSignerLoopData(
+                    new List<Map<String, Object>>{
+                        new Map<String, Object>{
+                            'signerName' => 'Ghost',
+                            'signerEmail' => 'g@test.com',
+                            'roleName' => 'Signer'
+                        }
+                    }
+                )
+            }
+        );
+        System.assert(out.contains('Agreement for World'), 'No {#Signatures} marker → existing merge is unchanged');
+        System.assert(!out.contains('Ghost'), 'Signer rows are never emitted without a {#Signatures} block');
+
+        // Backwards-compat guarantee #2: an empty signer collection collapses cleanly —
+        // the block emits nothing and never leaks the raw {#Signatures}/{Name} tags.
+        String withBlock = '<w:t>{#Signatures}</w:t><w:t>{Name}</w:t><w:t>{/Signatures}</w:t>';
+        String empty = DocGenService.processXmlForTest(
+            withBlock,
+            new Map<String, Object>{ 'Signatures' => new List<Object>() }
+        );
+        System.assert(
+            !empty.contains('{#Signatures}') && !empty.contains('{Name}'),
+            'Empty Signatures collection collapses cleanly with no leaked tags'
+        );
+    }
 }

--- a/force-app/main/default/classes/DocGenSignaturePdfTests.cls
+++ b/force-app/main/default/classes/DocGenSignaturePdfTests.cls
@@ -828,4 +828,48 @@ private class DocGenSignaturePdfTests {
             'Empty Signatures collection collapses cleanly with no leaked tags'
         );
     }
+
+    // The finalize queueable short-circuits under Test.isRunningTest(), so the snapshot
+    // re-render (mergeTemplateForSignatureFromData) was only covered by manual demo
+    // scripts. This exercises it directly and proves the point-in-time guarantee: the
+    // document renders from the send-time data snapshot, immune to later record edits.
+    @isTest
+    static void testMergeTemplateForSignatureFromData_rendersFromSnapshotNotLiveRecord() {
+        Account acc = new Account(Name = 'Frozen Co', Industry = 'FrozenIndustry');
+        insert acc;
+        Id templateId = createHtmlSignatureTemplate(
+            '<html><body><h1>{Name}</h1><p>Industry: {Industry}</p></body></html>'
+        );
+
+        // Capture the snapshot exactly as the send-time flow does.
+        Map<String, Object> snapshot = DocGenDataRetriever.getRecordData(acc.Id, 'Account', 'Name, Industry');
+
+        // Mutate the record AFTER the snapshot — the re-render must ignore this.
+        acc.Name = 'Mutated Co';
+        update acc;
+
+        Test.startTest();
+        Map<String, Object> merged = DocGenService.mergeTemplateForSignatureFromData(templateId, snapshot);
+        Test.stopTest();
+
+        String body = (String) merged.get('combinedDocumentXml');
+        if (String.isBlank(body)) {
+            body = (String) merged.get('documentXml');
+        }
+        System.assert(body.contains('Frozen Co'), 'Renders the frozen snapshot name: ' + body);
+        System.assert(!body.contains('Mutated Co'), 'Must NOT reflect the post-snapshot record edit');
+        System.assertEquals('HTML', (String) merged.get('templateType'), 'HTML template type preserved');
+    }
+
+    @isTest
+    static void testMergeTemplateForSignatureFromData_nullDataMapThrows() {
+        Id templateId = createHtmlSignatureTemplate('<html><body>{Name}</body></html>');
+        Boolean threw = false;
+        try {
+            DocGenService.mergeTemplateForSignatureFromData(templateId, null);
+        } catch (DocGenException e) {
+            threw = true;
+        }
+        System.assert(threw, 'A null snapshot data map must throw rather than fall back to the live record');
+    }
 }

--- a/force-app/main/default/classes/DocGenSignaturePdfTests.cls
+++ b/force-app/main/default/classes/DocGenSignaturePdfTests.cls
@@ -431,4 +431,259 @@ private class DocGenSignaturePdfTests {
         Test.stopTest();
         System.assertEquals(0, results.size());
     }
+
+    // =========================================================================
+    // M2 — snapshot signing (data snapshot at send-time → re-render + cert page
+    // onto the record at completion).
+    // =========================================================================
+
+    private static Id createHtmlSignatureTemplate(String bodyHtml) {
+        DocGen_Template__c tmpl = new DocGen_Template__c(
+            Name = 'M2 HTML Template ' + Datetime.now().getTime(),
+            Base_Object_API__c = 'Account',
+            Query_Config__c = 'Name, Industry',
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF'
+        );
+        insert tmpl;
+        ContentVersion bodyCv = new ContentVersion(
+            Title = tmpl.Name + ' Body',
+            PathOnClient = 'template.html',
+            VersionData = Blob.valueOf(bodyHtml),
+            FirstPublishLocationId = tmpl.Id
+        );
+        insert bodyCv;
+        bodyCv = [SELECT Id FROM ContentVersion WHERE Id = :bodyCv.Id LIMIT 1];
+        insert new DocGen_Template_Version__c(
+            Template__c = tmpl.Id,
+            Is_Active__c = true,
+            Content_Version_Id__c = bodyCv.Id
+        );
+        return tmpl.Id;
+    }
+
+    @isTest
+    static void testCreateTemplateSnapshotRequest_capturesSnapshot() {
+        Account acc = new Account(Name = 'Snapshot Co', Industry = 'Technology');
+        insert acc;
+        Id templateId = createHtmlSignatureTemplate(
+            '<html><body><h1>{Name}</h1><p>Industry: {Industry}</p></body></html>'
+        );
+        String signersJson = JSON.serialize(
+            new List<Map<String, Object>>{
+                new Map<String, Object>{
+                    'signerName' => 'Dana Buyer',
+                    'signerEmail' => 'dana@test.com',
+                    'roleName' => 'Buyer'
+                }
+            }
+        );
+
+        Test.startTest();
+        List<DocGenSignatureSenderController.SignerResult> res = DocGenSignatureSenderController.createTemplateSnapshotRequest(
+            templateId,
+            acc.Id,
+            signersJson,
+            'Parallel',
+            null
+        );
+        Test.stopTest();
+
+        System.assertEquals(1, res.size(), 'One signer result');
+        System.assert(String.isNotBlank(res[0].signerUrl), 'Signer URL minted');
+
+        DocGen_Signature_Request__c req = [
+            SELECT Template__c, Render_Data_Snapshot__c, Source_Document_Id__c, Related_Record_Id__c, Status__c
+            FROM DocGen_Signature_Request__c
+            WHERE Template__c = :templateId
+            ORDER BY CreatedDate DESC
+            LIMIT 1
+        ];
+        System.assertEquals(templateId, req.Template__c);
+        System.assertEquals(acc.Id, req.Related_Record_Id__c);
+        System.assertEquals('Sent', req.Status__c);
+        System.assert(String.isNotBlank(req.Render_Data_Snapshot__c), 'Snapshot JSON captured');
+        System.assert(req.Render_Data_Snapshot__c.contains('Snapshot Co'), 'Snapshot froze the record Name');
+        System.assert(req.Render_Data_Snapshot__c.contains('Technology'), 'Snapshot froze the record Industry');
+        System.assertNotEquals(null, req.Source_Document_Id__c, 'Viewing CV bound to the request');
+
+        List<ContentVersion> cvs = [SELECT Id FROM ContentVersion WHERE Id = :req.Source_Document_Id__c];
+        System.assertEquals(1, cvs.size(), 'Viewing PDF ContentVersion created');
+
+        List<DocGen_Signer__c> signers = [
+            SELECT Secure_Token__c, Status__c
+            FROM DocGen_Signer__c
+            WHERE Signature_Request__c = :req.Id
+        ];
+        System.assertEquals(1, signers.size());
+        System.assertEquals('Pending', signers[0].Status__c);
+        System.assert(String.isNotBlank(signers[0].Secure_Token__c), 'Signer token minted');
+    }
+
+    @isTest
+    static void testSavePdfSignature_snapshotBacked_leavesInProgressForFinalizer() {
+        // A snapshot-backed request must stay 'In Progress' after savePdfSignature so the
+        // platform-event trigger can enqueue the finalizer (which sets 'Signed'). This is the
+        // tell that the snapshot/publish branch was taken (vs the M1 path which sets 'Signed').
+        Account acc = new Account(Name = 'Finalize Co');
+        insert acc;
+        DocGen_Template__c tmpl = new DocGen_Template__c(
+            Name = 'M2 Stub Tmpl',
+            Base_Object_API__c = 'Account',
+            Type__c = 'HTML'
+        );
+        insert tmpl;
+        ContentVersion srcCv = new ContentVersion(
+            Title = 'Src',
+            PathOnClient = 'src.pdf',
+            VersionData = Blob.valueOf('%PDF-1.7 source')
+        );
+        insert srcCv;
+        srcCv = [SELECT Id FROM ContentVersion WHERE Id = :srcCv.Id LIMIT 1];
+
+        String token = '1111111111111111111111111111111111111111111111111111111111111111';
+        DocGen_Signature_Request__c req = new DocGen_Signature_Request__c(
+            Template__c = tmpl.Id,
+            Render_Data_Snapshot__c = '{"Name":"Finalize Co"}',
+            Source_Document_Id__c = srcCv.Id,
+            Related_Record_Id__c = acc.Id,
+            Status__c = 'Sent',
+            Signing_Order__c = 'Parallel'
+        );
+        Database.insert(req, AccessLevel.SYSTEM_MODE);
+        DocGen_Signer__c signer = new DocGen_Signer__c(
+            Signature_Request__c = req.Id,
+            Signer_Name__c = 'Pat',
+            Signer_Email__c = 'pat@test.com',
+            Role_Name__c = 'Signer',
+            Secure_Token__c = token,
+            Status__c = 'Pending',
+            Sort_Order__c = 1,
+            PIN_Verified_At__c = System.now()
+        );
+        Database.insert(signer, AccessLevel.SYSTEM_MODE);
+
+        // No Test.stopTest wrapper — assert the synchronous state savePdfSignature leaves,
+        // before the published event's trigger would finalize.
+        DocGenSignatureController.SavePdfSignatureResult result = DocGenSignatureController.savePdfSignature(
+            token,
+            'Pat',
+            true,
+            '1.2.3.4',
+            'UA'
+        );
+
+        System.assertEquals(true, result.success);
+        System.assertEquals(true, result.isComplete);
+        DocGen_Signer__c after = [SELECT Status__c FROM DocGen_Signer__c WHERE Id = :signer.Id];
+        System.assertEquals('Signed', after.Status__c, 'Signer marked Signed');
+        DocGen_Signature_Request__c reqAfter = [
+            SELECT Status__c
+            FROM DocGen_Signature_Request__c
+            WHERE Id = :req.Id
+        ];
+        System.assertEquals(
+            'In Progress',
+            reqAfter.Status__c,
+            'Snapshot-backed request stays In Progress so the finalizer can produce the doc + cert and set Signed'
+        );
+    }
+
+    @isTest
+    static void testSnapshotFinalizeQueueable_attachesSignedDocAndHash() {
+        // The finalizer (stubbed PDF under test) must attach a signed document to the related
+        // record, write the SHA-256 to the audit, and flip the request to Signed.
+        Account acc = new Account(Name = 'Queueable Co');
+        insert acc;
+        DocGen_Template__c tmpl = new DocGen_Template__c(
+            Name = 'M2 Q Tmpl',
+            Base_Object_API__c = 'Account',
+            Type__c = 'HTML'
+        );
+        insert tmpl;
+        DocGen_Signature_Request__c req = new DocGen_Signature_Request__c(
+            Template__c = tmpl.Id,
+            Render_Data_Snapshot__c = '{"Name":"Queueable Co"}',
+            Related_Record_Id__c = acc.Id,
+            Status__c = 'In Progress',
+            Signing_Order__c = 'Parallel'
+        );
+        Database.insert(req, AccessLevel.SYSTEM_MODE);
+        DocGen_Signer__c signer = new DocGen_Signer__c(
+            Signature_Request__c = req.Id,
+            Signer_Name__c = 'Pat',
+            Signer_Email__c = 'pat@test.com',
+            Secure_Token__c = '2222222222222222222222222222222222222222222222222222222222222222',
+            Status__c = 'Signed',
+            Sort_Order__c = 1
+        );
+        Database.insert(signer, AccessLevel.SYSTEM_MODE);
+        DocGen_Signature_Audit__c audit = new DocGen_Signature_Audit__c(
+            Signature_Request__c = req.Id,
+            Signer__c = signer.Id,
+            Signer_Name__c = 'Pat',
+            Signer_Email__c = 'pat@test.com',
+            Signed_Date__c = System.now(),
+            Consent_Captured__c = true
+        );
+        Database.insert(audit, AccessLevel.SYSTEM_MODE);
+
+        Test.startTest();
+        System.enqueueJob(new DocGenSignatureService.TemplateSignaturePdfQueueable(req.Id));
+        Test.stopTest();
+
+        DocGen_Signature_Request__c reqAfter = [SELECT Status__c FROM DocGen_Signature_Request__c WHERE Id = :req.Id];
+        System.assertEquals('Signed', reqAfter.Status__c, 'Finalizer flips the request to Signed');
+
+        DocGen_Signature_Audit__c auditAfter = [
+            SELECT Document_Hash_SHA256__c
+            FROM DocGen_Signature_Audit__c
+            WHERE Id = :audit.Id
+        ];
+        System.assert(String.isNotBlank(auditAfter.Document_Hash_SHA256__c), 'SHA-256 hash written to the audit');
+
+        List<ContentDocumentLink> links = [SELECT Id FROM ContentDocumentLink WHERE LinkedEntityId = :acc.Id];
+        System.assert(!links.isEmpty(), 'Signed PDF linked to the related record');
+    }
+
+    @isTest
+    static void testCertificate_showsTypedSignatureName() {
+        // The certificate must show the name the signer TYPED (Signature_Data__c) —
+        // their electronic signature — not just the invited name, and surface the
+        // invited name as "Registered as" when the two differ.
+        Account acc = new Account(Name = 'Cert Co');
+        insert acc;
+        DocGen_Signature_Request__c req = new DocGen_Signature_Request__c(
+            Related_Record_Id__c = acc.Id,
+            Status__c = 'Signed'
+        );
+        Database.insert(req, AccessLevel.SYSTEM_MODE);
+        DocGen_Signer__c signer = new DocGen_Signer__c(
+            Signature_Request__c = req.Id,
+            Signer_Name__c = 'Pat Tester',
+            Signer_Email__c = 'pat@test.com',
+            Role_Name__c = 'Signer',
+            Secure_Token__c = '3333333333333333333333333333333333333333333333333333333333333333',
+            Status__c = 'Signed',
+            Signature_Data__c = 'Pat Tester NATHAN',
+            Sort_Order__c = 1
+        );
+        Database.insert(signer, AccessLevel.SYSTEM_MODE);
+
+        List<DocGen_Signer__c> signers = [
+            SELECT Signer_Name__c, Signature_Data__c, Signer_Email__c, Role_Name__c, PIN_Verified_At__c
+            FROM DocGen_Signer__c
+            WHERE Id = :signer.Id
+        ];
+
+        Test.startTest();
+        String certHtml = DocGenSignatureService.buildVerificationBlockHtml(req.Id, signers);
+        Test.stopTest();
+
+        System.assert(certHtml.contains('Pat Tester NATHAN'), 'Certificate shows the typed signature name');
+        System.assert(
+            certHtml.contains('Registered as: Pat Tester'),
+            'Certificate shows the invited name as "Registered as" when the typed name differs'
+        );
+    }
 }

--- a/force-app/main/default/classes/DocGenSignaturePdfTests.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenSignaturePdfTests.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -944,6 +944,125 @@ public with sharing class DocGenSignatureSenderController {
     }
 
     /**
+     * Milestone 2 — "send a template for signature with a data snapshot".
+     *
+     * Captures the template's resolved merge data for the record as JSON at
+     * send-time (Render_Data_Snapshot__c) and generates the viewing PDF from that
+     * SAME snapshot, so what the signer reviews is byte-identical to what the
+     * completion finalizer re-renders. On completion the finalizer re-renders from
+     * the snapshot (not the live record) and appends the signing-certificate page —
+     * immune to edits made to the record between send and sign — then links the
+     * completed PDF to the related record.
+     *
+     * signersJson: [{signerName, signerEmail, roleName, contactId}, ...]
+     */
+    @AuraEnabled
+    public static List<SignerResult> createTemplateSnapshotRequest(
+        Id templateId,
+        String relatedRecordId,
+        String signersJson,
+        String signingOrder,
+        String documentTitleFormat
+    ) {
+        if (templateId == null) {
+            throw new AuraHandledException('A template Id is required.');
+        }
+        if (String.isBlank(relatedRecordId)) {
+            throw new AuraHandledException('A related record Id is required for snapshot signing.');
+        }
+
+        // Load the template's data-binding config.
+        DocGenFlsGuard.assertAccessible(
+            DocGen_Template__c.sObjectType,
+            new Set<String>{ 'Name', 'Base_Object_API__c', 'Query_Config__c' }
+        );
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        List<DocGen_Template__c> tpls = [
+            SELECT Name, Base_Object_API__c, Query_Config__c
+            FROM DocGen_Template__c
+            WHERE Id = :templateId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (tpls.isEmpty()) {
+            throw new AuraHandledException('Template not found.');
+        }
+        DocGen_Template__c tpl = tpls[0];
+        if (String.isBlank(tpl.Base_Object_API__c) || String.isBlank(tpl.Query_Config__c)) {
+            throw new AuraHandledException(
+                'Snapshot signing requires a template with a base object and query configuration.'
+            );
+        }
+
+        // Snapshot the record's merge data at send-time.
+        Map<String, Object> snapshot = DocGenDataRetriever.getRecordData(
+            relatedRecordId,
+            tpl.Base_Object_API__c,
+            tpl.Query_Config__c
+        );
+        String snapshotJson = JSON.serialize(snapshot);
+        if (snapshotJson.length() > 131072) {
+            throw new AuraHandledException(
+                'This document\'s data is too large for snapshot signing (over 131,072 characters). ' +
+                'Use a smaller template/dataset or the send-existing-document path.'
+            );
+        }
+
+        // Generate the viewing PDF from the SAME snapshot so the signer sees exactly
+        // what the completion finalizer will re-render.
+        Map<String, Object> gen = DocGenService.generatePdfBlobFromData(templateId, snapshot);
+        Blob viewingBlob = (Blob) gen.get('blob');
+        String genTitle = (String) gen.get('title');
+        String fileTitle = String.isNotBlank(genTitle) ? genTitle : tpl.Name;
+
+        // Standalone viewing ContentVersion (not linked to the record — the final
+        // signed + certificate PDF is what lands on the record at completion).
+        ContentVersion viewCv = new ContentVersion();
+        viewCv.Title = fileTitle;
+        viewCv.PathOnClient = fileTitle + '.pdf';
+        viewCv.VersionData = viewingBlob;
+        DocGenFlsGuard.assertCreateable(viewCv, new Set<String>{ 'Title', 'PathOnClient', 'VersionData' });
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        Database.insert(viewCv, AccessLevel.SYSTEM_MODE);
+
+        // Create the snapshot-backed request: Template__c + Render_Data_Snapshot__c
+        // drive the completion re-render; Source_Document_Id__c is the viewing CV.
+        DocGen_Signature_Request__c req = new DocGen_Signature_Request__c();
+        req.Template__c = templateId;
+        req.Render_Data_Snapshot__c = snapshotJson;
+        req.Source_Document_Id__c = viewCv.Id;
+        req.Related_Record_Id__c = relatedRecordId;
+        req.Status__c = 'Sent';
+        req.Signing_Order__c = String.isNotBlank(signingOrder) ? signingOrder : 'Parallel';
+        if (String.isNotBlank(documentTitleFormat)) {
+            req.Document_Title_Format__c = documentTitleFormat;
+        }
+        DocGenFlsGuard.assertCreateable(
+            req,
+            new Set<String>{
+                'Template__c',
+                'Render_Data_Snapshot__c',
+                'Source_Document_Id__c',
+                'Related_Record_Id__c',
+                'Status__c',
+                'Signing_Order__c',
+                'Document_Title_Format__c'
+            }
+        );
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        Database.insert(req, AccessLevel.SYSTEM_MODE);
+
+        // Create signer records + emails, URLs at the flat-PDF page.
+        // templateId=null → skip {@Signature} placement creation (snapshot signing has no tags).
+        List<Object> rawInputs = (List<Object>) JSON.deserializeUntyped(signersJson);
+        List<Map<String, Object>> signerInputs = new List<Map<String, Object>>();
+        for (Object item : rawInputs) {
+            signerInputs.add((Map<String, Object>) item);
+        }
+        return createSignersAndNotify(req.Id, null, fileTitle, signerInputs, true, getSigningPdfPagePath());
+    }
+
+    /**
      * Legacy single-signer request creation (backward compat).
      */
     @AuraEnabled

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -147,11 +147,13 @@ public with sharing class DocGenSignatureSenderController {
     private static String extractTemplatePlainText(Id templateId) {
         DocGenFlsGuard.assertAccessible(
             DocGen_Template_Version__c.sObjectType,
-            new Set<String>{ 'Template__c', 'Is_Active__c' }
+            new Set<String>{ 'Template__c', 'Is_Active__c', 'Content_Version_Id__c' }
         );
+        DocGenFlsGuard.assertAccessible(DocGen_Template__c.sObjectType, new Set<String>{ 'Type__c' });
+        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'Title', 'VersionData' });
         /* code-analyzer-suppress ApexFlsViolation */
         List<DocGen_Template_Version__c> activeVersions = [
-            SELECT Id
+            SELECT Id, Content_Version_Id__c, Template__r.Type__c
             FROM DocGen_Template_Version__c
             WHERE Template__c = :templateId AND Is_Active__c = TRUE
             WITH SYSTEM_MODE
@@ -160,7 +162,24 @@ public with sharing class DocGenSignatureSenderController {
         if (activeVersions.isEmpty())
             return null;
 
-        String xmlPrefix = 'docgen_tmpl_xml_' + activeVersions[0].Id + '_';
+        DocGen_Template_Version__c activeVersion = activeVersions[0];
+        if (activeVersion.Template__r.Type__c == 'HTML') {
+            if (String.isBlank(activeVersion.Content_Version_Id__c))
+                return null;
+
+            Id bodyCvId = (Id) activeVersion.Content_Version_Id__c;
+            /* code-analyzer-suppress ApexFlsViolation */
+            List<ContentVersion> htmlCvs = [
+                SELECT VersionData
+                FROM ContentVersion
+                WHERE Id = :bodyCvId
+                WITH USER_MODE
+                LIMIT 1
+            ];
+            return htmlCvs.isEmpty() || htmlCvs[0].VersionData == null ? null : htmlCvs[0].VersionData.toString();
+        }
+
+        String xmlPrefix = 'docgen_tmpl_xml_' + activeVersion.Id + '_';
         /* code-analyzer-suppress ApexFlsViolation */
         List<ContentVersion> xmlCvs = [
             SELECT Title, VersionData

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -561,12 +561,7 @@ public with sharing class DocGenSignatureSenderController {
             }
 
             // Render preview HTML using public URLs (small, no base64 bloat)
-            String docXml = (String) mergeData.get('combinedDocumentXml');
-            if (String.isBlank(docXml)) {
-                docXml = (String) mergeData.get('documentXml');
-            }
-            DocGenService.applyWatermarkOverride(templateId);
-            String previewHtml = DocGenHtmlRenderer.convertToHtml(docXml, previewImageMap);
+            String previewHtml = renderMergedSignatureHtml(mergeData, templateId, previewImageMap);
 
             // Inject interactive placement spans for the guided signing UI.
             // Watermark overlay is NOT injected here — base64-embedded image would blow
@@ -727,12 +722,7 @@ public with sharing class DocGenSignatureSenderController {
                     }
                 }
 
-                String docXml = (String) mergeData.get('combinedDocumentXml');
-                if (String.isBlank(docXml)) {
-                    docXml = (String) mergeData.get('documentXml');
-                }
-                DocGenService.applyWatermarkOverride(tid);
-                String docHtml = DocGenHtmlRenderer.convertToHtml(docXml, previewImageMap);
+                String docHtml = renderMergedSignatureHtml(mergeData, tid, previewImageMap);
                 docHtml = injectPlacementSpans(docHtml);
                 // Watermark overlay deferred to read time (cache size constraint).
 
@@ -1655,13 +1645,8 @@ public with sharing class DocGenSignatureSenderController {
     public static String getDocumentPreviewHtml(Id templateId, String relatedRecordId) {
         try {
             Map<String, Object> mergeData = DocGenService.mergeTemplateForSignature(templateId, relatedRecordId);
-            String docXml = (String) mergeData.get('combinedDocumentXml');
-            if (String.isBlank(docXml)) {
-                docXml = (String) mergeData.get('documentXml');
-            }
             Map<String, String> pdfImageMap = (Map<String, String>) mergeData.get('pdfImageMap');
-            DocGenService.applyWatermarkOverride(templateId);
-            String html = DocGenHtmlRenderer.convertToHtml(docXml, pdfImageMap);
+            String html = renderMergedSignatureHtml(mergeData, templateId, pdfImageMap);
             html = injectPlacementSpans(html);
             return injectPreviewWatermarkOverlay(html, templateId);
         } catch (Exception e) {
@@ -1688,6 +1673,25 @@ public with sharing class DocGenSignatureSenderController {
 
     private static Blob buildDocumentPreviewPdfBlob(Id templateId, String relatedRecordId) {
         Map<String, Object> mergeData = DocGenService.mergeTemplateForSignature(templateId, relatedRecordId);
+        Map<String, String> pdfImageMap = (Map<String, String>) mergeData.get('pdfImageMap');
+        String html = renderMergedSignatureHtml(mergeData, templateId, pdfImageMap);
+        if (String.isBlank(html)) {
+            return null;
+        }
+        html = injectPlacementSpans(html);
+
+        return Test.isRunningTest() ? Blob.valueOf('test-preview-pdf') : Blob.toPdf(html);
+    }
+
+    @TestVisible
+    private static String renderMergedSignatureHtml(
+        Map<String, Object> mergeData,
+        Id templateId,
+        Map<String, String> imageMap
+    ) {
+        if (mergeData == null) {
+            return null;
+        }
         String docXml = (String) mergeData.get('combinedDocumentXml');
         if (String.isBlank(docXml)) {
             docXml = (String) mergeData.get('documentXml');
@@ -1696,12 +1700,12 @@ public with sharing class DocGenSignatureSenderController {
             return null;
         }
 
-        Map<String, String> pdfImageMap = (Map<String, String>) mergeData.get('pdfImageMap');
-        DocGenService.applyWatermarkOverride(templateId);
-        String html = DocGenHtmlRenderer.convertToHtml(docXml, pdfImageMap);
-        html = injectPlacementSpans(html);
+        if ((String) mergeData.get('templateType') == 'HTML') {
+            return docXml;
+        }
 
-        return Test.isRunningTest() ? Blob.valueOf('test-preview-pdf') : Blob.toPdf(html);
+        DocGenService.applyWatermarkOverride(templateId);
+        return DocGenHtmlRenderer.convertToHtml(docXml, imageMap);
     }
 
     public static String getSigningPagePath() {

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -534,31 +534,11 @@ public with sharing class DocGenSignatureSenderController {
             Map<String, Object> mergeData = DocGenService.mergeTemplateForSignature(templateId, relatedRecordId);
             Map<String, String> pdfImageMap = (Map<String, String>) mergeData.get('pdfImageMap');
 
-            // Build preview HTML with public URLs for images (not data URIs — keeps size small).
-            // Create ContentDistributions for each template image so guest browser can load them.
-            Map<String, String> previewImageMap = new Map<String, String>();
-            for (String relId : pdfImageMap.keySet()) {
-                String url = pdfImageMap.get(relId);
-                if (url != null && url.contains('/version/download/')) {
-                    String cvId = url.substringAfterLast('/');
-                    try {
-                        ContentDistribution dist = new ContentDistribution();
-                        dist.Name = 'sig_preview_' + relId;
-                        dist.ContentVersionId = cvId;
-                        dist.PreferencesAllowViewInBrowser = true;
-                        dist.PreferencesLinkLatestVersion = false;
-                        dist.PreferencesExpires = false;
-                        Database.insert(dist, AccessLevel.USER_MODE);
-                        dist = [SELECT ContentDownloadUrl FROM ContentDistribution WHERE Id = :dist.Id WITH USER_MODE];
-                        previewImageMap.put(relId, dist.ContentDownloadUrl);
-                    } catch (Exception e) {
-                        System.debug(
-                            LoggingLevel.WARN,
-                            'DocGen: Could not create public link for ' + relId + ': ' + e.getMessage()
-                        );
-                    }
-                }
+            String mergedHtml = (String) mergeData.get('combinedDocumentXml');
+            if (String.isBlank(mergedHtml)) {
+                mergedHtml = (String) mergeData.get('documentXml');
             }
+            Map<String, String> previewImageMap = buildSignaturePreviewImageMap(pdfImageMap, mergedHtml);
 
             // Render preview HTML using public URLs (small, no base64 bloat)
             String previewHtml = renderMergedSignatureHtml(mergeData, templateId, previewImageMap);
@@ -695,32 +675,11 @@ public with sharing class DocGenSignatureSenderController {
                 Map<String, String> pdfImageMap = (Map<String, String>) mergeData.get('pdfImageMap');
                 combinedPdfImageMap.putAll(pdfImageMap);
 
-                // Build preview HTML for this document
-                Map<String, String> previewImageMap = new Map<String, String>();
-                for (String relId : pdfImageMap.keySet()) {
-                    String url = pdfImageMap.get(relId);
-                    if (url != null && url.contains('/version/download/')) {
-                        String cvId = url.substringAfterLast('/');
-                        try {
-                            ContentDistribution dist = new ContentDistribution();
-                            dist.Name = 'sig_preview_' + relId;
-                            dist.ContentVersionId = cvId;
-                            dist.PreferencesAllowViewInBrowser = true;
-                            dist.PreferencesLinkLatestVersion = false;
-                            dist.PreferencesExpires = false;
-                            Database.insert(dist, AccessLevel.USER_MODE);
-                            dist = [
-                                SELECT ContentDownloadUrl
-                                FROM ContentDistribution
-                                WHERE Id = :dist.Id
-                                WITH USER_MODE
-                            ];
-                            previewImageMap.put(relId, dist.ContentDownloadUrl);
-                        } catch (Exception e) {
-                            System.debug(LoggingLevel.WARN, 'DocGen: Could not create public link for ' + relId);
-                        }
-                    }
+                String mergedHtml = (String) mergeData.get('combinedDocumentXml');
+                if (String.isBlank(mergedHtml)) {
+                    mergedHtml = (String) mergeData.get('documentXml');
                 }
+                Map<String, String> previewImageMap = buildSignaturePreviewImageMap(pdfImageMap, mergedHtml);
 
                 String docHtml = renderMergedSignatureHtml(mergeData, tid, previewImageMap);
                 docHtml = injectPlacementSpans(docHtml);
@@ -1701,11 +1660,136 @@ public with sharing class DocGenSignatureSenderController {
         }
 
         if ((String) mergeData.get('templateType') == 'HTML') {
-            return docXml;
+            return rewriteHtmlImageSources(docXml, imageMap);
         }
 
         DocGenService.applyWatermarkOverride(templateId);
         return DocGenHtmlRenderer.convertToHtml(docXml, imageMap);
+    }
+
+    @TestVisible
+    private static Map<String, String> buildSignaturePreviewImageMap(Map<String, String> pdfImageMap, String html) {
+        Map<String, String> previewImageMap = new Map<String, String>();
+        if (pdfImageMap != null) {
+            for (String relId : pdfImageMap.keySet()) {
+                addSignaturePreviewImage(previewImageMap, relId, pdfImageMap.get(relId));
+            }
+        }
+        for (String src : extractHtmlImageSources(html)) {
+            addSignaturePreviewImage(previewImageMap, src, src);
+        }
+        return previewImageMap;
+    }
+
+    private static void addSignaturePreviewImage(Map<String, String> previewImageMap, String key, String sourceUrl) {
+        String cvId = extractContentVersionIdFromImageUrl(sourceUrl);
+        if (String.isBlank(cvId)) {
+            return;
+        }
+        if (previewImageMap.containsKey(cvId)) {
+            if (String.isNotBlank(key)) {
+                previewImageMap.put(key, previewImageMap.get(cvId));
+            }
+            previewImageMap.put('/sfc/servlet.shepherd/version/download/' + cvId, previewImageMap.get(cvId));
+            return;
+        }
+        try {
+            ContentDistribution dist = new ContentDistribution();
+            dist.Name = 'sig_preview_' + (String.isBlank(key) ? cvId : key).left(80);
+            dist.ContentVersionId = cvId;
+            dist.PreferencesAllowViewInBrowser = true;
+            dist.PreferencesLinkLatestVersion = false;
+            dist.PreferencesExpires = false;
+            Database.insert(dist, AccessLevel.USER_MODE);
+            dist = [SELECT ContentDownloadUrl FROM ContentDistribution WHERE Id = :dist.Id WITH USER_MODE];
+            if (String.isNotBlank(key)) {
+                previewImageMap.put(key, dist.ContentDownloadUrl);
+            }
+            previewImageMap.put(cvId, dist.ContentDownloadUrl);
+            previewImageMap.put('/sfc/servlet.shepherd/version/download/' + cvId, dist.ContentDownloadUrl);
+        } catch (Exception e) {
+            System.debug(
+                LoggingLevel.WARN,
+                'DocGen: Could not create public signature preview image link for ' + cvId + ': ' + e.getMessage()
+            );
+        }
+    }
+
+    @TestVisible
+    private static String rewriteHtmlImageSources(String html, Map<String, String> imageMap) {
+        if (String.isBlank(html) || imageMap == null || imageMap.isEmpty()) {
+            return html;
+        }
+
+        String rewritten = html;
+        for (String src : extractHtmlImageSources(html)) {
+            String replacement = imageMap.get(src);
+            if (String.isBlank(replacement)) {
+                replacement = imageMap.get(extractContentVersionIdFromImageUrl(src));
+            }
+            if (String.isBlank(replacement)) {
+                continue;
+            }
+            rewritten = rewritten.replace('"' + src + '"', '"' + replacement.escapeHtml4() + '"');
+            rewritten = rewritten.replace('\'' + src + '\'', '\'' + replacement.escapeHtml4() + '\'');
+        }
+        return rewritten;
+    }
+
+    private static List<String> extractHtmlImageSources(String html) {
+        List<String> sources = new List<String>();
+        if (String.isBlank(html) || !html.containsIgnoreCase('<img')) {
+            return sources;
+        }
+        String lower = html.toLowerCase();
+        Integer cursor = 0;
+        while (cursor < html.length()) {
+            Integer imgStart = lower.indexOf('<img', cursor);
+            if (imgStart == -1) {
+                break;
+            }
+            Integer imgEnd = html.indexOf('>', imgStart);
+            if (imgEnd == -1) {
+                break;
+            }
+            Integer srcIdx = lower.indexOf('src=', imgStart);
+            if (srcIdx == -1 || srcIdx > imgEnd) {
+                cursor = imgEnd + 1;
+                continue;
+            }
+            srcIdx += 4;
+            while (srcIdx < imgEnd && html.substring(srcIdx, srcIdx + 1) == ' ') {
+                srcIdx++;
+            }
+            if (srcIdx >= imgEnd) {
+                cursor = imgEnd + 1;
+                continue;
+            }
+            String quoteChar = html.substring(srcIdx, srcIdx + 1);
+            if (quoteChar != '"' && quoteChar != '\'') {
+                cursor = imgEnd + 1;
+                continue;
+            }
+            Integer valueStart = srcIdx + 1;
+            Integer valueEnd = html.indexOf(quoteChar, valueStart);
+            if (valueEnd != -1 && valueEnd <= imgEnd) {
+                String src = html.substring(valueStart, valueEnd);
+                if (String.isNotBlank(src)) {
+                    sources.add(src.replace('&amp;', '&'));
+                }
+            }
+            cursor = imgEnd + 1;
+        }
+        return sources;
+    }
+
+    private static String extractContentVersionIdFromImageUrl(String url) {
+        if (String.isBlank(url) || !url.contains('/version/download/')) {
+            return null;
+        }
+        String cvId = url.substringAfterLast('/version/download/');
+        cvId = cvId.substringBefore('?').substringBefore('#');
+        return cvId.startsWith('068') ? cvId : null;
     }
 
     public static String getSigningPagePath() {

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -881,6 +881,69 @@ public with sharing class DocGenSignatureSenderController {
     }
 
     /**
+     * Milestone 1 — "send an already-generated document for signature".
+     *
+     * Creates a Template__c-null signature request bound directly to a
+     * pre-generated ContentVersion (Source_Document_Id__c). The signer URLs
+     * point at the new flat-PDF signing page (getSigningPdfPagePath), which
+     * renders the real PDF and captures a name+consent signature → audit +
+     * Status='Signed'. No template merge, no placements (Template__c is null,
+     * so createPlacementsForSigners early-returns cleanly), no DOCX-XML
+     * stamping.
+     *
+     * signersJson: [{signerName, signerEmail, roleName, contactId}, ...]
+     */
+    @AuraEnabled
+    public static List<SignerResult> createRequestFromContentVersion(
+        Id contentVersionId,
+        String relatedRecordId,
+        String signersJson,
+        String signingOrder,
+        String documentTitleFormat
+    ) {
+        if (contentVersionId == null) {
+            throw new AuraHandledException('A source document (ContentVersion Id) is required.');
+        }
+
+        // Parse signers JSON
+        List<Object> rawInputs = (List<Object>) JSON.deserializeUntyped(signersJson);
+        List<Map<String, Object>> signerInputs = new List<Map<String, Object>>();
+        for (Object item : rawInputs) {
+            signerInputs.add((Map<String, Object>) item);
+        }
+
+        // Create parent request bound to the pre-generated CV (no Template__c)
+        DocGen_Signature_Request__c req = new DocGen_Signature_Request__c();
+        req.Source_Document_Id__c = contentVersionId;
+        req.Template__c = null;
+        req.Related_Record_Id__c = relatedRecordId;
+        req.Status__c = 'Sent';
+        req.Signing_Order__c = String.isNotBlank(signingOrder) ? signingOrder : 'Parallel';
+        if (String.isNotBlank(documentTitleFormat)) {
+            req.Document_Title_Format__c = documentTitleFormat;
+        }
+        // Package-internal object — CRUD controlled by DocGen permission sets
+        // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Create").
+        DocGenFlsGuard.assertCreateable(
+            req,
+            new Set<String>{
+                'Source_Document_Id__c',
+                'Related_Record_Id__c',
+                'Status__c',
+                'Signing_Order__c',
+                'Document_Title_Format__c'
+            }
+        );
+        /* code-analyzer-suppress ApexFlsViolation */
+        Database.insert(req, AccessLevel.SYSTEM_MODE);
+
+        // Create signer records + send emails, pointing URLs at the flat-PDF page.
+        // templateId=null → createPlacementsForSigners is skipped (no tags to place).
+        String documentTitle = getDocumentTitle(contentVersionId);
+        return createSignersAndNotify(req.Id, null, documentTitle, signerInputs, true, getSigningPdfPagePath());
+    }
+
+    /**
      * Legacy single-signer request creation (backward compat).
      */
     @AuraEnabled
@@ -1302,6 +1365,26 @@ public with sharing class DocGenSignatureSenderController {
         List<Map<String, Object>> signerInputs,
         Boolean sendEmails
     ) {
+        // Default to the legacy DOCX/HTML signing page. The flat-PDF path
+        // (createRequestFromContentVersion) calls the pagePath overload below.
+        return createSignersAndNotify(
+            requestId,
+            templateId,
+            documentTitle,
+            signerInputs,
+            sendEmails,
+            getSigningPagePath()
+        );
+    }
+
+    private static List<SignerResult> createSignersAndNotify(
+        Id requestId,
+        Id templateId,
+        String documentTitle,
+        List<Map<String, Object>> signerInputs,
+        Boolean sendEmails,
+        String pagePath
+    ) {
         String siteUrl = getSiteBaseUrl();
         List<DocGen_Signer__c> signerRecords = new List<DocGen_Signer__c>();
         List<SignerResult> results = new List<SignerResult>();
@@ -1337,7 +1420,7 @@ public with sharing class DocGenSignatureSenderController {
             sr.signerName = signerName;
             sr.roleName = roleName;
             sr.signerEmail = signerEmail;
-            sr.signerUrl = siteUrl + getSigningPagePath() + '?token=' + token;
+            sr.signerUrl = siteUrl + pagePath + '?token=' + token;
             results.add(sr);
         }
 
@@ -1799,6 +1882,19 @@ public with sharing class DocGenSignatureSenderController {
             return '/apex/' + ns + '__DocGenSignature';
         }
         return '/apex/DocGenSignature';
+    }
+
+    /**
+     * Milestone 1 — path to the new flat-PDF signing page (DocGenSignaturePdf.page).
+     * Same namespace-prefix rule as getSigningPagePath; used only by the
+     * "send existing ContentVersion" path (createRequestFromContentVersion).
+     */
+    public static String getSigningPdfPagePath() {
+        String ns = DocGenSignatureSenderController.class.getName().substringBefore('.');
+        if (String.isNotBlank(ns) && ns != 'DocGenSignatureSenderController') {
+            return '/apex/' + ns + '__DocGenSignaturePdf';
+        }
+        return '/apex/DocGenSignaturePdf';
     }
 
     public static String getSiteBaseUrl() {

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -1008,9 +1008,23 @@ public with sharing class DocGenSignatureSenderController {
             );
         }
 
+        // Parse signer inputs once — reused for the preview render below and for
+        // signer creation at the end of this method.
+        List<Object> rawInputs = (List<Object>) JSON.deserializeUntyped(signersJson);
+        List<Map<String, Object>> signerInputs = new List<Map<String, Object>>();
+        for (Object item : rawInputs) {
+            signerInputs.add((Map<String, Object>) item);
+        }
+
         // Generate the viewing PDF from the SAME snapshot so the signer sees exactly
-        // what the completion finalizer will re-render.
-        Map<String, Object> gen = DocGenService.generatePdfBlobFromData(templateId, snapshot);
+        // what the completion finalizer will re-render. M3 — the viewing render gets a
+        // COPY of the snapshot with the pending {#Signatures} loop rows injected, so the
+        // signer previews the signature layout (invited names, "Pending" status). The
+        // stored snapshot (snapshotJson) stays record-data-only; the finalizer injects
+        // the signed rows at completion.
+        Map<String, Object> viewData = new Map<String, Object>(snapshot);
+        viewData.put('Signatures', DocGenSignatureService.buildPendingSignerLoopData(signerInputs));
+        Map<String, Object> gen = DocGenService.generatePdfBlobFromData(templateId, viewData);
         Blob viewingBlob = (Blob) gen.get('blob');
         String genTitle = (String) gen.get('title');
         String fileTitle = String.isNotBlank(genTitle) ? genTitle : tpl.Name;
@@ -1052,13 +1066,8 @@ public with sharing class DocGenSignatureSenderController {
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
         Database.insert(req, AccessLevel.SYSTEM_MODE);
 
-        // Create signer records + emails, URLs at the flat-PDF page.
+        // Create signer records + emails, URLs at the flat-PDF page (signerInputs parsed above).
         // templateId=null → skip {@Signature} placement creation (snapshot signing has no tags).
-        List<Object> rawInputs = (List<Object>) JSON.deserializeUntyped(signersJson);
-        List<Map<String, Object>> signerInputs = new List<Map<String, Object>>();
-        for (Object item : rawInputs) {
-            signerInputs.add((Map<String, Object>) item);
-        }
         return createSignersAndNotify(req.Id, null, fileTitle, signerInputs, true, getSigningPdfPagePath());
     }
 

--- a/force-app/main/default/classes/DocGenSignatureService.cls
+++ b/force-app/main/default/classes/DocGenSignatureService.cls
@@ -189,7 +189,11 @@ public without sharing class DocGenSignatureService {
             // Signature name + Role. The name the signer actually typed at signing
             // (Signature_Data__c) is their electronic signature; fall back to the
             // invited name (Signer_Name__c) when no typed value was captured.
-            String signatureName = String.isNotBlank(s.Signature_Data__c) ? s.Signature_Data__c : s.Signer_Name__c;
+            // Read Signature_Data__c defensively: this method is public/global and a
+            // caller may pass signers queried without that field — getPopulatedFieldsAsMap
+            // returns null rather than throwing SObjectException when it wasn't selected.
+            String typedSig = (String) s.getPopulatedFieldsAsMap().get('Signature_Data__c');
+            String signatureName = String.isNotBlank(typedSig) ? typedSig : s.Signer_Name__c;
             html += '<span style="font-weight:bold;font-size:10pt;">' + signatureName.escapeHtml4() + '</span>';
             html +=
                 ' <span style="background:' +
@@ -202,7 +206,7 @@ public without sharing class DocGenSignatureService {
             html += '<span style="color:#555;">' + s.Signer_Email__c.escapeHtml4() + '</span><br/>';
 
             // If the signer amended their name at signing, also show the invited name.
-            if (String.isNotBlank(s.Signature_Data__c) && s.Signature_Data__c != s.Signer_Name__c) {
+            if (String.isNotBlank(typedSig) && typedSig != s.Signer_Name__c) {
                 html += '<span style="color:#555;">Registered as: ' + s.Signer_Name__c.escapeHtml4() + '</span><br/>';
             }
 
@@ -253,6 +257,142 @@ public without sharing class DocGenSignatureService {
 
         html += '</table></div>';
         return html;
+    }
+
+    /**
+     * M3 — signature loop block.
+     *
+     * Builds the per-signer collection injected under the reserved {#Signatures}
+     * render-data key. A template author writes ONE signature layout wrapped in
+     * {#Signatures}...{/Signatures} (anywhere in the document) and it renders once
+     * per signer, for any signer count — no per-count templates and no orphan role
+     * tags. Each row exposes:
+     *   {Name}           the typed e-signature (Signature_Data__c) or, if none was
+     *                    captured, the invited name (Signer_Name__c)
+     *   {RegisteredName} the invited name
+     *   {Role}           Role_Name__c (defaults to "Signer")
+     *   {Email}          Signer_Email__c
+     *   {SignedDate}     formatted signed date from the audit record (blank if unsigned)
+     *   {Status}         Status__c
+     *
+     * Purely additive: this list is only present when the finalizer/sender inject it,
+     * so templates without a {#Signatures} block are unaffected and role-tag
+     * ({@Signature_Role}) stamping is untouched. This is the completion (signed)
+     * variant; buildPendingSignerLoopData builds the pre-signing preview variant.
+     */
+    public static List<Map<String, Object>> buildSignerLoopData(Id requestId) {
+        List<Map<String, Object>> rows = new List<Map<String, Object>>();
+
+        DocGenFlsGuard.assertAccessible(
+            DocGen_Signer__c.sObjectType,
+            new Set<String>{
+                'Signer_Name__c',
+                'Signature_Data__c',
+                'Signer_Email__c',
+                'Role_Name__c',
+                'Status__c',
+                'Signature_Request__c',
+                'Sort_Order__c'
+            }
+        );
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        List<DocGen_Signer__c> signers = [
+            SELECT Id, Signer_Name__c, Signature_Data__c, Signer_Email__c, Role_Name__c, Status__c
+            FROM DocGen_Signer__c
+            WHERE Signature_Request__c = :requestId
+            WITH SYSTEM_MODE
+            ORDER BY Sort_Order__c ASC
+        ];
+        if (signers.isEmpty()) {
+            return rows;
+        }
+
+        // Signed dates come from the audit records — the same source the certificate
+        // block uses (one audit per signer; keep the earliest signed timestamp).
+        Map<Id, Datetime> signedDates = new Map<Id, Datetime>();
+        try {
+            DocGenFlsGuard.assertAccessible(
+                DocGen_Signature_Audit__c.sObjectType,
+                new Set<String>{ 'Signer__c', 'Signed_Date__c', 'Signature_Request__c' }
+            );
+            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+            List<DocGen_Signature_Audit__c> audits = [
+                SELECT Signer__c, Signed_Date__c
+                FROM DocGen_Signature_Audit__c
+                WHERE Signature_Request__c = :requestId AND Signer__c != NULL
+                WITH SYSTEM_MODE
+            ];
+            for (DocGen_Signature_Audit__c a : audits) {
+                if (a.Signed_Date__c != null && !signedDates.containsKey(a.Signer__c)) {
+                    signedDates.put(a.Signer__c, a.Signed_Date__c);
+                }
+            }
+        } catch (Exception e) {
+            // Signed-date enrichment is best-effort — fall back to blank dates.
+        }
+
+        for (DocGen_Signer__c s : signers) {
+            rows.add(
+                buildSignerLoopRow(
+                    String.isNotBlank(s.Signature_Data__c) ? s.Signature_Data__c : s.Signer_Name__c,
+                    s.Signer_Name__c,
+                    s.Role_Name__c,
+                    s.Signer_Email__c,
+                    signedDates.get(s.Id),
+                    s.Status__c
+                )
+            );
+        }
+        return rows;
+    }
+
+    /**
+     * M3 — pre-signing preview variant of the {#Signatures} loop collection. Built
+     * from the raw signer inputs (signerName/signerEmail/roleName) at send-time,
+     * before any DocGen_Signer__c rows exist, so the viewing PDF shows the signature
+     * layout with the invited signers and a "Pending" status (no typed name/date yet).
+     */
+    public static List<Map<String, Object>> buildPendingSignerLoopData(List<Map<String, Object>> signerInputs) {
+        List<Map<String, Object>> rows = new List<Map<String, Object>>();
+        if (signerInputs == null) {
+            return rows;
+        }
+        for (Map<String, Object> input : signerInputs) {
+            String name = (String) input.get('signerName');
+            rows.add(
+                buildSignerLoopRow(
+                    name, // pending: no typed signature yet → show the invited name
+                    name,
+                    (String) input.get('roleName'),
+                    (String) input.get('signerEmail'),
+                    null,
+                    'Pending'
+                )
+            );
+        }
+        return rows;
+    }
+
+    /**
+     * Shared row shape for the {#Signatures} loop so the signed (completion) and
+     * pending (preview) variants always expose identical field keys.
+     */
+    private static Map<String, Object> buildSignerLoopRow(
+        String name,
+        String registeredName,
+        String role,
+        String email,
+        Datetime signedDate,
+        String status
+    ) {
+        return new Map<String, Object>{
+            'Name' => String.isNotBlank(name) ? name : '',
+            'RegisteredName' => String.isNotBlank(registeredName) ? registeredName : '',
+            'Role' => String.isNotBlank(role) ? role : 'Signer',
+            'Email' => String.isNotBlank(email) ? email : '',
+            'SignedDate' => signedDate != null ? signedDate.format('MMMM d, yyyy') : '',
+            'Status' => String.isNotBlank(status) ? status : ''
+        };
     }
 
     /**
@@ -846,6 +986,12 @@ public without sharing class DocGenSignatureService {
                     Map<String, Object> snap = (Map<String, Object>) JSON.deserializeUntyped(
                         req.Render_Data_Snapshot__c
                     );
+                    // M3 — inject the signed-signer loop collection under the reserved
+                    // {#Signatures} key. The stored snapshot stays record-data-only, so
+                    // these signed rows are re-derived fresh at finalize (keeps M2's
+                    // deterministic re-render). Templates without a {#Signatures} block
+                    // simply ignore the extra key.
+                    snap.put('Signatures', buildSignerLoopData(requestId));
                     pdfBlob = renderTemplateSignaturePdf(requestId, req.Template__c, null, snap);
                 } else if (String.isNotBlank(req.Template_Ids__c)) {
                     // Multi-template packet

--- a/force-app/main/default/classes/DocGenSignatureService.cls
+++ b/force-app/main/default/classes/DocGenSignatureService.cls
@@ -325,6 +325,23 @@ public without sharing class DocGenSignatureService {
         return new StampResult(documentXml, relsXml, contentTypesXml, signatureImageUrls);
     }
 
+    @TestVisible
+    private static String stampSignaturesInHtml(String html, List<DocGen_Signature_Placement__c> placements) {
+        if (String.isBlank(html) || placements == null || placements.isEmpty()) {
+            return html;
+        }
+
+        for (DocGen_Signature_Placement__c plc : placements) {
+            if (plc.Status__c != 'Signed' || String.isBlank(plc.Tag_Text__c))
+                continue;
+
+            if (html.contains(plc.Tag_Text__c)) {
+                html = html.replaceFirst(Pattern.quote(plc.Tag_Text__c), buildPlacementText(plc).escapeHtml4());
+            }
+        }
+        return html;
+    }
+
     /**
      * Builds the replacement text for a signed placement based on its type.
      */
@@ -929,6 +946,7 @@ public without sharing class DocGenSignatureService {
             String relsXml = (String) mergeData.get('relsXml');
             String contentTypesXml = (String) mergeData.get('contentTypesXml');
             Map<String, String> pdfImageMap = (Map<String, String>) mergeData.get('pdfImageMap');
+            String templateType = (String) mergeData.get('templateType');
 
             // Use pre-computed image map from request creation
             DocGenFlsGuard.assertAccessible(
@@ -1045,16 +1063,27 @@ public without sharing class DocGenSignatureService {
                 ORDER BY Document_Index__c ASC, Sequence_Order__c ASC
             ]; // NOPMD ApexCRUDViolation - package-internal custom object; CRUD controlled by DocGen permission sets
 
-            // Stamp typed-name signatures into merged XML
-            StampResult stamped = stampSignaturesInXml(documentXml, relsXml, contentTypesXml, signerImages, placements);
+            String html;
+            if (templateType == 'HTML') {
+                html = stampSignaturesInHtml(documentXml, placements);
+            } else {
+                // Stamp typed-name signatures into merged XML
+                StampResult stamped = stampSignaturesInXml(
+                    documentXml,
+                    relsXml,
+                    contentTypesXml,
+                    signerImages,
+                    placements
+                );
 
-            // Re-prime the HTML renderer context immediately before convertToHtml.
-            DocGenHtmlRenderer.stylesXml = (String) mergeData.get('stylesXml');
-            DocGenHtmlRenderer.numberingXml = (String) mergeData.get('numberingXml');
-            DocGenService.applyWatermarkOverride(templateId);
+                // Re-prime the HTML renderer context immediately before convertToHtml.
+                DocGenHtmlRenderer.stylesXml = (String) mergeData.get('stylesXml');
+                DocGenHtmlRenderer.numberingXml = (String) mergeData.get('numberingXml');
+                DocGenService.applyWatermarkOverride(templateId);
 
-            // Render PDF with template images only (no signature images needed)
-            String html = DocGenHtmlRenderer.convertToHtml(stamped.documentXml, pdfImageMap);
+                // Render PDF with template images only (no signature images needed)
+                html = DocGenHtmlRenderer.convertToHtml(stamped.documentXml, pdfImageMap);
+            }
 
             // Append verification certificate block before closing body
             DocGenFlsGuard.assertAccessible(
@@ -1201,6 +1230,7 @@ public without sharing class DocGenSignatureService {
                 String relsXml = (String) mergeData.get('relsXml');
                 String contentTypesXml = (String) mergeData.get('contentTypesXml');
                 Map<String, String> pdfImageMap = (Map<String, String>) mergeData.get('pdfImageMap');
+                String templateType = (String) mergeData.get('templateType');
                 pdfImageMap.putAll(cachedImageMap);
 
                 // Filter placements for this document
@@ -1210,19 +1240,24 @@ public without sharing class DocGenSignatureService {
                         docPlacements.add(p);
                 }
 
-                StampResult stamped = stampSignaturesInXml(
-                    documentXml,
-                    relsXml,
-                    contentTypesXml,
-                    signerImages,
-                    docPlacements
-                );
-                // Re-prime renderer context for this document (see #28 — statics don't survive
-                // intermediate calls reliably in async context).
-                DocGenHtmlRenderer.stylesXml = (String) mergeData.get('stylesXml');
-                DocGenHtmlRenderer.numberingXml = (String) mergeData.get('numberingXml');
-                DocGenService.applyWatermarkOverride(tid);
-                String docHtml = DocGenHtmlRenderer.convertToHtml(stamped.documentXml, pdfImageMap);
+                String docHtml;
+                if (templateType == 'HTML') {
+                    docHtml = stampSignaturesInHtml(documentXml, docPlacements);
+                } else {
+                    StampResult stamped = stampSignaturesInXml(
+                        documentXml,
+                        relsXml,
+                        contentTypesXml,
+                        signerImages,
+                        docPlacements
+                    );
+                    // Re-prime renderer context for this document (see #28 — statics don't survive
+                    // intermediate calls reliably in async context).
+                    DocGenHtmlRenderer.stylesXml = (String) mergeData.get('stylesXml');
+                    DocGenHtmlRenderer.numberingXml = (String) mergeData.get('numberingXml');
+                    DocGenService.applyWatermarkOverride(tid);
+                    docHtml = DocGenHtmlRenderer.convertToHtml(stamped.documentXml, pdfImageMap);
+                }
 
                 if (docIdx > 0) {
                     htmlParts.add('<div style="page-break-before:always"></div>');

--- a/force-app/main/default/classes/DocGenSignatureService.cls
+++ b/force-app/main/default/classes/DocGenSignatureService.cls
@@ -186,8 +186,11 @@ public without sharing class DocGenSignatureService {
 
             html += '<tr><td colspan="2" style="padding:8px 0 2px 0;border-bottom:1px solid #eee;">';
 
-            // Name + Role
-            html += '<span style="font-weight:bold;font-size:10pt;">' + s.Signer_Name__c.escapeHtml4() + '</span>';
+            // Signature name + Role. The name the signer actually typed at signing
+            // (Signature_Data__c) is their electronic signature; fall back to the
+            // invited name (Signer_Name__c) when no typed value was captured.
+            String signatureName = String.isNotBlank(s.Signature_Data__c) ? s.Signature_Data__c : s.Signer_Name__c;
+            html += '<span style="font-weight:bold;font-size:10pt;">' + signatureName.escapeHtml4() + '</span>';
             html +=
                 ' <span style="background:' +
                 brandColor +
@@ -197,6 +200,11 @@ public without sharing class DocGenSignatureService {
 
             // Email
             html += '<span style="color:#555;">' + s.Signer_Email__c.escapeHtml4() + '</span><br/>';
+
+            // If the signer amended their name at signing, also show the invited name.
+            if (String.isNotBlank(s.Signature_Data__c) && s.Signature_Data__c != s.Signer_Name__c) {
+                html += '<span style="color:#555;">Registered as: ' + s.Signer_Name__c.escapeHtml4() + '</span><br/>';
+            }
 
             // Audit details
             if (audit != null) {
@@ -801,11 +809,23 @@ public without sharing class DocGenSignatureService {
         public void execute(QueueableContext ctx) {
             DocGenFlsGuard.assertAccessible(
                 DocGen_Signature_Request__c.sObjectType,
-                new Set<String>{ 'Template__c', 'Template_Ids__c', 'Related_Record_Id__c', 'Document_Title_Format__c' }
+                new Set<String>{
+                    'Template__c',
+                    'Template_Ids__c',
+                    'Related_Record_Id__c',
+                    'Document_Title_Format__c',
+                    'Render_Data_Snapshot__c'
+                }
             );
             /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
             List<DocGen_Signature_Request__c> requests = [
-                SELECT Id, Template__c, Template_Ids__c, Related_Record_Id__c, Document_Title_Format__c
+                SELECT
+                    Id,
+                    Template__c,
+                    Template_Ids__c,
+                    Related_Record_Id__c,
+                    Document_Title_Format__c,
+                    Render_Data_Snapshot__c
                 FROM DocGen_Signature_Request__c
                 WHERE Id = :requestId
                 WITH SYSTEM_MODE
@@ -820,6 +840,13 @@ public without sharing class DocGenSignatureService {
                 Blob pdfBlob;
                 if (Test.isRunningTest()) {
                     pdfBlob = Blob.toPdf('<html><body><p>Test PDF - Signed</p></body></html>');
+                } else if (String.isNotBlank(req.Render_Data_Snapshot__c) && req.Template__c != null) {
+                    // M2 snapshot-backed: re-render the document from the send-time
+                    // data snapshot (not the live record), then append the cert page.
+                    Map<String, Object> snap = (Map<String, Object>) JSON.deserializeUntyped(
+                        req.Render_Data_Snapshot__c
+                    );
+                    pdfBlob = renderTemplateSignaturePdf(requestId, req.Template__c, null, snap);
                 } else if (String.isNotBlank(req.Template_Ids__c)) {
                     // Multi-template packet
                     pdfBlob = renderPacketSignaturePdf(requestId, req.Template_Ids__c, req.Related_Record_Id__c);
@@ -938,7 +965,25 @@ public without sharing class DocGenSignatureService {
          * No DOCX intermediate — pure XML → HTML → PDF.
          */
         private Blob renderTemplateSignaturePdf(Id reqId, Id templateId, String recordId) {
-            Map<String, Object> mergeData = DocGenService.mergeTemplateForSignature(templateId, recordId);
+            return renderTemplateSignaturePdf(reqId, templateId, recordId, null);
+        }
+
+        /**
+         * snapshotData != null (M2) → re-render from the send-time data snapshot
+         * instead of the live record, so the signed PDF matches what the signer
+         * reviewed even if the record changed after send. All downstream
+         * processing (image/style hydration, placement stamping, certificate-page
+         * injection, Blob.toPdf) is identical.
+         */
+        private Blob renderTemplateSignaturePdf(
+            Id reqId,
+            Id templateId,
+            String recordId,
+            Map<String, Object> snapshotData
+        ) {
+            Map<String, Object> mergeData = (snapshotData != null)
+                ? DocGenService.mergeTemplateForSignatureFromData(templateId, snapshotData)
+                : DocGenService.mergeTemplateForSignature(templateId, recordId);
             String documentXml = (String) mergeData.get('combinedDocumentXml');
             if (String.isBlank(documentXml)) {
                 documentXml = (String) mergeData.get('documentXml');
@@ -1090,6 +1135,7 @@ public without sharing class DocGenSignatureService {
                 DocGen_Signer__c.sObjectType,
                 new Set<String>{
                     'Signer_Name__c',
+                    'Signature_Data__c',
                     'Signer_Email__c',
                     'Role_Name__c',
                     'PIN_Verified_At__c',
@@ -1100,7 +1146,7 @@ public without sharing class DocGenSignatureService {
             );
             /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
             List<DocGen_Signer__c> fullSigners = [
-                SELECT Signer_Name__c, Signer_Email__c, Role_Name__c, PIN_Verified_At__c
+                SELECT Signer_Name__c, Signature_Data__c, Signer_Email__c, Role_Name__c, PIN_Verified_At__c
                 FROM DocGen_Signer__c
                 WHERE Signature_Request__c = :reqId AND Status__c = 'Signed'
                 WITH SYSTEM_MODE
@@ -1272,6 +1318,7 @@ public without sharing class DocGenSignatureService {
                 DocGen_Signer__c.sObjectType,
                 new Set<String>{
                     'Signer_Name__c',
+                    'Signature_Data__c',
                     'Signer_Email__c',
                     'Role_Name__c',
                     'PIN_Verified_At__c',
@@ -1282,7 +1329,7 @@ public without sharing class DocGenSignatureService {
             );
             /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
             List<DocGen_Signer__c> fullSigners = [
-                SELECT Signer_Name__c, Signer_Email__c, Role_Name__c, PIN_Verified_At__c
+                SELECT Signer_Name__c, Signature_Data__c, Signer_Email__c, Role_Name__c, PIN_Verified_At__c
                 FROM DocGen_Signer__c
                 WHERE Signature_Request__c = :reqId AND Status__c = 'Signed'
                 WITH SYSTEM_MODE

--- a/force-app/main/default/classes/DocGenSignatureTests.cls
+++ b/force-app/main/default/classes/DocGenSignatureTests.cls
@@ -5005,6 +5005,49 @@ private class DocGenSignatureTests {
         System.assertEquals('Full', seller.placementType, 'v3 type captured');
     }
 
+    @isTest
+    static void testGetTemplateSignaturePlacements_htmlTemplateBody() {
+        DocGen_Template__c tmpl = new DocGen_Template__c(
+            Name = 'HTML Signature Template',
+            Base_Object_API__c = 'Account',
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF'
+        );
+        insert tmpl;
+
+        String html =
+            '<table class="sig-table"><tr>' +
+            '<td><div class="sig-line">{@Signature_Customer}</div></td>' +
+            '<td><div class="sig-line">{@Signature_Customer:1:Date}</div></td>' +
+            '</tr></table>';
+        ContentVersion bodyCv = new ContentVersion(
+            Title = 'docgen_html_body_test',
+            PathOnClient = 'template.html',
+            VersionData = Blob.valueOf(html),
+            FirstPublishLocationId = tmpl.Id
+        );
+        insert bodyCv;
+
+        DocGen_Template_Version__c ver = new DocGen_Template_Version__c(
+            Template__c = tmpl.Id,
+            Is_Active__c = true,
+            Content_Version_Id__c = bodyCv.Id
+        );
+        Database.insert(ver, AccessLevel.SYSTEM_MODE);
+
+        Test.startTest();
+        List<DocGenSignatureSenderController.PlacementInfo> placements = DocGenSignatureSenderController.getTemplateSignaturePlacements(
+            tmpl.Id
+        );
+        Test.stopTest();
+
+        System.assertEquals(2, placements.size(), 'HTML body signature tags should be detected');
+        System.assertEquals('Customer', placements[0].role, 'Bare HTML role parsed');
+        System.assertEquals('Full', placements[0].placementType, 'Bare HTML tag defaults to Full');
+        System.assertEquals('Customer', placements[1].role, 'Date HTML role parsed');
+        System.assertEquals('Date', placements[1].placementType, 'Date HTML tag parsed');
+    }
+
     // =========================================================================
     // Trigger coverage: exercise all platform event trigger paths
     // =========================================================================

--- a/force-app/main/default/classes/DocGenSignatureTests.cls
+++ b/force-app/main/default/classes/DocGenSignatureTests.cls
@@ -5093,6 +5093,79 @@ private class DocGenSignatureTests {
     }
 
     @isTest
+    static void testRenderMergedSignatureHtml_htmlTemplateRewritesImageSources() {
+        String cvId = '068000000000001AAA';
+        String sourceUrl = '/sfc/servlet.shepherd/version/download/' + cvId;
+        String publicUrl = 'https://example.file.force.com/sfc/dist/version/download/' + cvId;
+        Map<String, Object> mergeData = new Map<String, Object>{
+            'templateType' => 'HTML',
+            'combinedDocumentXml' => '<html><body><img src="' +
+            sourceUrl +
+            '"/><div>{@Signature_Customer}</div></body></html>'
+        };
+
+        Test.startTest();
+        String html = DocGenSignatureSenderController.renderMergedSignatureHtml(
+            mergeData,
+            null,
+            new Map<String, String>{ sourceUrl => publicUrl }
+        );
+        Test.stopTest();
+
+        System.assert(html.contains('src="' + publicUrl + '"'), 'HTML signature preview should use public image URLs');
+        System.assert(!html.contains('src="' + sourceUrl + '"'), 'Raw /sfc image URL should be rewritten for preview');
+        System.assert(html.contains('{@Signature_Customer}'), 'Signature tag should remain for placement injection');
+    }
+
+    @isTest
+    static void testRewriteHtmlImageSources_matchesContentVersionIdFallback() {
+        String cvId = '068000000000002AAA';
+        String sourceUrl = '/sfc/servlet.shepherd/version/download/' + cvId + '?operationContext=S1';
+        String publicUrl = 'https://example.file.force.com/sfc/dist/version/download/' + cvId;
+
+        Test.startTest();
+        String html = DocGenSignatureSenderController.rewriteHtmlImageSources(
+            '<html><body><img alt="Logo" src="' + sourceUrl + '"/></body></html>',
+            new Map<String, String>{ cvId => publicUrl }
+        );
+        Test.stopTest();
+
+        System.assert(html.contains('src="' + publicUrl + '"'), 'CV-id keyed preview map should rewrite HTML img src');
+        System.assert(!html.contains(sourceUrl), 'Original private image src should not remain in signer preview HTML');
+    }
+
+    @isTest
+    static void testBuildSignaturePreviewImageMap_createsPublicLinkForHtmlImageSource() {
+        String tinyPngB64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+        ContentVersion imgCv = new ContentVersion(
+            Title = 'html_signature_logo',
+            PathOnClient = 'logo.png',
+            VersionData = EncodingUtil.base64Decode(tinyPngB64)
+        );
+        insert imgCv;
+        imgCv = [SELECT Id FROM ContentVersion WHERE Id = :imgCv.Id LIMIT 1];
+        String sourceUrl = '/sfc/servlet.shepherd/version/download/' + imgCv.Id;
+
+        Test.startTest();
+        Map<String, String> previewMap = DocGenSignatureSenderController.buildSignaturePreviewImageMap(
+            new Map<String, String>(),
+            '<html><body><img src="' + sourceUrl + '"/>{@Signature_Customer}</body></html>'
+        );
+        Test.stopTest();
+
+        System.assert(previewMap.containsKey(sourceUrl), 'HTML image source should be mapped for signer preview');
+        System.assert(
+            String.isNotBlank(previewMap.get(sourceUrl)) && previewMap.get(sourceUrl).startsWith('http'),
+            'Signer preview image should use a public ContentDistribution URL'
+        );
+        System.assertEquals(
+            1,
+            [SELECT COUNT() FROM ContentDistribution WHERE ContentVersionId = :imgCv.Id],
+            'A public distribution should be created for the HTML template image'
+        );
+    }
+
+    @isTest
     static void testGetDocumentPreviewPdfBase64_htmlTemplateDoesNotBlank() {
         Account acc = [SELECT Id FROM Account LIMIT 1];
         Id tmplId = createHtmlSignatureTemplate(

--- a/force-app/main/default/classes/DocGenSignatureTests.cls
+++ b/force-app/main/default/classes/DocGenSignatureTests.cls
@@ -68,6 +68,33 @@ private class DocGenSignatureTests {
         return [SELECT Id, Status__c, Secure_Token__c FROM DocGen_Signature_Request__c LIMIT 1];
     }
 
+    private static Id createHtmlSignatureTemplate(String bodyHtml) {
+        DocGen_Template__c tmpl = new DocGen_Template__c(
+            Name = 'HTML Signature Template ' + Datetime.now().getTime(),
+            Base_Object_API__c = 'Account',
+            Query_Config__c = 'Name, Industry',
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF'
+        );
+        insert tmpl;
+
+        ContentVersion bodyCv = new ContentVersion(
+            Title = tmpl.Name + ' Body',
+            PathOnClient = 'template.html',
+            VersionData = Blob.valueOf(bodyHtml),
+            FirstPublishLocationId = tmpl.Id
+        );
+        insert bodyCv;
+        bodyCv = [SELECT Id FROM ContentVersion WHERE Id = :bodyCv.Id LIMIT 1];
+
+        insert new DocGen_Template_Version__c(
+            Template__c = tmpl.Id,
+            Is_Active__c = true,
+            Content_Version_Id__c = bodyCv.Id
+        );
+        return tmpl.Id;
+    }
+
     // =========================================================================
     // Token Validation
     // =========================================================================
@@ -5007,37 +5034,16 @@ private class DocGenSignatureTests {
 
     @isTest
     static void testGetTemplateSignaturePlacements_htmlTemplateBody() {
-        DocGen_Template__c tmpl = new DocGen_Template__c(
-            Name = 'HTML Signature Template',
-            Base_Object_API__c = 'Account',
-            Type__c = 'HTML',
-            Output_Format__c = 'PDF'
-        );
-        insert tmpl;
-
         String html =
             '<table class="sig-table"><tr>' +
             '<td><div class="sig-line">{@Signature_Customer}</div></td>' +
             '<td><div class="sig-line">{@Signature_Customer:1:Date}</div></td>' +
             '</tr></table>';
-        ContentVersion bodyCv = new ContentVersion(
-            Title = 'docgen_html_body_test',
-            PathOnClient = 'template.html',
-            VersionData = Blob.valueOf(html),
-            FirstPublishLocationId = tmpl.Id
-        );
-        insert bodyCv;
-
-        DocGen_Template_Version__c ver = new DocGen_Template_Version__c(
-            Template__c = tmpl.Id,
-            Is_Active__c = true,
-            Content_Version_Id__c = bodyCv.Id
-        );
-        Database.insert(ver, AccessLevel.SYSTEM_MODE);
+        Id tmplId = createHtmlSignatureTemplate(html);
 
         Test.startTest();
         List<DocGenSignatureSenderController.PlacementInfo> placements = DocGenSignatureSenderController.getTemplateSignaturePlacements(
-            tmpl.Id
+            tmplId
         );
         Test.stopTest();
 
@@ -5046,6 +5052,89 @@ private class DocGenSignatureTests {
         System.assertEquals('Full', placements[0].placementType, 'Bare HTML tag defaults to Full');
         System.assertEquals('Customer', placements[1].role, 'Date HTML role parsed');
         System.assertEquals('Date', placements[1].placementType, 'Date HTML tag parsed');
+    }
+
+    @isTest
+    static void testMergeTemplateForSignature_htmlTemplateReturnsReadyHtml() {
+        Account acc = [SELECT Id, Name FROM Account LIMIT 1];
+        Id tmplId = createHtmlSignatureTemplate(
+            '<html><body><h1>{Name}</h1><div>{@Signature_Customer}</div></body></html>'
+        );
+
+        Test.startTest();
+        Map<String, Object> result = DocGenService.mergeTemplateForSignature(tmplId, acc.Id);
+        Test.stopTest();
+
+        System.assertEquals('HTML', result.get('templateType'), 'Signature merge should retain HTML template type');
+        String combinedHtml = (String) result.get('combinedDocumentXml');
+        System.assertNotEquals(null, combinedHtml, 'HTML signature merge should return rendered HTML');
+        System.assert(combinedHtml.contains('<html'), 'HTML signature merge should not be converted as DOCX XML');
+        System.assert(combinedHtml.contains(acc.Name), 'HTML signature merge should resolve merge fields');
+        System.assert(
+            combinedHtml.contains('{@Signature_Customer}'),
+            'HTML signature merge should preserve signature tags for preview/final stamping'
+        );
+    }
+
+    @isTest
+    static void testGetDocumentPreviewHtml_htmlTemplateDoesNotBlank() {
+        Account acc = [SELECT Id, Name FROM Account LIMIT 1];
+        Id tmplId = createHtmlSignatureTemplate(
+            '<html><body><p>Agreement for {Name}</p><div>{@Signature_Customer}</div></body></html>'
+        );
+
+        Test.startTest();
+        String html = DocGenSignatureSenderController.getDocumentPreviewHtml(tmplId, acc.Id);
+        Test.stopTest();
+
+        System.assertNotEquals(null, html, 'HTML signature preview should not render blank');
+        System.assert(html.contains(acc.Name), 'HTML signature preview should contain merged record data');
+        System.assert(html.contains('docgen-sig'), 'HTML signature preview should inject placement spans');
+    }
+
+    @isTest
+    static void testGetDocumentPreviewPdfBase64_htmlTemplateDoesNotBlank() {
+        Account acc = [SELECT Id FROM Account LIMIT 1];
+        Id tmplId = createHtmlSignatureTemplate(
+            '<html><body><p>Preview PDF</p><div>{@Signature_Customer:1:Date}</div></body></html>'
+        );
+
+        Test.startTest();
+        String pdfBase64 = DocGenSignatureSenderController.getDocumentPreviewPdfBase64(tmplId, acc.Id);
+        Test.stopTest();
+
+        System.assertEquals(
+            EncodingUtil.base64Encode(Blob.valueOf('test-preview-pdf')),
+            pdfBase64,
+            'HTML signature PDF preview should return a base64 PDF payload'
+        );
+    }
+
+    @isTest
+    static void testStampSignaturesInHtml_escapesSignedValue() {
+        DocGen_Signer__c signer = getTestSigner();
+        DocGen_Signature_Request__c req = getTestRequest();
+        DocGen_Signature_Placement__c plc = new DocGen_Signature_Placement__c(
+            Signer__c = signer.Id,
+            Signature_Request__c = req.Id,
+            Placement_Type__c = 'Full',
+            Status__c = 'Signed',
+            Signed_Value__c = 'Jane <Doe>',
+            Signed_At__c = Datetime.newInstance(2026, 6, 11, 10, 0, 0),
+            Tag_Text__c = '{@Signature_Customer}'
+        );
+        insert plc;
+
+        Test.startTest();
+        String html = DocGenSignatureService.stampSignaturesInHtml(
+            '<html><body><div>{@Signature_Customer}</div></body></html>',
+            new List<DocGen_Signature_Placement__c>{ plc }
+        );
+        Test.stopTest();
+
+        System.assert(!html.contains('{@Signature_Customer}'), 'HTML signature tag should be replaced');
+        System.assert(html.contains('Jane &lt;Doe&gt;'), 'Signed value should be HTML escaped');
+        System.assert(html.contains('Electronically signed by'), 'Full placement should include legal text');
     }
 
     // =========================================================================

--- a/force-app/main/default/objects/DocGen_Signature_Request__c/fields/Render_Data_Snapshot__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Signature_Request__c/fields/Render_Data_Snapshot__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Render_Data_Snapshot__c</fullName>
+    <description
+    >JSON snapshot of the template merge data captured at send-time (DocGenDataRetriever.getRecordData). When present, the completion finalizer re-renders the document from this snapshot instead of the live record, so the signed PDF matches what the signer reviewed even if the source record is edited before signing.</description>
+    <externalId>false</externalId>
+    <label>Render Data Snapshot</label>
+    <length>131072</length>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
+</CustomField>

--- a/force-app/main/default/pages/DocGenSignaturePdf.page
+++ b/force-app/main/default/pages/DocGenSignaturePdf.page
@@ -329,8 +329,20 @@
                 }
 
                 /* ===== PDF VIEW LAYOUT ===== */
+                /* .page-wrapper is a centered flex column (align-items: center), so its
+                   state children shrink to content width. The PDF state must stretch
+                   full-width and re-center its child, or .pdf-wrapper's max-width below
+                   collapses to the shrink-to-fit content width. */
+                #state-pdf {
+                    width: 100%;
+                    display: flex;
+                    justify-content: center;
+                }
                 .pdf-wrapper {
-                    max-width: 900px;
+                    /* Wide enough to inspect a full-size document on desktop; still
+                       fluid (width:100%) so it fills smaller screens, and the
+                       max-width: 640px media query below governs phones. */
+                    max-width: 1600px;
                     width: 100%;
                     display: flex;
                     flex-direction: column;
@@ -751,7 +763,10 @@
                             var iframe = document.createElement('iframe');
                             iframe.title = 'Document to sign';
                             iframe.setAttribute('type', 'application/pdf');
-                            iframe.src = activeObjectUrl;
+                            // #view=FitH asks the native PDF viewer to fit the page to the
+                            // width of the (now full-width) viewer box so the document is
+                            // large and easy to inspect, rather than a centered column.
+                            iframe.src = activeObjectUrl + '#view=FitH';
                             containerEl.appendChild(iframe);
                         }
                     };

--- a/force-app/main/default/pages/DocGenSignaturePdf.page
+++ b/force-app/main/default/pages/DocGenSignaturePdf.page
@@ -1,0 +1,1143 @@
+<!-- CxSAST: without sharing required for guest user signing context; access gated by cryptographic token -->
+<apex:page
+    controller="DocGenSignatureController"
+    showHeader="false"
+    sidebar="false"
+    standardStylesheets="false"
+    applyBodyTag="false"
+    applyHtmlTag="false"
+    docType="html-5.0"
+>
+    <html lang="en">
+        <head>
+            <meta charset="utf-8" />
+            <!-- Allow pinch-to-zoom so signers can inspect images, QR codes, and fine print
+         at full fidelity on mobile instead of us shrinking the document to fit. -->
+            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+            <title>Document Signature</title>
+            <apex:slds />
+
+            <style>
+                * {
+                    box-sizing: border-box;
+                }
+                body {
+                    background-color: #f3f2f2;
+                    font-family:
+                        'Salesforce Sans',
+                        -apple-system,
+                        BlinkMacSystemFont,
+                        'Segoe UI',
+                        Roboto,
+                        sans-serif;
+                    margin: 0;
+                    padding: 0;
+                    color: #181818;
+                }
+                .page-wrapper {
+                    min-height: 100vh;
+                    display: flex;
+                    flex-direction: column;
+                    align-items: center;
+                    justify-content: center;
+                    padding: 1rem;
+                }
+
+                /* Card */
+                .sig-card {
+                    max-width: 640px;
+                    width: 100%;
+                    background: #fff;
+                    border-radius: 8px;
+                    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+                    padding: 2rem;
+                }
+                .sig-card h2 {
+                    font-size: 1.25rem;
+                    font-weight: 700;
+                    margin: 0 0 0.25rem 0;
+                }
+                .sig-card .subtitle {
+                    font-size: 0.875rem;
+                    color: #706e6b;
+                    margin: 0 0 1.25rem 0;
+                }
+
+                /* Form inputs */
+                .form-group {
+                    margin-bottom: 1rem;
+                }
+                .form-group label {
+                    display: block;
+                    font-size: 0.8125rem;
+                    font-weight: 600;
+                    color: #3e3e3c;
+                    margin-bottom: 0.25rem;
+                }
+                .form-input {
+                    width: 100%;
+                    padding: 0.5rem 0.75rem;
+                    border: 1px solid #dddbda;
+                    border-radius: 4px;
+                    font-size: 0.9375rem;
+                    font-family: inherit;
+                    color: #181818;
+                    transition: border-color 0.15s;
+                }
+                .form-input:focus {
+                    outline: none;
+                    border-color: #0176d3;
+                    box-shadow: 0 0 0 1px #0176d3;
+                }
+                .form-input::placeholder {
+                    color: #b0adab;
+                }
+
+                /* PIN */
+                .pin-input {
+                    font-size: 1.5rem;
+                    letter-spacing: 8px;
+                    text-align: center;
+                    font-family: monospace;
+                    max-width: 200px;
+                }
+                .pin-row {
+                    display: flex;
+                    align-items: center;
+                    gap: 0.75rem;
+                }
+
+                /* Consent */
+                .consent-row {
+                    display: flex;
+                    align-items: flex-start;
+                    gap: 0.5rem;
+                    margin: 1rem 0;
+                    padding: 1rem;
+                    background: #f8f9fa;
+                    border-radius: 4px;
+                    border: 1px solid #e5e5e5;
+                }
+                .consent-row input[type='checkbox'] {
+                    margin-top: 0.2rem;
+                    width: 18px;
+                    height: 18px;
+                    flex-shrink: 0;
+                }
+                .consent-row label {
+                    font-size: 0.8125rem;
+                    color: #3e3e3c;
+                    line-height: 1.4;
+                    cursor: pointer;
+                }
+
+                /* Buttons */
+                .btn-row {
+                    display: flex;
+                    gap: 0.5rem;
+                    justify-content: flex-end;
+                    margin-top: 1rem;
+                }
+                .btn {
+                    display: inline-flex;
+                    align-items: center;
+                    justify-content: center;
+                    padding: 0.5rem 1.25rem;
+                    border-radius: 4px;
+                    font-size: 0.875rem;
+                    font-weight: 600;
+                    border: 1px solid #dddbda;
+                    background: #fff;
+                    color: #181818;
+                    cursor: pointer;
+                }
+                .btn:hover {
+                    background: #f3f2f2;
+                }
+                .btn-brand {
+                    background: #0176d3;
+                    color: #fff;
+                    border-color: #0176d3;
+                }
+                .btn-brand:hover {
+                    background: #014486;
+                }
+                .btn-brand:disabled {
+                    background: #c9c7c5;
+                    border-color: #c9c7c5;
+                    cursor: not-allowed;
+                }
+                .btn-destructive {
+                    background: #fff;
+                    color: #ea001e;
+                    border-color: #ea001e;
+                }
+                .btn-destructive:hover {
+                    background: #fef0ef;
+                }
+
+                /* Messages */
+                .msg {
+                    padding: 0.75rem 1rem;
+                    border-radius: 4px;
+                    font-size: 0.8125rem;
+                    margin-bottom: 1rem;
+                }
+                .msg-info {
+                    background: #eef4fb;
+                    border: 1px solid #0176d3;
+                    color: #014486;
+                }
+                .msg-success {
+                    background: #e8f5e1;
+                    border: 1px solid #2e844a;
+                    color: #2e844a;
+                }
+                .msg-error {
+                    background: #fef0ef;
+                    border: 1px solid #ea001e;
+                    color: #ea001e;
+                }
+
+                /* Role Badge */
+                .role-badge {
+                    display: inline-block;
+                    background: #0176d3;
+                    color: #fff;
+                    font-size: 0.75rem;
+                    font-weight: 700;
+                    padding: 0.2rem 0.6rem;
+                    border-radius: 12px;
+                    margin-left: 0.5rem;
+                    vertical-align: middle;
+                }
+
+                /* Resend */
+                .resend-link {
+                    color: #0176d3;
+                    cursor: pointer;
+                    text-decoration: underline;
+                    font-size: 0.8125rem;
+                }
+                .resend-link:hover {
+                    color: #014486;
+                }
+                .resend-link.disabled {
+                    color: #b0adab;
+                    cursor: not-allowed;
+                    text-decoration: none;
+                }
+
+                /* State cards */
+                .error-card,
+                .success-card,
+                .waiting-card,
+                .processing-card {
+                    max-width: 480px;
+                    width: 100%;
+                    background: #fff;
+                    border-radius: 8px;
+                    padding: 2rem;
+                    text-align: center;
+                }
+                .error-card {
+                    border: 1px solid #fca5a5;
+                }
+                .error-icon {
+                    font-size: 3rem;
+                    color: #ea001e;
+                    margin-bottom: 0.5rem;
+                }
+                .error-card h2 {
+                    font-size: 1.125rem;
+                    font-weight: 700;
+                    margin: 0 0 0.5rem 0;
+                    color: #ea001e;
+                }
+                .error-card p {
+                    color: #706e6b;
+                    margin: 0;
+                }
+                .success-card {
+                    border: 1px solid #91db8b;
+                }
+                .success-icon {
+                    font-size: 3rem;
+                    color: #2e844a;
+                    margin-bottom: 0.5rem;
+                }
+                .success-card h2 {
+                    font-size: 1.125rem;
+                    font-weight: 700;
+                    margin: 0 0 0.5rem 0;
+                    color: #2e844a;
+                }
+                .success-card p {
+                    color: #706e6b;
+                    margin: 0;
+                }
+                .waiting-card {
+                    border: 1px solid #ffd27a;
+                }
+                .waiting-icon {
+                    font-size: 3rem;
+                    color: #fe9339;
+                    margin-bottom: 0.5rem;
+                }
+                .waiting-card h2 {
+                    font-size: 1.125rem;
+                    font-weight: 700;
+                    margin: 0 0 0.5rem 0;
+                    color: #fe9339;
+                }
+                .waiting-card p {
+                    color: #706e6b;
+                    margin: 0;
+                }
+                .processing-card {
+                    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+                }
+                .processing-card h2 {
+                    font-size: 1.125rem;
+                    font-weight: 700;
+                    margin: 0.75rem 0 0.5rem 0;
+                }
+                .processing-card p {
+                    color: #706e6b;
+                    margin: 0;
+                }
+
+                /* Spinner */
+                .spinner-container {
+                    display: flex;
+                    justify-content: center;
+                    align-items: center;
+                    padding: 2rem;
+                }
+                .spinner {
+                    width: 40px;
+                    height: 40px;
+                    border: 4px solid #dddbda;
+                    border-top-color: #0176d3;
+                    border-radius: 50%;
+                    animation: spin 0.8s linear infinite;
+                }
+                @keyframes spin {
+                    to {
+                        transform: rotate(360deg);
+                    }
+                }
+
+                /* ===== PDF VIEW LAYOUT ===== */
+                .pdf-wrapper {
+                    max-width: 900px;
+                    width: 100%;
+                    display: flex;
+                    flex-direction: column;
+                    height: calc(100vh - 2rem);
+                }
+
+                /* Top bar */
+                .pdf-header {
+                    background: #fff;
+                    padding: 1rem 1.5rem;
+                    border-radius: 8px 8px 0 0;
+                    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+                    display: flex;
+                    align-items: center;
+                    gap: 1rem;
+                    flex-shrink: 0;
+                }
+                .pdf-header h2 {
+                    font-size: 1rem;
+                    font-weight: 700;
+                    margin: 0;
+                    flex: 1;
+                    min-width: 0;
+                    white-space: nowrap;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                }
+
+                /* Document viewer area — DocGenPdfViewer.render() owns the inside of this box */
+                .pdf-viewer {
+                    flex: 1;
+                    overflow: hidden;
+                    background: #525659;
+                    border-left: 1px solid #e5e5e5;
+                    border-right: 1px solid #e5e5e5;
+                    min-height: 360px;
+                    position: relative;
+                }
+                /* The viewer module renders an iframe (native impl) filling the area. */
+                .pdf-viewer iframe,
+                .pdf-viewer embed,
+                .pdf-viewer object,
+                .pdf-viewer canvas {
+                    width: 100%;
+                    height: 100%;
+                    border: 0;
+                    display: block;
+                }
+                .pdf-viewer .spinner-container {
+                    position: absolute;
+                    inset: 0;
+                }
+
+                /* Bottom action bar with the Sign button */
+                .pdf-action-bar {
+                    background: #fff;
+                    padding: 1rem 1.5rem;
+                    border-radius: 0 0 8px 8px;
+                    box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.08);
+                    flex-shrink: 0;
+                    display: flex;
+                    align-items: center;
+                    gap: 1rem;
+                    flex-wrap: wrap;
+                }
+                .pdf-action-bar .signer-context {
+                    flex: 1;
+                    min-width: 0;
+                    font-size: 0.875rem;
+                    color: #706e6b;
+                }
+                .pdf-action-bar .signer-context strong {
+                    color: #181818;
+                }
+                .btn-lg {
+                    padding: 0.65rem 1.75rem;
+                    font-size: 0.9375rem;
+                }
+
+                /* ===== SLDS-STYLE MODAL ===== */
+                .modal-backdrop {
+                    position: fixed;
+                    inset: 0;
+                    background: rgba(0, 0, 0, 0.5);
+                    z-index: 9000;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    padding: 1rem;
+                }
+                .modal-dialog {
+                    background: #fff;
+                    border-radius: 8px;
+                    max-width: 480px;
+                    width: 100%;
+                    max-height: calc(100vh - 2rem);
+                    overflow-y: auto;
+                    box-shadow: 0 2px 16px rgba(0, 0, 0, 0.25);
+                }
+                .modal-header {
+                    padding: 1.25rem 1.5rem;
+                    border-bottom: 1px solid #e5e5e5;
+                    position: relative;
+                }
+                .modal-header h2 {
+                    font-size: 1.125rem;
+                    font-weight: 700;
+                    margin: 0;
+                }
+                .modal-header .modal-subtitle {
+                    font-size: 0.8125rem;
+                    color: #706e6b;
+                    margin: 0.25rem 0 0 0;
+                }
+                .modal-close {
+                    position: absolute;
+                    top: 1rem;
+                    right: 1rem;
+                    background: none;
+                    border: none;
+                    font-size: 1.25rem;
+                    line-height: 1;
+                    color: #706e6b;
+                    cursor: pointer;
+                    padding: 0.25rem;
+                }
+                .modal-close:hover {
+                    color: #181818;
+                }
+                .modal-body {
+                    padding: 1.5rem;
+                }
+                .modal-footer {
+                    padding: 1rem 1.5rem;
+                    border-top: 1px solid #e5e5e5;
+                    display: flex;
+                    justify-content: flex-end;
+                    gap: 0.5rem;
+                }
+
+                @media (max-width: 640px) {
+                    .page-wrapper {
+                        padding: 0;
+                        justify-content: flex-start;
+                    }
+                    .pdf-wrapper {
+                        height: auto;
+                        min-height: 100vh;
+                        border-radius: 0;
+                    }
+                    .pdf-viewer {
+                        min-height: 60vh;
+                    }
+                    .pdf-header {
+                        padding: 0.75rem 1rem;
+                    }
+                    .pdf-action-bar {
+                        padding: 0.75rem 1rem;
+                        position: sticky;
+                        bottom: 0;
+                        z-index: 100;
+                        border-top: 3px solid #0176d3;
+                    }
+                    .sig-card {
+                        padding: 1.25rem;
+                    }
+                }
+            </style>
+        </head>
+        <body>
+            <div class="page-wrapper" id="page-wrapper">
+                <!-- STATE: Loading -->
+                <div id="state-loading">
+                    <div class="spinner-container"><div class="spinner"></div></div>
+                </div>
+
+                <!-- STATE: Error -->
+                <div id="state-error" style="display: none">
+                    <div class="error-card">
+                        <div class="error-icon">&#9888;</div>
+                        <h2>Signature Error</h2>
+                        <p id="error-message"></p>
+                    </div>
+                </div>
+
+                <!-- STATE: Email Verification (PIN) -->
+                <div id="state-verify" style="display: none">
+                    <div class="sig-card">
+                        <h2 id="verify-doc-title"></h2>
+                        <p class="subtitle">Verify your email to continue</p>
+                        <div id="verify-msg"></div>
+                        <div class="form-group">
+                            <label for="verify-email">Email Address</label>
+                            <input
+                                id="verify-email"
+                                type="email"
+                                class="form-input"
+                                placeholder="Enter your email address"
+                            />
+                        </div>
+                        <div id="pin-section" style="display: none">
+                            <div class="form-group">
+                                <label for="verify-pin">Verification Code</label>
+                                <div class="pin-row">
+                                    <input
+                                        id="verify-pin"
+                                        type="text"
+                                        class="form-input pin-input"
+                                        maxlength="6"
+                                        placeholder="000000"
+                                        inputmode="numeric"
+                                        pattern="[0-9]{6}"
+                                    />
+                                    <button id="btn-verify-pin" class="btn btn-brand" type="button">Verify</button>
+                                </div>
+                            </div>
+                            <p id="resend-link" class="resend-link disabled">Resend code</p>
+                        </div>
+                        <div class="btn-row">
+                            <button id="btn-send-pin" class="btn btn-brand" type="button">
+                                Send Verification Code
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- STATE: PDF View + Sign button -->
+                <div id="state-pdf" style="display: none">
+                    <div class="pdf-wrapper">
+                        <div class="pdf-header">
+                            <h2 id="pdf-doc-title">Document Signature</h2>
+                            <span id="pdf-role-badge" class="role-badge" style="display: none"></span>
+                        </div>
+
+                        <!-- DocGenPdfViewer.render() renders into this container. -->
+                        <div class="pdf-viewer" id="pdf-viewer-container">
+                            <div class="spinner-container"><div class="spinner"></div></div>
+                        </div>
+
+                        <div class="pdf-action-bar">
+                            <div class="signer-context">
+                                Signing as: <strong id="pdf-signer-name"></strong>
+                                <span id="pdf-progress-info" style="display: none"></span>
+                            </div>
+                            <button id="btn-decline" class="btn btn-destructive" type="button">Decline</button>
+                            <button id="btn-open-sign" class="btn btn-brand btn-lg" type="button">Sign Document</button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- STATE: Processing -->
+                <div id="state-processing" style="display: none">
+                    <div class="processing-card">
+                        <div class="spinner-container" style="padding: 0.5rem"><div class="spinner"></div></div>
+                        <h2>Processing Signature</h2>
+                        <p id="processing-status">Finalizing your signature...</p>
+                    </div>
+                </div>
+
+                <!-- STATE: Success -->
+                <div id="state-success" style="display: none">
+                    <div class="success-card">
+                        <div class="success-icon">&#10003;</div>
+                        <h2>Signature Complete</h2>
+                        <p>Your document has been signed and processed securely. You may close this window.</p>
+                    </div>
+                </div>
+
+                <!-- STATE: Waiting -->
+                <div id="state-waiting" style="display: none">
+                    <div class="waiting-card">
+                        <div class="waiting-icon">&#10003;</div>
+                        <h2>Signature Recorded</h2>
+                        <p id="waiting-message">
+                            Your signature has been recorded. Waiting for other signers to complete.
+                        </p>
+                    </div>
+                </div>
+
+                <!-- STATE: Decline Confirmation -->
+                <div id="state-decline" style="display: none">
+                    <div class="sig-card" style="max-width: 480px">
+                        <h2 style="color: #ea001e">Decline Signature</h2>
+                        <p class="subtitle">Are you sure you want to decline this signature request?</p>
+                        <div class="form-group">
+                            <label for="decline-reason">Reason (optional)</label>
+                            <textarea
+                                id="decline-reason"
+                                class="form-input"
+                                rows="3"
+                                placeholder="Let the sender know why you're declining..."
+                            ></textarea>
+                        </div>
+                        <div class="btn-row">
+                            <button id="btn-decline-cancel" class="btn" type="button">Go Back</button>
+                            <button id="btn-decline-confirm" class="btn btn-destructive" type="button">
+                                Confirm Decline
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- ===== SIGNING MODAL (button-launched) ===== -->
+            <div id="sign-modal" class="modal-backdrop" style="display: none" role="dialog" aria-modal="true">
+                <div class="modal-dialog">
+                    <div class="modal-header">
+                        <h2>Sign Document</h2>
+                        <p class="modal-subtitle">Confirm your name and consent to sign electronically.</p>
+                        <button id="modal-close" class="modal-close" type="button" aria-label="Close">&#10005;</button>
+                    </div>
+                    <div class="modal-body">
+                        <div id="modal-msg"></div>
+                        <div class="form-group">
+                            <label for="modal-typed-name">Type your full name to sign</label>
+                            <input
+                                id="modal-typed-name"
+                                type="text"
+                                class="form-input"
+                                placeholder="e.g., John Smith"
+                                autocomplete="name"
+                            />
+                        </div>
+                        <div class="consent-row" style="margin: 0">
+                            <input id="modal-consent-checkbox" type="checkbox" />
+                            <label for="modal-consent-checkbox">
+                                I agree to sign this document electronically. I understand that my typed name
+                                constitutes my legal electronic signature, and I consent to conducting this transaction
+                                electronically.
+                            </label>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button id="modal-cancel" class="btn" type="button">Cancel</button>
+                        <button id="btn-sign-submit" class="btn btn-brand" type="button" disabled="disabled">
+                            Sign
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <!--
+                ============================================================================
+                DocGenPdfViewer — swappable PDF render module
+                ============================================================================
+                PUBLIC CONTRACT (the ONLY surface the rest of the page may depend on):
+
+                    DocGenPdfViewer.render(base64, containerEl)
+
+                  - base64       String   Base64-encoded PDF bytes (raw, no data: prefix).
+                  - containerEl  Element  The element the viewer renders into. The module
+                                          OWNS the inside of this element: it clears it and
+                                          injects whatever DOM its engine needs.
+
+                This module is the ONLY place in the page that knows the render engine.
+                The controller, state machine, signing modal, and save flow MUST NOT
+                reference iframes, blobs, object URLs, or PDF.js directly — they only ever
+                call DocGenPdfViewer.render(...).
+
+                CURRENT ENGINE (native): base64 -> Uint8Array -> Blob(application/pdf)
+                -> URL.createObjectURL -> iframe src.
+
+                FUTURE SWAP (Milestone 3 — PDF.js, for sign-spot positioning + reliable
+                mobile inline render): replace ONLY the body of render() (and any private
+                helpers/state inside this IIFE). Nothing outside this module changes — the
+                swap is mechanical because the contract above is the entire boundary.
+                ============================================================================
+            -->
+            <script>
+                var DocGenPdfViewer = (function () {
+                    // --- Private engine state (never exposed) ---
+                    // Track the most recent object URL so we can revoke it before creating a
+                    // new one, avoiding a blob-URL leak across re-renders.
+                    var activeObjectUrl = null;
+
+                    function base64ToBytes(base64) {
+                        var binary = atob(base64);
+                        var len = binary.length;
+                        var bytes = new Uint8Array(len);
+                        for (var i = 0; i < len; i++) {
+                            bytes[i] = binary.charCodeAt(i);
+                        }
+                        return bytes;
+                    }
+
+                    function clearContainer(containerEl) {
+                        while (containerEl.firstChild) {
+                            containerEl.removeChild(containerEl.firstChild);
+                        }
+                    }
+
+                    return {
+                        // render(base64, containerEl) — see contract header above.
+                        render: function (base64, containerEl) {
+                            if (!containerEl) {
+                                return;
+                            }
+                            if (!base64) {
+                                clearContainer(containerEl);
+                                var msg = document.createElement('p');
+                                msg.style.cssText = 'color:#fff;text-align:center;padding:2rem;';
+                                msg.textContent = 'Document unavailable.';
+                                containerEl.appendChild(msg);
+                                return;
+                            }
+
+                            // Revoke the previous blob URL if we are re-rendering.
+                            if (activeObjectUrl) {
+                                URL.revokeObjectURL(activeObjectUrl);
+                                activeObjectUrl = null;
+                            }
+
+                            var bytes = base64ToBytes(base64);
+                            var blob = new Blob([bytes], { type: 'application/pdf' });
+                            activeObjectUrl = URL.createObjectURL(blob);
+
+                            clearContainer(containerEl);
+                            var iframe = document.createElement('iframe');
+                            iframe.title = 'Document to sign';
+                            iframe.setAttribute('type', 'application/pdf');
+                            iframe.src = activeObjectUrl;
+                            containerEl.appendChild(iframe);
+                        }
+                    };
+                })();
+            </script>
+
+            <script>
+                (function () {
+                    // ===== STATE MANAGEMENT =====
+                    var stateIds = ['loading', 'error', 'verify', 'pdf', 'processing', 'success', 'waiting', 'decline'];
+                    function showState(name) {
+                        for (var i = 0; i < stateIds.length; i++) {
+                            document.getElementById('state-' + stateIds[i]).style.display =
+                                stateIds[i] === name ? '' : 'none';
+                        }
+                        // The PDF view uses the full height, so align the wrapper to the top.
+                        var pw = document.getElementById('page-wrapper');
+                        if (name === 'pdf') {
+                            pw.style.justifyContent = 'flex-start';
+                        } else {
+                            pw.style.justifyContent = 'center';
+                        }
+                        pw.style.padding = '1rem';
+                    }
+                    function showError(msg) {
+                        document.getElementById('error-message').textContent = msg;
+                        showState('error');
+                    }
+                    function showVerifyMsg(msg, type) {
+                        document.getElementById('verify-msg').innerHTML =
+                            '<div class="msg msg-' + type + '">' + msg + '</div>';
+                    }
+                    function showModalMsg(msg, type) {
+                        document.getElementById('modal-msg').innerHTML = msg
+                            ? '<div class="msg msg-' + type + '">' + msg + '</div>'
+                            : '';
+                    }
+
+                    // ===== TOKEN FROM URL =====
+                    var urlParams = new URLSearchParams(window.location.search);
+                    var token = urlParams.get('token');
+                    if (!token) {
+                        showError('Invalid or missing security token. Please check your signature link.');
+                        return;
+                    }
+
+                    // ===== GLOBAL STATE =====
+                    var signerData = null;
+                    var isMultiSigner = false;
+                    var resendTimer = null;
+                    var capturedIp = '';
+
+                    // ===== CLIENT-SIDE IP CAPTURE =====
+                    // The signing page is hosted on a Salesforce Site, so signers are Guest users.
+                    // Auth.SessionManagement.getCurrentSession() is blocked for Guest, and
+                    // X-Forwarded-For headers aren't always set by Salesforce's edge for VF requests.
+                    // Asking the browser to fetch its own public IP is the most reliable path —
+                    // the third-party service only sees the signer's IP (which they'd see anyway
+                    // by virtue of the request), no other PII flows. Server-side resolveClientIp()
+                    // falls back to header inspection if this fetch fails.
+                    try {
+                        fetch('https://api.ipify.org?format=json', { cache: 'no-store' })
+                            .then(function (r) {
+                                return r.ok ? r.json() : null;
+                            })
+                            .then(function (j) {
+                                if (j && j.ip) capturedIp = j.ip;
+                            })
+                            .catch(function () {
+                                /* fallback to server-side capture */
+                            });
+                    } catch (e) {
+                        /* fetch unavailable — fall back to server-side capture */
+                    }
+
+                    // ===== STEP 1: VALIDATE TOKEN =====
+                    Visualforce.remoting.Manager.invokeAction(
+                        '{!$RemoteAction.DocGenSignatureController.validateToken}',
+                        token,
+                        function (result, event) {
+                            if (event.status && result && result.isValid) {
+                                signerData = result;
+                                if (result.requiresPin) {
+                                    initVerifyScreen(result);
+                                } else {
+                                    initAfterVerification(result);
+                                }
+                            } else {
+                                showError(
+                                    result && result.errorMessage
+                                        ? result.errorMessage
+                                        : 'This signature request is no longer active.'
+                                );
+                            }
+                        },
+                        { escape: false }
+                    );
+
+                    // ===== EMAIL VERIFICATION (PIN) =====
+                    function initVerifyScreen(data) {
+                        document.getElementById('verify-doc-title').textContent =
+                            data.documentTitle || 'Document Signature';
+                        if (data.signerEmail) {
+                            var parts = data.signerEmail.split('@');
+                            document.getElementById('verify-email').placeholder =
+                                'Enter: ' + parts[0].substring(0, 2) + '***@' + parts[1];
+                        }
+                        showState('verify');
+                        document.getElementById('btn-send-pin').addEventListener('click', handleSendPin);
+                        document.getElementById('btn-verify-pin').addEventListener('click', handleVerifyPin);
+                        document.getElementById('resend-link').addEventListener('click', handleResendPin);
+                        document.getElementById('verify-pin').addEventListener('keydown', function (e) {
+                            if (e.key === 'Enter') handleVerifyPin();
+                        });
+                        document.getElementById('verify-email').addEventListener('keydown', function (e) {
+                            if (e.key === 'Enter') handleSendPin();
+                        });
+                    }
+
+                    function handleSendPin() {
+                        var email = document.getElementById('verify-email').value.trim();
+                        if (!email) {
+                            showVerifyMsg('Please enter your email address.', 'error');
+                            return;
+                        }
+                        var btn = document.getElementById('btn-send-pin');
+                        btn.disabled = true;
+                        btn.textContent = 'Sending...';
+                        Visualforce.remoting.Manager.invokeAction(
+                            '{!$RemoteAction.DocGenSignatureController.sendPin}',
+                            token,
+                            email,
+                            function (result, event) {
+                                btn.disabled = false;
+                                btn.textContent = 'Send Verification Code';
+                                if (event.status && result && result.success) {
+                                    showVerifyMsg(result.message, 'success');
+                                    document.getElementById('pin-section').style.display = '';
+                                    btn.style.display = 'none';
+                                    startResendTimer();
+                                } else {
+                                    showVerifyMsg(
+                                        result ? result.message : 'Failed to send verification code.',
+                                        'error'
+                                    );
+                                }
+                            },
+                            { escape: false }
+                        );
+                    }
+
+                    function handleVerifyPin() {
+                        var pin = document.getElementById('verify-pin').value.trim();
+                        if (!pin || pin.length !== 6) {
+                            showVerifyMsg('Please enter the 6-digit code from your email.', 'error');
+                            return;
+                        }
+                        var btn = document.getElementById('btn-verify-pin');
+                        btn.disabled = true;
+                        btn.textContent = 'Verifying...';
+                        Visualforce.remoting.Manager.invokeAction(
+                            '{!$RemoteAction.DocGenSignatureController.verifyPin}',
+                            token,
+                            pin,
+                            function (result, event) {
+                                btn.disabled = false;
+                                btn.textContent = 'Verify';
+                                if (event.status && result && result.success) {
+                                    initAfterVerification(signerData);
+                                } else {
+                                    showVerifyMsg(result ? result.message : 'Verification failed.', 'error');
+                                }
+                            },
+                            { escape: false }
+                        );
+                    }
+
+                    function handleResendPin() {
+                        if (document.getElementById('resend-link').classList.contains('disabled')) return;
+                        var email = document.getElementById('verify-email').value.trim();
+                        Visualforce.remoting.Manager.invokeAction(
+                            '{!$RemoteAction.DocGenSignatureController.sendPin}',
+                            token,
+                            email,
+                            function (result, event) {
+                                if (event.status && result && result.success) {
+                                    showVerifyMsg('New verification code sent.', 'success');
+                                    startResendTimer();
+                                } else {
+                                    showVerifyMsg(result ? result.message : 'Failed to resend code.', 'error');
+                                }
+                            },
+                            { escape: false }
+                        );
+                    }
+
+                    function startResendTimer() {
+                        var link = document.getElementById('resend-link');
+                        link.classList.add('disabled');
+                        var seconds = 60;
+                        link.textContent = 'Resend code (' + seconds + 's)';
+                        if (resendTimer) clearInterval(resendTimer);
+                        resendTimer = setInterval(function () {
+                            seconds--;
+                            if (seconds <= 0) {
+                                clearInterval(resendTimer);
+                                link.classList.remove('disabled');
+                                link.textContent = 'Resend code';
+                            } else {
+                                link.textContent = 'Resend code (' + seconds + 's)';
+                            }
+                        }, 1000);
+                    }
+
+                    // ===== AFTER VERIFICATION: SHOW PDF =====
+                    function initAfterVerification(data) {
+                        isMultiSigner = data.isSignerToken === true;
+
+                        document.getElementById('pdf-doc-title').textContent =
+                            data.documentTitle || 'Document Signature';
+                        document.getElementById('pdf-signer-name').textContent = data.signerName || '';
+                        if (data.roleName) {
+                            var badge = document.getElementById('pdf-role-badge');
+                            badge.textContent = data.roleName;
+                            badge.style.display = 'inline-block';
+                        }
+                        if (isMultiSigner) {
+                            var progressEl = document.getElementById('pdf-progress-info');
+                            progressEl.textContent =
+                                ' (Signer ' + ((data.signedCount || 0) + 1) + ' of ' + (data.totalSigners || 1) + ')';
+                            progressEl.style.display = 'inline';
+                        }
+
+                        showState('pdf');
+
+                        // Wire the action bar.
+                        document.getElementById('btn-open-sign').addEventListener('click', openSignModal);
+                        document.getElementById('btn-decline').addEventListener('click', function () {
+                            showState('decline');
+                        });
+                        document.getElementById('btn-decline-cancel').addEventListener('click', function () {
+                            showState('pdf');
+                        });
+                        document.getElementById('btn-decline-confirm').addEventListener('click', handleDecline);
+
+                        // Wire the modal.
+                        wireSignModal();
+
+                        // Load and render the real PDF through the viewer abstraction.
+                        loadPdf();
+                    }
+
+                    // ===== PDF LOAD + RENDER (via DocGenPdfViewer) =====
+                    function loadPdf() {
+                        var containerEl = document.getElementById('pdf-viewer-container');
+                        Visualforce.remoting.Manager.invokeAction(
+                            '{!$RemoteAction.DocGenSignatureController.getSourcePdfBase64}',
+                            token,
+                            function (result, event) {
+                                if (event.status && result && result.base64) {
+                                    // The viewer module owns rendering — the page never touches
+                                    // blobs/iframes/PDF.js directly.
+                                    DocGenPdfViewer.render(result.base64, containerEl);
+                                } else {
+                                    DocGenPdfViewer.render(null, containerEl);
+                                }
+                            },
+                            { escape: false, buffer: false, timeout: 120000 }
+                        );
+                    }
+
+                    // ===== SIGNING MODAL =====
+                    function wireSignModal() {
+                        document.getElementById('modal-close').addEventListener('click', closeSignModal);
+                        document.getElementById('modal-cancel').addEventListener('click', closeSignModal);
+                        document
+                            .getElementById('modal-consent-checkbox')
+                            .addEventListener('change', updateSignSubmitState);
+                        document.getElementById('modal-typed-name').addEventListener('input', updateSignSubmitState);
+                        document.getElementById('btn-sign-submit').addEventListener('click', handleSignSubmit);
+                    }
+
+                    function openSignModal() {
+                        // Prefill the confirmed name from validateToken.signerName.
+                        var nameInput = document.getElementById('modal-typed-name');
+                        nameInput.value = signerData && signerData.signerName ? signerData.signerName : '';
+                        document.getElementById('modal-consent-checkbox').checked = false;
+                        showModalMsg('', 'info');
+                        updateSignSubmitState();
+                        document.getElementById('sign-modal').style.display = '';
+                        setTimeout(function () {
+                            nameInput.focus();
+                        }, 50);
+                    }
+
+                    function closeSignModal() {
+                        document.getElementById('sign-modal').style.display = 'none';
+                    }
+
+                    function updateSignSubmitState() {
+                        var nameVal = document.getElementById('modal-typed-name').value.trim();
+                        var consentVal = document.getElementById('modal-consent-checkbox').checked;
+                        // Sign stays disabled until consent is checked (and a name is present).
+                        document.getElementById('btn-sign-submit').disabled = !(nameVal && consentVal);
+                    }
+
+                    function handleSignSubmit() {
+                        var typedName = document.getElementById('modal-typed-name').value.trim();
+                        var consentGiven = document.getElementById('modal-consent-checkbox').checked;
+                        if (!typedName || !consentGiven) return;
+
+                        var btn = document.getElementById('btn-sign-submit');
+                        btn.disabled = true;
+                        btn.textContent = 'Signing...';
+
+                        // Capture IP (browser fetch above; server resolveClientIp falls back).
+                        var userAgent = navigator.userAgent || 'Unknown';
+
+                        Visualforce.remoting.Manager.invokeAction(
+                            '{!$RemoteAction.DocGenSignatureController.savePdfSignature}',
+                            token,
+                            typedName,
+                            consentGiven,
+                            capturedIp,
+                            userAgent,
+                            function (result, event) {
+                                btn.disabled = false;
+                                btn.textContent = 'Sign';
+                                if (!event.status || !result || result.success === false) {
+                                    showModalMsg(
+                                        'Save failed: ' +
+                                            ((result && result.message) || event.message || 'Unknown error'),
+                                        'error'
+                                    );
+                                    return;
+                                }
+                                closeSignModal();
+                                if (result.isComplete) {
+                                    showState('success');
+                                } else {
+                                    var rem = result.remaining || 0;
+                                    document.getElementById('waiting-message').textContent =
+                                        'Your signature has been recorded. Waiting for ' +
+                                        rem +
+                                        ' more signer' +
+                                        (rem > 1 ? 's' : '') +
+                                        ' to complete.';
+                                    showState('waiting');
+                                }
+                            },
+                            { escape: false, buffer: false, timeout: 120000 }
+                        );
+                    }
+
+                    // ===== DECLINE =====
+                    function handleDecline() {
+                        var reason = document.getElementById('decline-reason').value.trim();
+                        var btn = document.getElementById('btn-decline-confirm');
+                        btn.disabled = true;
+                        btn.textContent = 'Declining...';
+
+                        var ua = navigator.userAgent || 'Unknown';
+                        Visualforce.remoting.Manager.invokeAction(
+                            '{!$RemoteAction.DocGenSignatureController.declineSignature}',
+                            token,
+                            reason,
+                            capturedIp,
+                            ua,
+                            function (result, event) {
+                                btn.disabled = false;
+                                btn.textContent = 'Confirm Decline';
+                                if (event.status && result && result.success) {
+                                    document.getElementById('error-message').textContent =
+                                        'You have declined this signature request.';
+                                    document.querySelector('.error-card h2').textContent = 'Request Declined';
+                                    document.querySelector('.error-icon').textContent = '✖';
+                                    showState('error');
+                                } else {
+                                    alert(result ? result.message : 'Failed to decline. Please try again.');
+                                }
+                            },
+                            { escape: false }
+                        );
+                    }
+                })();
+            </script>
+        </body>
+    </html>
+</apex:page>

--- a/force-app/main/default/pages/DocGenSignaturePdf.page-meta.xml
+++ b/force-app/main/default/pages/DocGenSignaturePdf.page-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <availableInTouch>false</availableInTouch>
+    <confirmationTokenRequired>false</confirmationTokenRequired>
+    <label>DocGenSignaturePdf</label>
+</ApexPage>

--- a/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
@@ -457,6 +457,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>DocGen_Signature_Request__c.Render_Data_Snapshot__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>DocGen_Signature_Request__c.Source_Document_Id__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/DocGen_Guest_Signature.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Guest_Signature.permissionset-meta.xml
@@ -111,6 +111,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>DocGen_Signature_Request__c.Render_Data_Snapshot__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>DocGen_Signature_Request__c.Source_Document_Id__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/DocGen_Guest_Signature.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Guest_Signature.permissionset-meta.xml
@@ -278,6 +278,10 @@
         <enabled>true</enabled>
     </pageAccesses>
     <pageAccesses>
+        <apexPage>DocGenSignaturePdf</apexPage>
+        <enabled>true</enabled>
+    </pageAccesses>
+    <pageAccesses>
         <apexPage>DocGenSign</apexPage>
         <enabled>true</enabled>
     </pageAccesses>

--- a/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
@@ -444,6 +444,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>DocGen_Signature_Request__c.Render_Data_Snapshot__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>DocGen_Signature_Request__c.Source_Document_Id__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/triggers/DocGenSignaturePdfTrigger.trigger
+++ b/force-app/main/default/triggers/DocGenSignaturePdfTrigger.trigger
@@ -22,6 +22,8 @@ trigger DocGenSignaturePdfTrigger on DocGen_Signature_PDF__e(after insert) {
                 Template_Ids__c,
                 Status__c,
                 Signing_Order__c,
+                Source_Document_Id__c,
+                Render_Data_Snapshot__c,
                 (
                     SELECT
                         Id,
@@ -135,11 +137,16 @@ trigger DocGenSignaturePdfTrigger on DocGen_Signature_PDF__e(after insert) {
                 if (req.Signing_Order__c == 'Sequential' && nextPendingSigner != null) {
                     try {
                         String siteUrl = DocGenSignatureSenderController.getSiteBaseUrl();
-                        String sigUrl =
-                            siteUrl +
-                            DocGenSignatureSenderController.getSigningPagePath() +
-                            '?token=' +
-                            nextPendingSigner.Secure_Token__c;
+                        // Route sequential signer 2+ to the SAME page the first signer got.
+                        // PDF-viewer requests (snapshot re-render or send-existing-CV) set
+                        // Render_Data_Snapshot__c or Source_Document_Id__c; the classic
+                        // typed-name flow sets neither. Without this, follow-up signers on a
+                        // PDF-viewer request were emailed the legacy /DocGenSignature page.
+                        Boolean isPdfViewer = req.Render_Data_Snapshot__c != null || req.Source_Document_Id__c != null;
+                        String signingPath = isPdfViewer
+                            ? DocGenSignatureSenderController.getSigningPdfPagePath()
+                            : DocGenSignatureSenderController.getSigningPagePath();
+                        String sigUrl = siteUrl + signingPath + '?token=' + nextPendingSigner.Secure_Token__c;
 
                         String docTitle = 'Document';
                         if (req.Template__c != null && templateNameMap.containsKey(req.Template__c)) {

--- a/scripts/e2e-06-signatures.apex
+++ b/scripts/e2e-06-signatures.apex
@@ -453,6 +453,90 @@ try {
     System.debug('SETUP VALIDATION: FAIL — ' + e.getMessage());
 }
 
+// ===== Send Existing ContentVersion (flat-PDF signing path, Milestone 1) =====
+try {
+    // A pre-generated document stored as a ContentVersion (what the signer will see).
+    ContentVersion srcCv = new ContentVersion(
+        Title = 'E2E Generated Agreement',
+        PathOnClient = 'e2e-agreement.pdf',
+        VersionData = Blob.valueOf('%PDF-1.7 e2e source document bytes')
+    );
+    insert srcCv;
+    srcCv = [SELECT Id FROM ContentVersion WHERE Id = :srcCv.Id LIMIT 1];
+
+    String pdfSignersJson = '[{"signerName":"Carol Existing","signerEmail":"carol@e2etest.example.com","roleName":"Signer","contactId":""}]';
+
+    List<DocGenSignatureSenderController.SignerResult> pdfResults = DocGenSignatureSenderController.createRequestFromContentVersion(
+        srcCv.Id,
+        acctId,
+        pdfSignersJson,
+        'Parallel',
+        null
+    );
+
+    // One signer whose URL targets the NEW flat-PDF page (not /DocGenSignature).
+    Boolean urlOk =
+        pdfResults != null &&
+        pdfResults.size() == 1 &&
+        pdfResults[0].signerUrl != null &&
+        pdfResults[0].signerUrl.contains('DocGenSignaturePdf');
+    if (urlOk) {
+        pass++;
+        System.debug('SEND EXISTING CV — SIGNER URL: PASS');
+    } else {
+        fail++;
+        System.debug('SEND EXISTING CV — SIGNER URL: FAIL');
+    }
+
+    // The created request is Template__c-null and bound to the source CV.
+    DocGen_Signer__c pdfSigner = [
+        SELECT
+            Secure_Token__c,
+            Signature_Request__c,
+            Signature_Request__r.Source_Document_Id__c,
+            Signature_Request__r.Template__c,
+            Signature_Request__r.Status__c
+        FROM DocGen_Signer__c
+        WHERE Signer_Email__c = 'carol@e2etest.example.com'
+        ORDER BY CreatedDate DESC
+        LIMIT 1
+    ];
+    Boolean reqOk =
+        pdfSigner.Signature_Request__r.Source_Document_Id__c == srcCv.Id &&
+        pdfSigner.Signature_Request__r.Template__c == null &&
+        pdfSigner.Signature_Request__r.Status__c == 'Sent';
+    if (reqOk) {
+        pass++;
+        System.debug('SEND EXISTING CV — TEMPLATE-NULL REQUEST: PASS');
+    } else {
+        fail++;
+        System.debug('SEND EXISTING CV — TEMPLATE-NULL REQUEST: FAIL');
+    }
+
+    // The signer's token round-trips through getSourcePdfBase64 → serves the bound PDF.
+    Map<String, String> pdfBytes = DocGenSignatureController.getSourcePdfBase64(pdfSigner.Secure_Token__c);
+    if (
+        pdfBytes.get('error') == null &&
+        pdfBytes.get('mimeType') == 'application/pdf' &&
+        pdfBytes.get('base64') == EncodingUtil.base64Encode(Blob.valueOf('%PDF-1.7 e2e source document bytes'))
+    ) {
+        pass++;
+        System.debug('SEND EXISTING CV — getSourcePdfBase64 ROUND-TRIP: PASS');
+    } else {
+        fail++;
+        System.debug('SEND EXISTING CV — getSourcePdfBase64 ROUND-TRIP: FAIL — ' + pdfBytes.get('error'));
+    }
+
+    // Cleanup the request, signer, and source document created here.
+    Id pdfReqId = pdfSigner.Signature_Request__c;
+    delete [SELECT Id FROM DocGen_Signer__c WHERE Signature_Request__c = :pdfReqId];
+    delete [SELECT Id FROM DocGen_Signature_Request__c WHERE Id = :pdfReqId];
+    delete [SELECT Id FROM ContentDocument WHERE LatestPublishedVersionId = :srcCv.Id];
+} catch (Exception e) {
+    fail++;
+    System.debug('SEND EXISTING CV: FAIL — ' + e.getMessage());
+}
+
 System.debug('========================================');
 System.debug(
     'E2E-06 SIGNATURES — PASS: ' + pass + '  FAIL: ' + fail + (fail == 0 ? '  ALL TESTS PASSED' : '  FAILURES DETECTED')

--- a/scripts/make-m3-signatures-demo.apex
+++ b/scripts/make-m3-signatures-demo.apex
@@ -1,0 +1,93 @@
+// M3 demo: builds a throwaway HTML template containing a styled {#Signatures} loop
+// block, then snapshot-sends it to TWO signers against a record. Sign both in the
+// browser; the completed "... - Signed" PDF attached to the record should show TWO
+// styled signature blocks inline (where the {#Signatures} block sits) + the cert page.
+// Re-run with one signer in the `signers` list to confirm the SAME template renders
+// exactly one block.
+//
+// Run: sf apex run --target-org docgen-test -f scripts/make-m3-signatures-demo.apex
+Id recordId = '001Pu00000pUEOPIA4'; // E2E Test Corp (Account)
+
+// --- Build a demo template with a {#Signatures} loop block ----------------------
+// Styled with CSS 2.1 only (Flying Saucer subset): no flex/grid/gradients.
+// The name renders italic on a ruled line to read like a signature.
+String body =
+    '<html><head><style>' +
+    'body{font-family:Helvetica,Arial,sans-serif;color:#222;font-size:11pt;}' +
+    'h1{color:#0176D3;font-size:18pt;}' +
+    '.sig{margin:18px 0;padding:10px 0;border-top:1px solid #ddd;}' +
+    '.sig .name{font-style:italic;font-size:16pt;border-bottom:1px solid #333;' +
+    'padding-bottom:2px;display:inline-block;min-width:260px;}' +
+    '.sig .meta{color:#555;font-size:9pt;margin-top:4px;}' +
+    '</style></head><body>' +
+    '<h1>Service Agreement</h1>' +
+    '<p>This agreement is entered into by <b>{Name}</b> ' +
+    '(Industry: {Industry}).</p>' +
+    '<p>The parties below have signed electronically:</p>' +
+    '{#Signatures}' +
+    '<div class="sig">' +
+    '<span class="name">{Name}</span>' +
+    '<div class="meta">{Role} &middot; {Email}<br/>' +
+    'Electronically signed on {SignedDate} &middot; Status: {Status}</div>' +
+    '</div>' +
+    '{/Signatures}' +
+    '</body></html>';
+
+DocGen_Template__c tmpl = new DocGen_Template__c(
+    Name = 'M3 Signatures Demo',
+    Base_Object_API__c = 'Account',
+    Query_Config__c = 'Name, Industry',
+    Type__c = 'HTML',
+    Output_Format__c = 'PDF'
+);
+insert tmpl;
+
+ContentVersion bodyCv = new ContentVersion(
+    Title = 'M3 Signatures Demo Body',
+    PathOnClient = 'm3-demo.html',
+    VersionData = Blob.valueOf(body),
+    FirstPublishLocationId = tmpl.Id
+);
+insert bodyCv;
+
+insert new DocGen_Template_Version__c(Template__c = tmpl.Id, Is_Active__c = true, Content_Version_Id__c = bodyCv.Id);
+
+// --- Snapshot-send to TWO signers ----------------------------------------------
+String signers = JSON.serialize(
+    new List<Map<String, Object>>{
+        new Map<String, Object>{
+            'signerName' => 'Pat Tester',
+            'signerEmail' => 'pat@example.com',
+            'roleName' => 'Buyer'
+        },
+        new Map<String, Object>{
+            'signerName' => 'Sam Counter',
+            'signerEmail' => 'sam@example.com',
+            'roleName' => 'Seller'
+        }
+    }
+);
+
+List<DocGenSignatureSenderController.SignerResult> res = DocGenSignatureSenderController.createTemplateSnapshotRequest(
+    tmpl.Id,
+    recordId,
+    signers,
+    'Parallel', // both can sign independently; 'Sequential' to enforce order
+    null
+);
+
+// Pre-verify each signer's PIN so the scratch org (no outbound email) skips the email step.
+Set<Id> signerIds = new Set<Id>();
+for (DocGenSignatureSenderController.SignerResult r : res) {
+    signerIds.add(r.signerId);
+}
+List<DocGen_Signer__c> toVerify = [SELECT Id FROM DocGen_Signer__c WHERE Id IN :signerIds];
+for (DocGen_Signer__c s : toVerify) {
+    s.PIN_Verified_At__c = System.now();
+}
+update toVerify;
+
+System.debug('TEMPLATE_ID >>> ' + tmpl.Id);
+for (DocGenSignatureSenderController.SignerResult r : res) {
+    System.debug('SIGNER_URL (' + r.signerId + ') >>> ' + r.signerUrl);
+}

--- a/scripts/make-pdf-signing-url.apex
+++ b/scripts/make-pdf-signing-url.apex
@@ -1,0 +1,46 @@
+// Dev helper: mint a test PDF signing request for the new DocGenSignaturePdf flow.
+// Creates a real PDF ContentVersion, an Account to attach to, then calls the new
+// createRequestFromContentVersion entry point and prints the signer URL + token.
+// Run: sf apex run --target-org docgen-test -f scripts/make-pdf-signing-url.apex
+
+Blob pdf = Blob.toPdf('<html><body><h1>Test Agreement</h1><p>Please review and sign below.</p></body></html>');
+ContentVersion cv = new ContentVersion(Title = 'Test Agreement', PathOnClient = 'TestAgreement.pdf', VersionData = pdf);
+insert cv;
+Id cvId = [SELECT Id FROM ContentVersion WHERE Id = :cv.Id LIMIT 1].Id;
+
+Account a = new Account(Name = 'Signing Test Co');
+insert a;
+
+String signers = JSON.serialize(
+    new List<Map<String, Object>>{
+        new Map<String, Object>{
+            'signerName' => 'Pat Tester',
+            'signerEmail' => 'pat@example.com',
+            'roleName' => 'Signer'
+        }
+    }
+);
+
+List<DocGenSignatureSenderController.SignerResult> res = DocGenSignatureSenderController.createRequestFromContentVersion(
+    cvId,
+    a.Id,
+    signers,
+    'Parallel',
+    null
+);
+
+for (DocGenSignatureSenderController.SignerResult r : res) {
+    System.debug('SIGNER_URL >>> ' + r.signerUrl);
+    System.debug('SIGNER_ID  >>> ' + r.signerId);
+}
+
+// Raw token + the source CV, so a public URL can be built by hand if the
+// generated signerUrl points at the internal domain instead of the Site domain.
+for (DocGen_Signer__c s : [
+    SELECT Secure_Token__c
+    FROM DocGen_Signer__c
+    WHERE Signature_Request__c IN (SELECT Id FROM DocGen_Signature_Request__c WHERE Source_Document_Id__c = :cvId)
+]) {
+    System.debug('TOKEN >>> ' + s.Secure_Token__c);
+}
+System.debug('SOURCE_CV >>> ' + cvId);

--- a/scripts/make-snapshot-signing-url.apex
+++ b/scripts/make-snapshot-signing-url.apex
@@ -1,0 +1,32 @@
+// M2 helper: mint a SNAPSHOT signing request. Snapshots the record's merge data
+// now; on completion the document is re-rendered from that snapshot, a signing
+// certificate page is appended, and the combined PDF is attached to the record.
+// Run: sf apex run --target-org docgen-test -f scripts/make-snapshot-signing-url.apex
+Id templateId = 'a09Pu00000S9y2jIAB'; // Account-Test (HTML + images)
+Id recordId = '001Pu00000pUEOPIA4'; // E2E Test Corp
+
+String signers = JSON.serialize(
+    new List<Map<String, Object>>{
+        new Map<String, Object>{
+            'signerName' => 'Pat Tester',
+            'signerEmail' => 'pat@example.com',
+            'roleName' => 'Signer'
+        }
+    }
+);
+List<DocGenSignatureSenderController.SignerResult> res = DocGenSignatureSenderController.createTemplateSnapshotRequest(
+    templateId,
+    recordId,
+    signers,
+    'Parallel',
+    null
+);
+
+// Pre-verify the signer's PIN so the scratch org (no outbound email) skips the email step.
+DocGen_Signer__c s = [SELECT Id, Secure_Token__c FROM DocGen_Signer__c WHERE Id = :res[0].signerId];
+s.PIN_Verified_At__c = System.now();
+update s;
+
+for (DocGenSignatureSenderController.SignerResult r : res) {
+    System.debug('SIGNER_URL >>> ' + r.signerUrl);
+}

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,14 +1,14 @@
 {
   "packageDirectories": [
     {
-      "versionName": "v3.05.0 — Signature Template Fidelity",
-      "versionNumber": "3.5.0.NEXT",
-      "ancestorId": "04tVx000000nGZtIAM",
+      "versionName": "v3.06.0 — HTML Signature Placement Detection",
+      "versionNumber": "3.6.0.NEXT",
+      "ancestorId": "04tVx000000nI5RIAU",
       "path": "force-app",
       "default": true,
       "definitionFile": "config/build-def.json",
       "package": "Portwood DocGen Managed",
-      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v3.05 improves e-signature document fidelity so Word template headers, footers, and branding are preserved through preview, sending, and final signed PDFs, with updated permission sets for signature Flow and reminder features. Free for all users."
+      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v3.06 fixes e-signature setup for HTML templates so signature fields are detected correctly when sending documents for signature. Free for all users."
     }
   ],
   "name": "Portwood DocGen",
@@ -166,6 +166,7 @@
     "Portwood DocGen Managed@3.2.0-1": "04tVx000000muJFIAY",
     "Portwood DocGen Managed@3.3.0-1": "04tVx000000nEHxIAM",
     "Portwood DocGen Managed@3.4.0-1": "04tVx000000nGZtIAM",
-    "Portwood DocGen Managed@3.5.0-1": "04tVx000000nI5RIAU"
+    "Portwood DocGen Managed@3.5.0-1": "04tVx000000nI5RIAU",
+    "Portwood DocGen Managed@3.6.0-1": "04tVx000000nIv4IAE"
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,14 +1,14 @@
 {
   "packageDirectories": [
     {
-      "versionName": "v3.07.0 — HTML Signature Rendering",
-      "versionNumber": "3.7.0.NEXT",
-      "ancestorId": "04tVx000000nIv4IAE",
+      "versionName": "v3.08.0 — Signature Images and Generation Access",
+      "versionNumber": "3.8.0.NEXT",
+      "ancestorId": "04tVx000000nLOHIA2",
       "path": "force-app",
       "default": true,
       "definitionFile": "config/build-def.json",
       "package": "Portwood DocGen Managed",
-      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v3.07 fixes e-signature previews and completed signed PDFs for HTML templates. Free for all users."
+      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v3.08 improves HTML e-signature image rendering and fixes non-admin generation access for large templates. Free for all users."
     }
   ],
   "name": "Portwood DocGen",
@@ -168,6 +168,7 @@
     "Portwood DocGen Managed@3.4.0-1": "04tVx000000nGZtIAM",
     "Portwood DocGen Managed@3.5.0-1": "04tVx000000nI5RIAU",
     "Portwood DocGen Managed@3.6.0-1": "04tVx000000nIv4IAE",
-    "Portwood DocGen Managed@3.7.0-1": "04tVx000000nLOHIA2"
+    "Portwood DocGen Managed@3.7.0-1": "04tVx000000nLOHIA2",
+    "Portwood DocGen Managed@3.8.0-1": "04tVx000000nOFhIAM"
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,14 +1,14 @@
 {
   "packageDirectories": [
     {
-      "versionName": "v3.06.0 — HTML Signature Placement Detection",
-      "versionNumber": "3.6.0.NEXT",
-      "ancestorId": "04tVx000000nI5RIAU",
+      "versionName": "v3.07.0 — HTML Signature Rendering",
+      "versionNumber": "3.7.0.NEXT",
+      "ancestorId": "04tVx000000nIv4IAE",
       "path": "force-app",
       "default": true,
       "definitionFile": "config/build-def.json",
       "package": "Portwood DocGen Managed",
-      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v3.06 fixes e-signature setup for HTML templates so signature fields are detected correctly when sending documents for signature. Free for all users."
+      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record — 100% native, no external services or callouts. v3.07 fixes e-signature previews and completed signed PDFs for HTML templates. Free for all users."
     }
   ],
   "name": "Portwood DocGen",
@@ -167,6 +167,7 @@
     "Portwood DocGen Managed@3.3.0-1": "04tVx000000nEHxIAM",
     "Portwood DocGen Managed@3.4.0-1": "04tVx000000nGZtIAM",
     "Portwood DocGen Managed@3.5.0-1": "04tVx000000nI5RIAU",
-    "Portwood DocGen Managed@3.6.0-1": "04tVx000000nIv4IAE"
+    "Portwood DocGen Managed@3.6.0-1": "04tVx000000nIv4IAE",
+    "Portwood DocGen Managed@3.7.0-1": "04tVx000000nLOHIA2"
   }
 }


### PR DESCRIPTION
 ## Summary
  Adds an opt-in PDF-viewer e-signature flow: signers review the real rendered PDF in-browser and the completed document is pushed back onto the record. Purely additive — the
  existing typed-name signing flow, `{@Signature_Role}` role tags, and all current templates are unchanged.

  ## Changes
  - **In-browser PDF-viewer signing page** (`DocGenSignaturePdf`) — renders the actual PDF and guides the signer through a modal (token/PIN → review → consent → sign). Guest reads
  use the established `DocGenFlsGuard` + `WITH SYSTEM_MODE` pattern; the signer token resolves only its own bound document (IDOR-safe).
  - **Snapshot re-render onto the record** — captures the record's merge data at send-time; on completion re-renders from that snapshot (immune to later edits), appends a
  signing-certificate page, and attaches the signed PDF to the related record with a SHA-256 audit hash. The certificate shows the name each signer typed.
  - **`{#Signatures}` loop block** — one signature layout repeats per signer for any signer count; no per-count templates, no orphaned role tags. Backwards-compatible: a template
  without the block renders identically, and role tags still work for fixed positions.
  - **New Flow action** `DocGenSignaturePdfFlowAction` ("DocGen: Send Existing Document for Signature") — Template-Id (snapshot) or Content-Version-Id (existing document) modes.
  - Docs: UserGuide §10.7, §11.1, §11.7, §12.4; CHANGELOG Unreleased entry.

  ## Testing
  - [x] Apex unit tests — `RunLocalTests` **1515/1515 (100%)**, org-wide coverage **76%** (authoritative, isolated test data)
  - [x] E2E parser/permission/image suites — `e2e-01` (48), `e2e-07-syntax1..4` (35/31/17/16), `e2e-09-images` (8), `e2e-08-cleanup` (12) all **PASS / FAIL 0**
  - [ ] `e2e-02..06` not run clean in my dev scratch org — the standard Account Duplicate Rule blocks the Account/Contact *fixture* inserts (`DUPLICATES_DETECTED`) from
  accumulated test data; unrelated to this branch (no template-CRUD or Account/Contact code changed). Runs clean on a fresh org.
  - [x] Manual scratch-org test — live 2-signer snapshot send, signed in-browser, re-rendered document with two `{#Signatures}` blocks + certificate attached to the record
  - [x] Added/updated test assertions (`DocGenSignaturePdfTests`: loop render, `buildSignerLoopData`, backwards-compat regressions)

## Related Issues
  Closes #161

  ## Checklist
  - [x] No hardcoded IDs, URLs, or credentials (demo script uses placeholders)
  - [x] No `VersionData` in PDF image queries (see CLAUDE.md)
  - [x] SOQL uses the package's established `DocGenFlsGuard` + `WITH SYSTEM_MODE` hybrid (the pattern used across the signing subsystem; see CLAUDE.md) rather than `WITH
  USER_MODE`
  - [x] No new external dependencies introduced

  > **For maintainers:** extends the existing shipped e-signature subsystem (v3). Deferred as follow-ups (not in this PR): a "Sign via PDF viewer" toggle in the
  `docGenSignatureSender` LWC, a `DocGen_Settings__c` default, and snapshot-eligibility gating in the template picker — today the flow is reached via the new Flow action.