### PR TITLE
Fix: date fields render one day early (timezone off-by-one)

### DIFF
--- a/force-app/main/default/classes/DocGenDataRetriever.cls
+++ b/force-app/main/default/classes/DocGenDataRetriever.cls
@@ -1926,7 +1926,24 @@ public with sharing class DocGenDataRetriever {
                         new Map<String, Object>{ 'latitude' => loc.getLatitude(), 'longitude' => loc.getLongitude() }
                     );
                 } else {
-                    data.put(key, value);
+                    // DATE-field timezone fix: Salesforce returns a Date field via untyped
+                    // get()/getPopulatedFieldsAsMap() as a GMT-midnight Datetime. The merge
+                    // formatter renders Datetimes in the running user's local time zone, so a
+                    // user behind UTC sees the date rolled back a day (the "dates off by one"
+                    // bug). Apex instanceof can't tell Date from Datetime at runtime (both
+                    // match Datetime), so we use the Schema field type: for DATE fields,
+                    // re-express the value as LOCAL midnight of the same calendar date, which
+                    // formats to the correct day. Datetime fields are left untouched — they
+                    // SHOULD render in local time.
+                    Object toStore = value;
+                    if (value instanceof Datetime) {
+                        Schema.SObjectField sof = fieldMap.get(key.toLowerCase());
+                        if (sof != null && sof.getDescribe().getType() == Schema.DisplayType.DATE) {
+                            Date dg = ((Datetime) value).dateGmt();
+                            toStore = Datetime.newInstance(dg.year(), dg.month(), dg.day(), 0, 0, 0);
+                        }
+                    }
+                    data.put(key, toStore);
                     String label = resolvePicklistLabel(fieldMap, key, value);
                     if (label != null) {
                         picklistLabels.put(key, label);

--- a/force-app/main/default/classes/DocGenMiscTests.cls
+++ b/force-app/main/default/classes/DocGenMiscTests.cls
@@ -9549,4 +9549,21 @@ private class DocGenMiscTests {
         }
         System.assert(hits > 0, 'Sanity: expected internal ' + titlePrefix + ' ContentVersion reads in ' + className);
     }
+
+    @IsTest
+    static void testDateFieldDoesNotShiftByTimezone() {
+        // Regression for the "dates off by one" bug (Slack #bug-reports): Salesforce
+        // returns a Date field via untyped get()/getPopulatedFieldsAsMap() as a
+        // GMT-midnight Datetime, which the merge formatter renders in the running user's
+        // local time zone — so a user behind UTC saw the date roll back one day.
+        // getRecordData now re-expresses DATE fields (by Schema type) as local midnight.
+        Contact c = new Contact(LastName = 'TZ Date', Birthdate = Date.newInstance(2026, 5, 29));
+        insert c;
+        Map<String, Object> data = DocGenDataRetriever.getRecordData(c.Id, 'Contact', 'Birthdate');
+        System.assertEquals(
+            '05/29/2026',
+            DocGenService.processXmlForTest('{Birthdate:MM/dd/yyyy}', data),
+            'Date field must render the same calendar day, not shift back one (timezone off-by-one bug)'
+        );
+    }
 }


### PR DESCRIPTION
## Bug (Slack #bug-reports — Craig Warren, Sarah Amin)
Salesforce **Date** fields render one calendar day **earlier** in generated docs than in the UI (5/29 → 5/28) for users behind UTC. Format suffix (`{Field:Date}`, `{Field:MM/dd/yyyy}`) didn't help. Workaround was a text formula field.

## Root cause
Salesforce returns a Date field via untyped `SObject.get()` / `getPopulatedFieldsAsMap()` as a **GMT-midnight `Datetime`**. The merge formatter renders Datetimes in the running user's **local time zone**, rolling the date back a day west of UTC. Apex `instanceof` can't distinguish Date from Datetime at runtime (a Date is also `instanceof Datetime`), so the formatter's date branch never fired.

## Fix
`DocGenDataRetriever.mapSObject` uses the **Schema field type**: DATE fields are re-expressed as **local midnight** of the same calendar date; DATETIME fields are untouched (they should render in local time).

## Validation (UTC-7 scratch org, where the bug reproduces)
- `{Birthdate:MM/dd/yyyy}` and `{Birthdate:date}` → 05/29 (were 05/28)
- `CreatedDate` (real datetime) → still local time
- RunLocalTests **1504/100%**; regression test `DocGenMiscTests.testDateFieldDoesNotShiftByTimezone`

🤖 Generated with [Claude Code](https://claude.com/claude-code)