### PR TITLE
Unified signature sending — inline signatures on every route (v3.21.0)

### DIFF
--- a/force-app/main/default/classes/DocGenSignaturePdfFlowAction.cls
+++ b/force-app/main/default/classes/DocGenSignaturePdfFlowAction.cls
@@ -99,8 +99,8 @@ global with sharing class DocGenSignaturePdfFlowAction { // NOPMD AvoidGlobalMod
     }
 
     @InvocableMethod(
-        label='DocGen: Send Existing Document for Signature'
-        description='Sends an already-generated document (a ContentVersion) for signature on the flat-PDF signing page. Pass the Content Version Id and a collection of Signers. Returns signing URLs.'
+        label='DocGen: Send Existing Document for Signature (Deprecated — use "DocGen: Create Signature Request")'
+        description='DEPRECATED: use "DocGen: Create Signature Request" instead. Kept for existing Flows; now routes through the same unified signing path, so signature placement tags ({@Signature_Role:Order:Type[:inline]}) are honored and the {#Signatures} loop still populates. Pass a Template Id, Related Record Id, and a Signers collection. Returns signing URLs.'
         category='Document Generation'
     )
     global static List<Result> send(List<Request> requests) {
@@ -153,10 +153,13 @@ global with sharing class DocGenSignaturePdfFlowAction { // NOPMD AvoidGlobalMod
             }
 
             String signersJson = JSON.serialize(signerInputs);
-            // Template-only: snapshot the record data + re-render with a certificate page
-            // on completion. (The pre-generated-PDF path was removed — see the templateId
-            // guard above.)
-            List<DocGenSignatureSenderController.SignerResult> signerResults = DocGenSignatureSenderController.createTemplateSnapshotRequest(
+            // DEPRECATED action — routed through the single canonical entry point so its
+            // behavior is identical to "DocGen: Create Signature Request": placement tags
+            // ({@Signature_Role:Order:Type[:inline]}) are positioned/inline-composited, and
+            // a {#Signatures}-loop template is dispatched to the snapshot render strategy
+            // internally. Previously this called createTemplateSnapshotRequest directly,
+            // which silently dropped {@Signature_*} tags (and :inline). See #NNN.
+            List<DocGenSignatureSenderController.SignerResult> signerResults = DocGenSignatureSenderController.createGuidedPdfSignatureRequest(
                 req.templateId,
                 req.relatedRecordId,
                 signersJson,

--- a/force-app/main/default/classes/DocGenSignaturePdfTests.cls
+++ b/force-app/main/default/classes/DocGenSignaturePdfTests.cls
@@ -564,6 +564,101 @@ private class DocGenSignaturePdfTests {
     }
 
     @isTest
+    static void testGuidedEntry_loopOnlyTemplate_routesToSnapshot() {
+        // Consolidation: the single canonical entry (createGuidedPdfSignatureRequest)
+        // dispatches a {#Signatures}-loop template that has NO {@Signature_*} placement
+        // tags to the snapshot render strategy, so the variable-signer loop still
+        // repopulates with signed rows at completion (the guided frozen-body path can't).
+        // Backwards-compat for loop templates after both Flow actions were unified.
+        Account acc = new Account(Name = 'Loop Co', Industry = 'Technology');
+        insert acc;
+        Id templateId = createHtmlSignatureTemplate(
+            '<html><body><h1>{Name}</h1>{#Signatures}<div>{Name} {Date}</div>{/Signatures}</body></html>'
+        );
+        String signersJson = JSON.serialize(
+            new List<Map<String, Object>>{
+                new Map<String, Object>{
+                    'signerName' => 'Loop Signer',
+                    'signerEmail' => 'loop@test.com',
+                    'roleName' => 'Signer'
+                }
+            }
+        );
+
+        Test.startTest();
+        DocGenSignatureSenderController.createGuidedPdfSignatureRequest(
+            templateId,
+            acc.Id,
+            signersJson,
+            'Parallel',
+            null
+        );
+        Test.stopTest();
+
+        DocGen_Signature_Request__c req = [
+            SELECT Render_Data_Snapshot__c, Frozen_Document__c
+            FROM DocGen_Signature_Request__c
+            WHERE Template__c = :templateId
+            ORDER BY CreatedDate DESC
+            LIMIT 1
+        ];
+        System.assert(
+            String.isNotBlank(req.Render_Data_Snapshot__c),
+            'Loop-only template must route to the snapshot strategy so the loop repopulates at completion'
+        );
+        System.assert(String.isBlank(req.Frozen_Document__c), 'Snapshot strategy does not freeze a sentinel body');
+    }
+
+    @isTest
+    static void testGuidedEntry_tagTemplate_staysGuidedAndKeepsInline() {
+        // A {@Signature_*} template stays on the guided sentinel path and carries the
+        // :inline flag onto the placement — Sarah's waiver fix (:inline was previously
+        // dropped when the deprecated Flow action sent through the snapshot path).
+        Account acc = new Account(Name = 'Tag Co');
+        insert acc;
+        Id templateId = createHtmlSignatureTemplate(
+            '<html><body><p>Sign: {@Signature_Signer:1:Full:inline}</p></body></html>'
+        );
+        String signersJson = JSON.serialize(
+            new List<Map<String, Object>>{
+                new Map<String, Object>{
+                    'signerName' => 'Tag Signer',
+                    'signerEmail' => 'tag@test.com',
+                    'roleName' => 'Signer'
+                }
+            }
+        );
+
+        Test.startTest();
+        DocGenSignatureSenderController.createGuidedPdfSignatureRequest(
+            templateId,
+            acc.Id,
+            signersJson,
+            'Parallel',
+            null
+        );
+        Test.stopTest();
+
+        DocGen_Signature_Request__c req = [
+            SELECT Render_Data_Snapshot__c, Frozen_Document__c
+            FROM DocGen_Signature_Request__c
+            WHERE Template__c = :templateId
+            ORDER BY CreatedDate DESC
+            LIMIT 1
+        ];
+        System.assert(String.isNotBlank(req.Frozen_Document__c), 'Tag template stays on the guided frozen-body path');
+        System.assert(String.isBlank(req.Render_Data_Snapshot__c), 'Guided path does not snapshot record data');
+
+        DocGen_Signature_Placement__c plc = [
+            SELECT Render_Inline__c
+            FROM DocGen_Signature_Placement__c
+            WHERE Signature_Request__c = :req.Id AND Placement_Type__c = 'Full'
+            LIMIT 1
+        ];
+        System.assertEquals(true, plc.Render_Inline__c, ':inline flag must reach the placement on the guided path');
+    }
+
+    @isTest
     static void testSavePdfSignature_snapshotBacked_leavesInProgressForFinalizer() {
         // A snapshot-backed request must stay 'In Progress' after savePdfSignature so the
         // platform-event trigger can enqueue the finalizer (which sets 'Signed'). This is the

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -146,6 +146,19 @@ public with sharing class DocGenSignatureSenderController {
     }
 
     /**
+     * True when the template body contains the reserved {#Signatures} variable-signer
+     * loop block. Drives the canonical-entry dispatch in createGuidedPdfSignatureRequest:
+     * a loop-only template (no {@Signature_*} tags) routes to the snapshot render
+     * strategy, because the guided frozen-body path freezes the loop empty at send and
+     * can't repopulate it with signed rows at completion.
+     */
+    @TestVisible
+    private static Boolean templateHasSignaturesLoopBlock(Id templateId) {
+        String plain = extractTemplatePlainText(templateId);
+        return plain != null && plain.contains('{#Signatures}');
+    }
+
+    /**
      * Extracts concatenated plain text from a template's pre-decomposed document.xml.
      * Reads from stored XML ContentVersions — no ZIP decompression needed.
      */
@@ -831,6 +844,12 @@ public with sharing class DocGenSignatureSenderController {
     /**
      * Milestone 2 — "send a template for signature with a data snapshot".
      *
+     * NOTE: no longer a primary entry point. createGuidedPdfSignatureRequest is the
+     * single canonical send method; it dispatches here ONLY for templates that use the
+     * {#Signatures} variable-signer loop block and carry no {@Signature_*} placement
+     * tags, because the loop needs this snapshot/re-render strategy to repopulate signed
+     * rows at completion. Still @AuraEnabled (a thin direct caller + its test remain).
+     *
      * Captures the template's resolved merge data for the record as JSON at
      * send-time (Render_Data_Snapshot__c) and generates the viewing PDF from that
      * SAME snapshot, so what the signer reviews is byte-identical to what the
@@ -1110,6 +1129,48 @@ public with sharing class DocGenSignatureSenderController {
             signerInputs.add((Map<String, Object>) item);
         }
 
+        // ── Single canonical signature-send entry point ─────────────────────────
+        // Every send action (the runner LWC, "DocGen: Create Signature Request", and
+        // the deprecated "DocGen: Send Existing Document for Signature") funnels
+        // through here. Dispatch by template shape:
+        //   • {@Signature_*} placement tags  → guided sentinel path below (inline-aware)
+        //   • tag-less                        → guided synthetic "Signatures" block (#170)
+        //   • {#Signatures} loop block ONLY   → snapshot render strategy (this branch)
+        // The {#Signatures} variable-signer loop is repopulated with the SIGNED rows at
+        // completion (buildSignerLoopData). The guided frozen-body path freezes the loop
+        // empty at send and can't reproduce that, so loop-only templates must use the
+        // snapshot mechanism to stay backwards-compatible. A template that has BOTH tags
+        // and a loop block keeps the guided path (tags win); the loop renders empty — a
+        // rare, documented edge.
+        List<PlacementInfo> placements = getTemplateSignaturePlacements(templateId);
+        if (placements.isEmpty() && templateHasSignaturesLoopBlock(templateId)) {
+            DocGenFlsGuard.assertAccessible(
+                DocGen_Template__c.sObjectType,
+                new Set<String>{ 'Base_Object_API__c', 'Query_Config__c' }
+            );
+            /* code-analyzer-suppress ApexFlsViolation */
+            List<DocGen_Template__c> shape = [
+                SELECT Base_Object_API__c, Query_Config__c
+                FROM DocGen_Template__c
+                WHERE Id = :templateId
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ]; // NOPMD ApexCRUDViolation - package-internal custom object; CRUD controlled by DocGen permission sets
+            if (
+                !shape.isEmpty() &&
+                String.isNotBlank(shape[0].Base_Object_API__c) &&
+                String.isNotBlank(shape[0].Query_Config__c)
+            ) {
+                return createTemplateSnapshotRequest(
+                    templateId,
+                    relatedRecordId,
+                    signersJson,
+                    signingOrder,
+                    documentTitleFormat
+                );
+            }
+        }
+
         // Merge the template against the live record (point-in-time body).
         Map<String, Object> mergeData = DocGenService.mergeTemplateForSignature(templateId, relatedRecordId);
         String templateType = (String) mergeData.get('templateType');
@@ -1122,7 +1183,6 @@ public with sharing class DocGenSignatureSenderController {
             body = (String) mergeData.get('documentXml');
         }
 
-        List<PlacementInfo> placements = getTemplateSignaturePlacements(templateId);
         if (placements.isEmpty()) {
             // Option (b) for tag-less legacy templates (#170): synthesize a "Signatures"
             // block (one Full + Date per signer) and append it to the merged body so the

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -184,6 +184,7 @@
     "Portwood DocGen Managed@3.18.0-1": "04tVx000000nb85IAA",
     "Portwood DocGen Managed@3.18.0-2": "04tVx000000nbBJIAY",
     "Portwood DocGen Managed@3.19.0-1": "04tVx000000ncSLIAY",
-    "Portwood DocGen Managed@3.20.0-1": "04tVx000000nij3IAA"
+    "Portwood DocGen Managed@3.20.0-1": "04tVx000000nij3IAA",
+    "Portwood DocGen Managed@3.21.0-1": "04tVx000000npXdIAI"
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,14 +1,14 @@
 {
   "packageDirectories": [
     {
-      "versionName": "v3.20.0 — E-signature reliability + inline signatures",
-      "versionNumber": "3.20.0.NEXT",
-      "ancestorId": "04tVx000000ncSLIAY",
+      "versionName": "v3.21.0 — Unified signature sending (inline signatures on every route)",
+      "versionNumber": "3.21.0.NEXT",
+      "ancestorId": "04tVx000000nij3IAA",
       "path": "force-app",
       "default": true,
       "definitionFile": "config/build-def.json",
       "package": "Portwood DocGen Managed",
-      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record. v3.20 makes e-signatures more reliable: signers now always receive their completion email, signed documents follow the same naming pattern as your generated documents, and there's a new compact in-place signature style for tight layouts. Admins also get a heads-up when a new template version reuses the previous file. 100% native Salesforce — no external services or callouts. Free for all users."
+      "versionDescription": "Portwood DocGen generates Word and PDF documents from any Salesforce record. v3.21 makes signature placement consistent everywhere you send from — a record page or an automated Flow. Drop {@Signature_Role} tags (with the compact :inline style) anywhere in your template and signers' marks land exactly where you put them, then the signed PDF is filed back to the record automatically. 100% native Salesforce — no external services or callouts. Free for all users."
     }
   ],
   "name": "Portwood DocGen",


### PR DESCRIPTION
## What

Consolidates signature sending onto a single guided path so `{@Signature_Role:…:inline}` placement tags are honored on **every** send route — fixing Sarah's waiver where `:inline` was silently ignored (signature landed only in the bottom Certificate, never inline at the tag).

## Root cause

The **"DocGen: Send Existing Document for Signature"** Flow action (`DocGenSignaturePdfFlowAction`) called `createTemplateSnapshotRequest` (snapshot path), which passes `templateId=null` and therefore **drops `{@Signature_*}` placement tags and the `:inline` modifier entirely**. The runner LWC and the "Create Signature Request" action already used the guided path, so they honored `:inline` — only this action didn't.

## Change

- Repoint `DocGenSignaturePdfFlowAction` → `createGuidedPdfSignatureRequest` (the single canonical entry). Mark the action **deprecated** in its label/description (managed-package immutability blocks removal; existing Flows keep working, now correctly).
- Make `createGuidedPdfSignatureRequest` **shape-aware**:
  - `{@Signature_*}` tag templates → guided sentinel path (`:inline` honored)
  - tag-less → guided synthetic "Signatures" block (#170)
  - **`{#Signatures}` loop-only → snapshot mechanism** (backwards-compat: the guided frozen-body path freezes the loop empty at send, so loop templates must use the snapshot re-render to repopulate signed rows at completion)
- New tests: `testGuidedEntry_loopOnlyTemplate_routesToSnapshot`, `testGuidedEntry_tagTemplate_staysGuidedAndKeepsInline`.

## Validation

- **Proven end-to-end in a real browser** on Sarah's actual `SHWaiver.docx` via **both** the Flow action and the runner LWC: drew a signature → final signed PDF attached to the record shows the ink **inline on the Signature line** + date inline.
- Namespaced package build `RunLocalTests` passed (77% coverage, passed-coverage-check).
- `code-analyzer` (Security/AppExchange): 0 violations.
- e2e-02 (10/0), e2e-06 signatures (24/0), e2e-07 syntax 1–4 (35/31/17/20, 0 fail), `DocGenSignaturePdfTests` 29/29.

Released as **v3.21.0** (`04tVx000000npXdIAI`, promoted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
