### PR TITLE
feat(admin): surface body file in Version History (template stale-body diagnostics)

### DIFF
--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -3291,6 +3291,58 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
     }
 
     /**
+     * Returns the body ContentVersion's version number + filename for each given
+     * Content_Version_Id__c, so the Version History view can show which underlying
+     * file a version actually points at (diagnostic for "generation read a body I
+     * didn't expect"). Keyed by ContentVersion Id → { versionNumber, fileName }.
+     *
+     * SYSTEM_MODE for the read (with an explicit per-field FLS guard) mirrors
+     * getTemplateFileContent: the template-body CV's ContentDocumentLink can default
+     * to Visibility=InternalUsers, which a USER_MODE read would strip.
+     */
+    @AuraEnabled
+    public static Map<String, Object> getVersionBodyFileInfo(List<String> contentVersionIds) {
+        Map<String, Object> result = new Map<String, Object>();
+        if (contentVersionIds == null || contentVersionIds.isEmpty()) {
+            return result;
+        }
+        Set<Id> ids = new Set<Id>();
+        for (String s : contentVersionIds) {
+            if (String.isBlank(s)) {
+                continue;
+            }
+            try {
+                ids.add((Id) s);
+            } catch (Exception e) {
+                String noop = e.getMessage(); // NOPMD — skip non-Id values defensively
+            }
+        }
+        if (ids.isEmpty() || !Schema.sObjectType.ContentVersion.isAccessible()) {
+            return result;
+        }
+        DocGenFlsGuard.assertAccessible(
+            ContentVersion.sObjectType,
+            new Set<String>{ 'VersionNumber', 'Title', 'PathOnClient' }
+        );
+        /* code-analyzer-suppress ApexFlsViolation */
+        for (ContentVersion cv : [
+            SELECT Id, VersionNumber, Title, PathOnClient
+            FROM ContentVersion
+            WHERE Id IN :ids
+            WITH SYSTEM_MODE
+        ]) {
+            result.put(
+                String.valueOf(cv.Id),
+                new Map<String, Object>{
+                    'versionNumber' => cv.VersionNumber,
+                    'fileName' => String.isNotBlank(cv.PathOnClient) ? cv.PathOnClient : cv.Title
+                }
+            );
+        }
+        return result;
+    }
+
+    /**
      * Issue #83 — Deletes a non-active template version and its associated files.
      * Removes the version record, its body ContentVersion, and all pre-decomposed
      * XML ContentVersions (titles starting with `docgen_tmpl_xml_<versionId>_`).

--- a/force-app/main/default/classes/DocGenControllerTests.cls
+++ b/force-app/main/default/classes/DocGenControllerTests.cls
@@ -436,6 +436,38 @@ private class DocGenControllerTests {
     }
 
     // -----------------------------------------------------------------------
+    // getVersionBodyFileInfo
+    // -----------------------------------------------------------------------
+    @IsTest
+    static void testGetVersionBodyFileInfo() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            ContentVersion cv = new ContentVersion(
+                Title = 'docgen_html_body_test',
+                PathOnClient = 'body.html',
+                VersionData = Blob.valueOf('<html>{Name}</html>'),
+                IsMajorVersion = false
+            );
+            insert cv;
+            String cvId = [SELECT Id FROM ContentVersion WHERE Id = :cv.Id LIMIT 1].Id;
+
+            Test.startTest();
+            // Includes a null and a non-Id value to exercise the defensive skip.
+            Map<String, Object> info = DocGenController.getVersionBodyFileInfo(
+                new List<String>{ cvId, null, 'not-an-id' }
+            );
+            Map<String, Object> emptyResult = DocGenController.getVersionBodyFileInfo(new List<String>());
+            Test.stopTest();
+
+            System.assert(info.containsKey(cvId), 'Should return file info keyed by ContentVersion Id');
+            Map<String, Object> meta = (Map<String, Object>) info.get(cvId);
+            System.assertEquals('body.html', meta.get('fileName'), 'fileName should come from PathOnClient');
+            System.assertNotEquals(null, meta.get('versionNumber'), 'versionNumber should be populated');
+            System.assert(emptyResult.isEmpty(), 'Empty input should return an empty map');
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // getObjectOptions (Schema)
     // -----------------------------------------------------------------------
     @IsTest

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -2633,6 +2633,7 @@
                                                 data={versions}
                                                 columns={versionColumns}
                                                 onrowaction={handleRestoreVersion}
+                                                column-widths-mode="auto"
                                                 hide-checkbox-column
                                             >
                                             </lightning-datatable>

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -11,6 +11,7 @@ import deleteTemplate from '@salesforce/apex/DocGenController.deleteTemplate';
 import saveTemplate from '@salesforce/apex/DocGenController.saveTemplate';
 import generateDocumentData from '@salesforce/apex/DocGenController.generateDocumentData';
 import getTemplateVersions from '@salesforce/apex/DocGenController.getTemplateVersions';
+import getVersionBodyFileInfo from '@salesforce/apex/DocGenController.getVersionBodyFileInfo';
 import deleteTemplateVersion from '@salesforce/apex/DocGenController.deleteTemplateVersion';
 import generateDocumentParts from '@salesforce/apex/DocGenController.generateDocumentParts';
 import getContentVersionBase64 from '@salesforce/apex/DocGenController.getContentVersionBase64';
@@ -191,6 +192,10 @@ const VERSION_COLUMNS = [
         }
     },
     { label: 'Created By', fieldName: 'CreatedByName' },
+    // Body file the version points at — surfaces which underlying ContentVersion
+    // generation actually reads (diagnostic for stale/mismatched template bodies).
+    { label: 'File Ver', fieldName: 'bodyCvVersion', initialWidth: 80 },
+    { label: 'File Name', fieldName: 'bodyCvFileName' },
     {
         type: 'button',
         initialWidth: 130,
@@ -2894,12 +2899,35 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                         CreatedByName: v.CreatedBy ? v.CreatedBy.Name : '',
                         isActiveLabel: isActive ? '✓' : '',
                         activeClass: isActive ? 'slds-text-color_success slds-text-title_bold' : '',
-                        activateVariant: isActive ? 'neutral' : 'brand'
+                        activateVariant: isActive ? 'neutral' : 'brand',
+                        bodyCvVersion: '',
+                        bodyCvFileName: ''
                     };
                 });
                 // Sync watermark CV from the active version so the tab shows current state
                 const active = data.find((v) => v[F.VerIsActive]);
                 this.editTemplateWatermarkCvId = active ? active[F.VerWatermarkCv] || null : null;
+
+                // Enrich with the body ContentVersion's number + filename so the table
+                // shows which underlying file each version points at (diagnostic).
+                const cvIds = data.map((v) => v[F.VerCvId]).filter(Boolean);
+                if (cvIds.length) {
+                    getVersionBodyFileInfo({ contentVersionIds: cvIds })
+                        .then((info) => {
+                            if (!info) {
+                                return;
+                            }
+                            this.versions = this.versions.map((row) => {
+                                const meta = info[row[F.VerCvId]];
+                                return meta
+                                    ? { ...row, bodyCvVersion: meta.versionNumber, bodyCvFileName: meta.fileName }
+                                    : row;
+                            });
+                        })
+                        .catch(() => {
+                            // Non-fatal — leave the file columns blank if the lookup fails.
+                        });
+                }
             })
             .catch(() => {
                 this.versions = [];

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -170,7 +170,7 @@ const COLUMNS = [
 ];
 
 const VERSION_COLUMNS = [
-    { label: 'Ver', fieldName: 'VersionNumber', initialWidth: 70 },
+    { label: 'Version', fieldName: 'VersionNumber', initialWidth: 90 },
     {
         label: 'Active',
         fieldName: 'isActiveLabel',
@@ -194,7 +194,8 @@ const VERSION_COLUMNS = [
     { label: 'Created By', fieldName: 'CreatedByName' },
     // Body file the version points at — surfaces which underlying ContentVersion
     // generation actually reads (diagnostic for stale/mismatched template bodies).
-    { label: 'File Ver', fieldName: 'bodyCvVersion', initialWidth: 80 },
+    // The same CV Id across rows = a metadata-only save reused the prior body.
+    { label: 'File CV Id', fieldName: 'bodyCvId', initialWidth: 170 },
     { label: 'File Name', fieldName: 'bodyCvFileName' },
     {
         type: 'button',
@@ -2890,17 +2891,17 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                     this.editTemplateWatermarkCvId = null;
                     return;
                 }
-                const total = data.length;
-                this.versions = data.map((v, index) => {
+                this.versions = data.map((v) => {
                     const isActive = v[F.VerIsActive];
                     return {
                         ...v,
-                        VersionNumber: 'v' + (total - index),
+                        // Show the real version record name (e.g. V-0024), not a synthetic index.
+                        VersionNumber: v.Name,
                         CreatedByName: v.CreatedBy ? v.CreatedBy.Name : '',
                         isActiveLabel: isActive ? '✓' : '',
                         activeClass: isActive ? 'slds-text-color_success slds-text-title_bold' : '',
                         activateVariant: isActive ? 'neutral' : 'brand',
-                        bodyCvVersion: '',
+                        bodyCvId: v[F.VerCvId] || '',
                         bodyCvFileName: ''
                     };
                 });
@@ -2919,9 +2920,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                             }
                             this.versions = this.versions.map((row) => {
                                 const meta = info[row[F.VerCvId]];
-                                return meta
-                                    ? { ...row, bodyCvVersion: meta.versionNumber, bodyCvFileName: meta.fileName }
-                                    : row;
+                                return meta ? { ...row, bodyCvFileName: meta.fileName } : row;
                             });
                         })
                         .catch(() => {

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -170,11 +170,10 @@ const COLUMNS = [
 ];
 
 const VERSION_COLUMNS = [
-    { label: 'Version', fieldName: 'VersionNumber', initialWidth: 90 },
+    { label: 'Version', fieldName: 'VersionNumber' },
     {
         label: 'Active',
         fieldName: 'isActiveLabel',
-        initialWidth: 70,
         cellAttributes: {
             class: { fieldName: 'activeClass' }
         }
@@ -195,7 +194,7 @@ const VERSION_COLUMNS = [
     // Body file the version points at — surfaces which underlying ContentVersion
     // generation actually reads (diagnostic for stale/mismatched template bodies).
     // The same CV Id across rows = a metadata-only save reused the prior body.
-    { label: 'File CV Id', fieldName: 'bodyCvId', initialWidth: 170 },
+    { label: 'File CV Id', fieldName: 'bodyCvId' },
     { label: 'File Name', fieldName: 'bodyCvFileName' },
     {
         type: 'button',

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -196,9 +196,11 @@ const VERSION_COLUMNS = [
     // The same CV Id across rows = a metadata-only save reused the prior body.
     { label: 'File CV Id', fieldName: 'bodyCvId' },
     { label: 'File Name', fieldName: 'bodyCvFileName' },
+    // Action buttons: uniform fixed width + centered so they line up at the right.
     {
         type: 'button',
         initialWidth: 130,
+        cellAttributes: { alignment: 'center' },
         typeAttributes: {
             label: 'Preview',
             name: 'preview',
@@ -208,6 +210,8 @@ const VERSION_COLUMNS = [
     },
     {
         type: 'button',
+        initialWidth: 130,
+        cellAttributes: { alignment: 'center' },
         typeAttributes: {
             label: 'Activate',
             name: 'restore',
@@ -221,7 +225,8 @@ const VERSION_COLUMNS = [
         // Disabled on the active version; the row.disableDelete flag is set in
         // loadVersions() to mirror Is_Active__c.
         type: 'button',
-        initialWidth: 110,
+        initialWidth: 130,
+        cellAttributes: { alignment: 'center' },
         typeAttributes: {
             label: 'Delete',
             name: 'deleteVersion',


### PR DESCRIPTION
What & why

  Investigates reports of generation rendering a stale/unexpected template body, and adds the observability to diagnose it from the Version History UI.

  Finding (not a race / stale-pointer bug): generation reads exactly the body the active version points at. The real mechanism is carry-forward — DocGenController.saveTemplate reuses the prior version's Content_Version_Id__c when you "Save as New Version" without re-uploading a
  body file. So metadata-only saves produce new version rows that share one body ContentVersion. Verified on a live template where 7 versions shared a single body CV. (The save runs in one synchronous transaction, so the "non-atomic deactivate/insert" race theory doesn't hold.)

  This was invisible in the UI, which is what made it hard to diagnose — so this PR surfaces it.

  Changes (admin Version History table)

  - New File CV Id + File Name columns — the body ContentVersion each version points at. The same CV Id repeated down the rows = carry-forward (a save reused the prior body), now obvious at a glance.
  - Version column shows the real record name (e.g. V-0024) instead of a synthetic v11 line-number index that read like a version number but wasn't one.
  - Auto-sized data columns (column-widths-mode="auto"); uniform 130px, centered action buttons (Preview / Activate / Delete) so they line up at the right.
  - New @AuraEnabled DocGenController.getVersionBodyFileInfo(List<String>) returning {versionNumber, fileName} per ContentVersion Id (SYSTEM_MODE + per-field FLS guard, mirroring getTemplateFileContent's internal-CV read). Defensive skip of null/non-Id input.

  Testing

  - DocGenControllerTests.testGetVersionBodyFileInfo (incl. null / non-Id defensive path) — DocGenControllerTests 224 / 100% on the scratch org.
  - Deployed and verified live: the new columns correctly show the carry-forward (repeated CV Id) across versions.

  Scope note

  Observability only — this does not change the carry-forward save behavior. If we decide that behavior is wrong (e.g. a metadata-only save should warn when it reuses the old body), that's a follow-up.

  Pre-existing (unrelated)

  Cut from current main, so it carries the existing e2e-07-syntax1 "SIGNATURE TAG PRESERVED" failure from the signing leak-fix (preserveSignatureTags=false default). This branch does not touch signing.

  🤖 Generated with Claude Code (https://claude.com/claude-code)