### PR TITLE
v3.15.0 — Barcodes & QR codes in HTML templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v3.15.0 — Barcodes & QR codes in HTML templates (`04tVx000000nZ33IAE`, build `3.15.0-1`, promoted 2026-06-14)
+
+`{*Field:code128}` and `{*Field:qr}` tags now render in **HTML templates**, not just Word — so HTML invoices can carry a QR pay-link, and HTML catalogs/price lists can carry a scannable barcode per row.
+
+**Root cause of the prior "Word-only" behavior:** the barcode tag is replaced during merge with a `##BARCODE:type:size:value##` sentinel, but the sentinel→CSS converter (`DocGenHtmlRenderer.renderBarcodeHtml`) was only invoked from the Word→HTML run-text path. A pure HTML template never passes through that path, so the marker survived as literal text. The rendering capability already existed (pure CSS bars / QR modules that `Blob.toPdf` renders perfectly) — it just wasn't wired into the HTML branch.
+
+**Fix:** new `DocGenHtmlRenderer.replaceBarcodeMarkersInHtml(html)` swaps every `##BARCODE:…##` marker for inline CSS **without escaping the surrounding HTML** (the Word path's per-run helper escapes its plain-text surroundings, which is wrong for already-HTML content). `DocGenService.mergeHtmlTemplate` now runs it over the merged body, header, and footer before handing off to `Blob.toPdf`. Supported symbologies remain Code 128 and QR (Level Q error correction, ≤600 chars). No new dependencies; renders entirely in-platform.
+
+**Validation:** e2e-01..08 + 07-syntax1..4 PASS/FAIL0 (new `HTML BARCODE+QR` assertion in 07-syntax4), RunLocalTests 1547/100%/76%, `sf code-analyzer` 0 violations, real HTML→PDF render confirmed (QR invoice + per-row barcode price list).
+
 ## v3.14.0 — Flow Signing Consolidation + Signed-Document Naming (`04tVx000000nYgTIAU`, build `3.14.0-2`, promoted 2026-06-14)
 
 Addresses four customer-reported issues from the Flow-triggered, single-signer signing flow — and the root-cause document-naming bug behind one of them. The theme is consolidation: Flow-triggered signing and the Signature Sender now behave identically.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 
 [Join the Community Channel](https://portwood.dev/community) | [Website](https://portwood.dev) | [Roadmap](https://portwood.dev/roadmap)
 
-[![Version](https://img.shields.io/badge/version-3.14.0-blue.svg)](#install)
+[![Version](https://img.shields.io/badge/version-3.15.0-blue.svg)](#install)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Salesforce-00A1E0.svg)](https://www.salesforce.com)
 [![Namespace](https://img.shields.io/badge/namespace-portwoodglobal-purple.svg)](#install)
-[![Apex Tests](https://img.shields.io/badge/Apex_Tests-1490_passing-brightgreen)](#code-quality)
+[![Apex Tests](https://img.shields.io/badge/Apex_Tests-1547_passing-brightgreen)](#code-quality)
 [![Coverage](https://img.shields.io/badge/Coverage-76%25-brightgreen)](#code-quality)
 [![Security](https://img.shields.io/badge/Code_Analyzer-0%2F0%2F0-brightgreen)](#security)
 [![Website](https://img.shields.io/badge/website-portwood.dev-blue)](https://portwood.dev)
@@ -18,10 +18,10 @@ Generate PDFs and Word docs from any Salesforce record. Merge PDFs, add barcodes
 ## Install
 
 ```bash
-sf package install --package 04tVx000000nPGbIAM --wait 10 --target-org <your-org>
+sf package install --package 04tVx000000nZ33IAE --wait 10 --target-org <your-org>
 ```
 
-[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nPGbIAM) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nPGbIAM)
+[Install in Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nZ33IAE) | [Install in Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tVx000000nZ33IAE)
 
 **Then:** Assign **DocGen Admin** permission set | Enable **Blob.toPdf() Release Update** | Open the **DocGen** app
 
@@ -371,7 +371,7 @@ Decompress → Merge XML tags → Recompress
 
 ## Releases
 
-DocGen ships on a **biweekly release cycle**. Latest release: **v3.11.0 — Shared Template Image Rendering**.
+DocGen ships on a **biweekly release cycle**. Latest release: **v3.15.0 — Barcodes & QR codes in HTML templates**.
 
 See [CHANGELOG.md](CHANGELOG.md) for full version history.
 
@@ -444,7 +444,11 @@ Found a vulnerability? See [SECURITY.md](SECURITY.md).
 
 | Version | Channel                                 | Package ID           |
 | ------- | --------------------------------------- | -------------------- |
-| v3.11.0 | **Latest (Released)**                   | `04tVx000000nPGbIAM` |
+| v3.15.0 | **Latest (Released)**                   | `04tVx000000nZ33IAE` |
+| v3.14.0 | Previous                                | `04tVx000000nYgTIAU` |
+| v3.13.0 | Previous                                | `04tVx000000nYdFIAU` |
+| v3.12.0 | Previous                                | `04tVx000000nYTZIA2` |
+| v3.11.0 | Previous                                | `04tVx000000nPGbIAM` |
 | v3.10.0 | Previous                                | `04tVx000000nOh7IAE` |
 | v3.09.0 | Previous                                | `04tVx000000nOdtIAE` |
 | v3.08.0 | Previous                                | `04tVx000000nOFhIAM` |

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -729,7 +729,7 @@ HTML templates work with every generation path: single-record, bulk (individual 
 
 #### 5.7.9 Known limitations
 
-- **Barcodes / QR codes** — `{*Field:qr}` etc. are Word-only today; in HTML templates the tag falls back to plain text. On the roadmap.
+- **Barcodes / QR codes** — `{*Field:qr}` / `{*Field:code128}` render in both Word **and** HTML templates (HTML support added in v3.15). They render as crisp CSS in the PDF — no external services.
 - **DOCX output** — not applicable. HTML templates are PDF-only.
 - **Signatures** — fully supported on HTML templates (as well as Word). `{@Signature_Role:Order:Type}` tags, guided field-to-field signing, draw-or-type, multi-signer, and the Certificate of Completion all work on HTML; HTML is in fact the recommended format for signature templates because the stamp-card layout has the most room to breathe.
 - **Page counters + rich header/footer content** — see §5.7.5. Flying Saucer flattens the margin to text when counters are present.
@@ -1666,7 +1666,7 @@ Handles multiple sources automatically:
 {*URL:qr:200}                   200px QR code
 ```
 
-Barcodes are rendered as images in PDF and DOCX output. Types supported: `code128`, `qr`.
+Barcodes render in Word **and** HTML templates (HTML support added in v3.15) across PDF and DOCX output. Types supported: `code128`, `qr`.
 
 QR codes are generated natively in Salesforce with Level Q error correction and support values up to 600 characters. For printed or mailed documents, short URLs or tokens under 120 characters are recommended for 1 inch square QR codes.
 

--- a/force-app/main/default/classes/DocGenHtmlRenderer.cls
+++ b/force-app/main/default/classes/DocGenHtmlRenderer.cls
@@ -4518,6 +4518,53 @@ public with sharing class DocGenHtmlRenderer {
             (String.isNotBlank(after) ? after.escapeHtml4() : '');
     }
 
+    /**
+     * Replaces EVERY ##BARCODE:type:size:value## marker in already-HTML content
+     * with inline CSS barcode / QR markup, leaving the surrounding HTML intact.
+     *
+     * Used by the HTML-template path (see DocGenService.mergeHtmlTemplate). The
+     * Word path renders markers per text-run via renderBarcodeHtml (which escapes
+     * its surrounding plain text); HTML-template bodies are already HTML, so the
+     * surrounding content must NOT be escaped — only the marker is swapped out.
+     * Blob.toPdf() renders the CSS perfectly — no images needed.
+     */
+    public static String replaceBarcodeMarkersInHtml(String html) {
+        if (String.isBlank(html) || !html.contains('##BARCODE:')) {
+            return html;
+        }
+        String result = '';
+        Integer cursor = 0;
+        while (true) {
+            Integer startIdx = html.indexOf('##BARCODE:', cursor);
+            if (startIdx == -1) {
+                result += html.substring(cursor);
+                break;
+            }
+            Integer endIdx = html.indexOf('##', startIdx + 10);
+            if (endIdx == -1) {
+                result += html.substring(cursor);
+                break;
+            }
+            result += html.substring(cursor, startIdx);
+            String marker = html.substring(startIdx + 10, endIdx);
+            List<String> parts = marker.split(':', 3);
+            String barcodeType = parts.size() > 0 ? parts[0] : '';
+            String sizeSpec = parts.size() > 1 ? parts[1] : '';
+            String value = parts.size() > 2 ? parts[2] : '';
+            value = value.replace('&amp;', '&').replace('&lt;', '<').replace('&gt;', '>');
+            String pattern = BarcodeGenerator.getPattern(value, barcodeType);
+            if (pattern == null) {
+                result += value.escapeHtml4();
+            } else if (barcodeType == 'qr') {
+                result += renderQrHtml(pattern, sizeSpec);
+            } else {
+                result += renderCode128Html(pattern, sizeSpec);
+            }
+            cursor = endIdx + 2;
+        }
+        return result;
+    }
+
     /** Renders Code 128 as inline CSS bars. */
     private static String renderCode128Html(String pattern, String sizeSpec) {
         // Parse size: "300x80" or default

--- a/force-app/main/default/classes/DocGenHtmlRendererTest.cls
+++ b/force-app/main/default/classes/DocGenHtmlRendererTest.cls
@@ -915,6 +915,45 @@ private class DocGenHtmlRendererTest {
         }
     }
 
+    // --- HTML-template path: replaceBarcodeMarkersInHtml (v3.15) ---------------
+
+    @IsTest
+    static void testReplaceBarcodeMarkersInHtmlCode128() {
+        // Marker embedded in already-HTML content (e.g. an HTML template table cell).
+        String html = '<td class="x">SKU: ##BARCODE:code128:200x44:PWG-1001##</td>';
+        String out = DocGenHtmlRenderer.replaceBarcodeMarkersInHtml(html);
+        System.assert(!out.contains('##BARCODE:'), 'Marker must be converted, not left raw');
+        System.assert(out.contains('display:inline-block'), 'Should render Code 128 CSS bars');
+        // Surrounding HTML must be preserved unescaped (not &lt;td&gt;).
+        System.assert(out.contains('<td class="x">'), 'Surrounding HTML must not be escaped');
+        System.assert(out.contains('SKU:'), 'Surrounding text preserved');
+    }
+
+    @IsTest
+    static void testReplaceBarcodeMarkersInHtmlQr() {
+        String html = '<div>Scan: ##BARCODE:qr:160:https://verify.portwood.dev/c/ABC##</div>';
+        String out = DocGenHtmlRenderer.replaceBarcodeMarkersInHtml(html);
+        System.assert(!out.contains('##BARCODE:'), 'QR marker must be converted');
+        System.assert(out.contains('display:inline-block'), 'Should render QR CSS modules');
+        System.assert(out.contains('<div>'), 'Surrounding HTML preserved');
+    }
+
+    @IsTest
+    static void testReplaceBarcodeMarkersInHtmlMultipleAndNoMarker() {
+        // Two markers in one body (e.g. a loop) are both converted.
+        String html = '<tr><td>##BARCODE:code128::A1##</td><td>##BARCODE:qr::A1##</td></tr>';
+        String out = DocGenHtmlRenderer.replaceBarcodeMarkersInHtml(html);
+        System.assert(!out.contains('##BARCODE:'), 'All markers converted');
+        System.assert(
+            out.contains('<tr><td>') && out.contains('</td><td>'),
+            'Surrounding table HTML preserved around both markers'
+        );
+        // No marker / null / blank are passthrough.
+        System.assertEquals('<p>no codes</p>', DocGenHtmlRenderer.replaceBarcodeMarkersInHtml('<p>no codes</p>'));
+        System.assertEquals(null, DocGenHtmlRenderer.replaceBarcodeMarkersInHtml(null));
+        System.assertEquals('', DocGenHtmlRenderer.replaceBarcodeMarkersInHtml(''));
+    }
+
     @IsTest
     static void testRenderBarcodeCode128WithSize() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -8295,6 +8295,14 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             ? null
             : processXml(decodeBraceEntities(footerHtml), recordDataMap);
 
+        // Convert {*Field:qr} / {*Field:code128} barcode markers (emitted by
+        // processXml as ##BARCODE:...##) into inline CSS so they render in
+        // HTML-template PDFs. The Word path does this per text-run; HTML bodies
+        // are already HTML, so swap only the marker (no surrounding escaping).
+        mergedBody = DocGenHtmlRenderer.replaceBarcodeMarkersInHtml(mergedBody);
+        mergedHeader = DocGenHtmlRenderer.replaceBarcodeMarkersInHtml(mergedHeader);
+        mergedFooter = DocGenHtmlRenderer.replaceBarcodeMarkersInHtml(mergedFooter);
+
         // 1.68 — set the renderer overrides BEFORE wrapping so wrapHtmlForPdf can
         // call computePageCss() and pick up the size/orientation/margins from
         // the merge result. Statics are cleared in renderPdf's finally block.

--- a/scripts/e2e-07-syntax4.apex
+++ b/scripts/e2e-07-syntax4.apex
@@ -389,6 +389,34 @@ try {
     System.debug('PICKLIST LABEL SUFFIX: FAIL — ' + e.getMessage());
 }
 
+// ===== Barcode / QR tags in HTML templates (v3.15) =====
+// processXml emits ##BARCODE:...## markers; the HTML path converts them to CSS
+// via DocGenHtmlRenderer.replaceBarcodeMarkersInHtml (Word path uses renderBarcodeHtml).
+try {
+    String bt = '<td>SKU {*Code__c:code128:200x44} <span>scan {*Url__c:qr:160}</span></td>';
+    String marked = DocGenService.processXmlForTest(
+        bt,
+        new Map<String, Object>{ 'Code__c' => 'PWG-1001', 'Url__c' => 'https://verify.portwood.dev/x' }
+    );
+    Boolean emitted = marked.contains('##BARCODE:code128') && marked.contains('##BARCODE:qr');
+    String rendered = DocGenHtmlRenderer.replaceBarcodeMarkersInHtml(marked);
+    Boolean ok =
+        emitted &&
+        !rendered.contains('##BARCODE:') &&
+        rendered.contains('display:inline-block') &&
+        rendered.contains('<td>'); // surrounding HTML preserved unescaped
+    if (ok) {
+        pass++;
+        System.debug('HTML BARCODE+QR: PASS');
+    } else {
+        fail++;
+        System.debug('HTML BARCODE+QR: FAIL — emitted=' + emitted + ' rendered=' + rendered.left(120));
+    }
+} catch (Exception e) {
+    fail++;
+    System.debug('HTML BARCODE+QR: FAIL — ' + e.getMessage());
+}
+
 System.debug('========================================');
 System.debug(
     'E2E-07-SYNTAX4 — PASS: ' + pass + '  FAIL: ' + fail + (fail == 0 ? '  ALL TESTS PASSED' : '  FAILURES DETECTED')

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,14 +1,14 @@
 {
   "packageDirectories": [
     {
-      "versionName": "v3.14.0 — Flow + Sender both use guided signing; doc-naming, signer email, Single order",
-      "versionNumber": "3.14.0.NEXT",
-      "ancestorId": "04tVx000000nYdFIAU",
+      "versionName": "v3.15.0 — Barcodes & QR codes in HTML templates",
+      "versionNumber": "3.15.0.NEXT",
+      "ancestorId": "04tVx000000nYgTIAU",
       "path": "force-app",
       "default": true,
       "definitionFile": "config/build-def.json",
       "package": "Portwood DocGen Managed",
-      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record. v3.14 brings the guided e-signature experience to every way you send — Flow automations and the Signature Sender alike — for both Word and HTML templates: signers walk field-by-field through the real PDF, drawing or typing their signature, initials, and date, with a clean signature stamp on the finished document and a Certificate of Completion attached automatically. Signed documents now follow your template's naming pattern, signers receive a completion confirmation email, and single-signer requests are simpler to set up. 100% native — no external services or callouts. Free for all users."
+      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record. v3.15 brings scannable barcodes and QR codes to HTML templates — not just Word. Drop a Code 128 barcode or QR code into any HTML template with a simple tag and it renders crisply in the PDF: invoices with QR pay-links, product catalogs and price lists with scannable SKUs, event tickets, and verifiable certificates all work from HTML now. 100% native — no external services or callouts. Free for all users."
     }
   ],
   "name": "Portwood DocGen",
@@ -178,6 +178,7 @@
     "Portwood DocGen Managed@3.13.0-2": "04tVx000000nYWnIAM",
     "Portwood DocGen Managed@3.13.0-3": "04tVx000000nYdFIAU",
     "Portwood DocGen Managed@3.14.0-1": "04tVx000000nYerIAE",
-    "Portwood DocGen Managed@3.14.0-2": "04tVx000000nYgTIAU"
+    "Portwood DocGen Managed@3.14.0-2": "04tVx000000nYgTIAU",
+    "Portwood DocGen Managed@3.15.0-1": "04tVx000000nZ33IAE"
   }
 }


### PR DESCRIPTION
Enables `{*Field:code128}` / `{*Field:qr}` in **HTML templates**, not just Word.

**Root cause:** the `##BARCODE:` marker→CSS converter (`renderBarcodeHtml`) was only wired into the Word→HTML run-text path, so pure HTML templates leaked the raw marker. The CSS rendering capability already existed.

**Fix:** new `DocGenHtmlRenderer.replaceBarcodeMarkersInHtml()` swaps every marker for inline CSS without escaping surrounding HTML; `DocGenService.mergeHtmlTemplate` runs it over body/header/footer before `Blob.toPdf`.

**Validation:** e2e 01-08 + syntax1-4 PASS/FAIL0 (new `HTML BARCODE+QR` assertion), RunLocalTests 1547/100%/76%, code-analyzer 0. Real HTML→PDF render confirmed (QR invoice + per-row barcode price list). Docs updated (README install links/table, CHANGELOG, UserGuide).

Shipped as managed `04tVx000000nZ33IAE` (3.15.0-1, promoted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)