### PR TITLE
feat(bulk): deferred giant-query fallback for oversized records (#155)

### DIFF
--- a/force-app/main/default/classes/DocGenBatch.cls
+++ b/force-app/main/default/classes/DocGenBatch.cls
@@ -19,6 +19,18 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
     private Integer heapFailCount = 0;
     private static final Integer MAX_ERROR_LINES = 200;
 
+    // #155 — IDs of records that failed with heap/oversize errors, captured so finish()
+    // can enqueue a Queueable fallback that re-runs each through the giant-query path
+    // (the bulk batch itself cannot launch a Batchable). Stateful — accumulates across
+    // execute() chunks. Capped so a pathological filter can't grow this unbounded; the
+    // overflow count is surfaced in the error log (never silently dropped).
+    @TestVisible
+    private List<Id> oversizedRecordIds = new List<Id>();
+    @TestVisible
+    private Integer oversizedOverflowCount = 0;
+    @TestVisible
+    private static final Integer MAX_FALLBACK_RECORDS = 100;
+
     // Bulk data cache — populated in start(), read in execute()
     public Id dataCacheCvId;
     public String cachedDataJson;
@@ -336,6 +348,12 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
         String reason;
         if (e instanceof HeapPressureException || isHeapError(e)) {
             heapFailCount++;
+            // #155 — capture the Id for the giant-query fallback (capped; overflow counted).
+            if (oversizedRecordIds.size() < MAX_FALLBACK_RECORDS) {
+                oversizedRecordIds.add(recordId);
+            } else {
+                oversizedOverflowCount++;
+            }
             reason =
                 'too large for standard bulk generation (too many related rows) — ' +
                 'generate this record individually so it routes through the giant-query path';
@@ -371,8 +389,19 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
         if (heapFailCount > 0) {
             lines.add(
                 heapFailCount +
-                    ' record(s) were too large for standard bulk generation — generate those ' +
-                    'individually to use the giant-query path. Details below.'
+                    ' record(s) were too large for standard bulk generation — these are being ' +
+                    'queued automatically for individual giant-query generation (#155). Details below.'
+            );
+        }
+        if (oversizedOverflowCount > 0) {
+            // No silent caps: say plainly how many oversized records exceeded the
+            // auto-recovery cap and still need a manual individual run.
+            lines.add(
+                'Note: only the first ' +
+                    MAX_FALLBACK_RECORDS +
+                    ' oversized record(s) were queued for automatic recovery; ' +
+                    oversizedOverflowCount +
+                    ' more must be generated individually by hand.'
             );
         }
         lines.addAll(errorLog);
@@ -425,6 +454,22 @@ public with sharing class DocGenBatch implements Database.Batchable<SObject>, Da
                     Error_Count__c = failCount
                 ); // NOPMD ApexCRUDViolation — package-internal; CRUD controlled by permission sets
             }
+        } else if (!oversizedRecordIds.isEmpty()) {
+            // #155 — some records were too large for standard bulk generation. A batch
+            // can't launch a batch, but it can enqueue a Queueable that does: dispatch each
+            // oversized record through the giant-query path. The parent stays 'Recovering'
+            // until DocGenBulkGiantFallbackJob has dispatched them all, then it flips the
+            // job to 'Completed with Errors'. (Merge-mode oversized records are out of
+            // scope — they remain flagged in the log, as before.)
+            status = 'Recovering';
+            update new DocGen_Job__c( // NOPMD ApexCRUDViolation — package-internal; CRUD controlled by permission sets
+                Id = jobId,
+                Status__c = status,
+                Success_Count__c = successCount,
+                Error_Count__c = failCount,
+                Error_Log__c = buildErrorLog()
+            );
+            System.enqueueJob(new DocGenBulkGiantFallbackJob(jobId, templateId, oversizedRecordIds));
         } else {
             update new DocGen_Job__c( // NOPMD ApexCRUDViolation — package-internal; CRUD controlled by permission sets
                 Id = jobId,

--- a/force-app/main/default/classes/DocGenBatchErrorLogTest.cls
+++ b/force-app/main/default/classes/DocGenBatchErrorLogTest.cls
@@ -79,4 +79,59 @@ private class DocGenBatchErrorLogTest {
         DocGenBatch batch = new DocGenBatch(jobId);
         System.assertEquals(null, batch.buildErrorLog(), 'No failures → null (Error_Log__c stays empty)');
     }
+
+    // #155 — oversized records are captured by Id (not just counted) so finish() can
+    // hand them to the giant-query fallback Queueable.
+    @isTest
+    static void heapFailureCapturesRecordIdForFallback() {
+        Id jobId = newJob();
+        Id recId = anAccountId();
+        DocGenBatch batch = new DocGenBatch(jobId);
+
+        batch.recordFailure(recId, new HeapPressureException());
+
+        System.assertEquals(1, batch.oversizedRecordIds.size(), 'Oversized record Id captured for fallback');
+        System.assertEquals(recId, batch.oversizedRecordIds[0], 'Captured the right record Id');
+        System.assertEquals(0, batch.oversizedOverflowCount, 'No overflow under the cap');
+    }
+
+    @isTest
+    static void genericFailureDoesNotCaptureForFallback() {
+        Id jobId = newJob();
+        Id recId = anAccountId();
+        DocGenBatch batch = new DocGenBatch(jobId);
+
+        // Message deliberately avoids the word "heap" — isHeapError() matches on that substring.
+        batch.recordFailure(recId, new DocGenException('some unrelated validation error'));
+
+        System.assertEquals(0, batch.oversizedRecordIds.size(), 'Non-heap failures are not queued for giant-query');
+    }
+
+    // #155 — the fallback list is capped; overflow is counted and surfaced in the log
+    // rather than silently dropped.
+    @isTest
+    static void oversizedCapOverflowIsNotedInLog() {
+        Id jobId = newJob();
+        Id recId = anAccountId();
+        DocGenBatch batch = new DocGenBatch(jobId);
+
+        Integer attempts = DocGenBatch.MAX_FALLBACK_RECORDS + 3;
+        for (Integer i = 0; i < attempts; i++) {
+            batch.recordFailure(recId, new HeapPressureException());
+        }
+        batch.failCount = attempts;
+
+        System.assertEquals(
+            DocGenBatch.MAX_FALLBACK_RECORDS,
+            batch.oversizedRecordIds.size(),
+            'Fallback list is capped at MAX_FALLBACK_RECORDS'
+        );
+        System.assertEquals(3, batch.oversizedOverflowCount, 'Overflow beyond the cap is counted');
+
+        String log = batch.buildErrorLog();
+        System.assert(
+            log.contains('must be generated individually by hand'),
+            'Overflow note surfaces the records that exceeded auto-recovery: ' + log
+        );
+    }
 }

--- a/force-app/main/default/classes/DocGenBulkGiantFallbackJob.cls
+++ b/force-app/main/default/classes/DocGenBulkGiantFallbackJob.cls
@@ -1,0 +1,115 @@
+/**
+ * #155 — Deferred giant-query fallback for oversized bulk records.
+ *
+ * DocGenBatch flags records that fail with heap/oversize errors (too many related
+ * rows to render in one transaction) but cannot recover them itself: Apex forbids
+ * launching a Batchable from a running batch's start/execute/finish. DocGenBatch.finish()
+ * therefore enqueues THIS Queueable — from a Queueable, launching a Batchable (the
+ * giant-query path) is allowed.
+ *
+ * Each execute() processes ONE oversized record through DocGenController.generateDocumentGiantQuery
+ * (which launches its own giant-query Batchable), then self-chains for the next record.
+ * "One giant render per Queueable" keeps each transaction within limits.
+ *
+ * Concurrency (decision A): each recovered record launches an async Batchable, and the
+ * platform caps concurrent batch jobs. Before launching, we check how many batch jobs are
+ * already in flight; if at/over MAX_ACTIVE_BATCHES we re-enqueue self WITHOUT consuming a
+ * record, backing off until a slot frees rather than throwing a LimitException.
+ *
+ * Status (decision B): the parent DocGen_Job__c is left at 'Recovering' by finish() while
+ * dispatch is in flight, then set to 'Completed with Errors' once every record has been
+ * dispatched. Each per-record giant job reports its own completion separately; we do not
+ * try to roll child results back into the parent's Success_Count__c.
+ */
+public with sharing class DocGenBulkGiantFallbackJob implements Queueable, Database.AllowsCallouts {
+    private final Id jobId;
+    private final Id templateId;
+    private final List<Id> remaining;
+
+    // Headroom under the platform's 5-concurrent-batch limit — leave one slot so an
+    // unrelated job launched between our check and executeBatch doesn't tip us over.
+    @TestVisible
+    private static final Integer MAX_ACTIVE_BATCHES = 4;
+
+    public DocGenBulkGiantFallbackJob(Id jobId, Id templateId, List<Id> recordIds) {
+        this.jobId = jobId;
+        this.templateId = templateId;
+        this.remaining = recordIds == null ? new List<Id>() : recordIds;
+    }
+
+    public void execute(QueueableContext ctx) {
+        if (remaining.isEmpty()) {
+            finalizeRecovery();
+            return;
+        }
+
+        // Decision A — back off if the batch slots are full; don't consume a record.
+        if (activeBatchCount() >= MAX_ACTIVE_BATCHES) {
+            chainSelf();
+            return;
+        }
+
+        Id recordId = remaining.remove(0);
+        try {
+            // Launches the giant-query Batchable (or falls through to normal generation
+            // if the record turns out not to be oversized after all).
+            DocGenController.generateDocumentGiantQuery(templateId, recordId);
+        } catch (Exception e) {
+            logFailure(recordId, e);
+        }
+
+        if (!remaining.isEmpty()) {
+            chainSelf();
+        } else {
+            finalizeRecovery();
+        }
+    }
+
+    /** Count batch jobs currently occupying a slot (not yet finished). */
+    private Integer activeBatchCount() {
+        return [
+            SELECT COUNT()
+            FROM AsyncApexJob
+            WHERE JobType = 'BatchApex' AND Status IN ('Queued', 'Preparing', 'Processing')
+        ];
+    }
+
+    /**
+     * Chain the next hop with whatever remains. Queueable chaining is not supported in
+     * test context (throws a stack-depth limit), so the chain is suppressed under
+     * Test.isRunningTest(); tests drive a single hop directly and assert on its effect.
+     */
+    private void chainSelf() {
+        if (Test.isRunningTest()) {
+            return;
+        }
+        System.enqueueJob(new DocGenBulkGiantFallbackJob(jobId, templateId, remaining));
+    }
+
+    /** All records dispatched — mark the parent job done (it had bulk failures). */
+    private void finalizeRecovery() {
+        try {
+            DocGen_Job__c parent = new DocGen_Job__c(Id = jobId, Status__c = 'Completed with Errors');
+            DocGenFlsGuard.assertUpdateable(parent, new Set<String>{ 'Status__c' });
+            /* code-analyzer-suppress ApexFlsViolation */
+            Database.update(parent, false, AccessLevel.SYSTEM_MODE);
+        } catch (Exception e) {
+            // Non-fatal: the per-record giant jobs still run and report their own status.
+            String noop = e.getMessage(); // NOPMD UnusedLocalVariable
+        }
+    }
+
+    private void logFailure(Id recordId, Exception e) {
+        try {
+            DocGenErrorLogger.Entry entry = new DocGenErrorLogger.Entry();
+            entry.severity = 'Error';
+            entry.context = 'Bulk Giant Fallback';
+            entry.operation = 'generateDocumentGiantQuery';
+            entry.recordId = recordId == null ? null : String.valueOf(recordId);
+            entry.cause = e;
+            DocGenErrorLogger.log(entry);
+        } catch (Exception logErr) {
+            String noop = logErr.getMessage(); // NOPMD UnusedLocalVariable
+        }
+    }
+}

--- a/force-app/main/default/classes/DocGenBulkGiantFallbackJob.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenBulkGiantFallbackJob.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenBulkGiantFallbackJobTest.cls
+++ b/force-app/main/default/classes/DocGenBulkGiantFallbackJobTest.cls
@@ -1,0 +1,89 @@
+/**
+ * #155 — DocGenBulkGiantFallbackJob: the deferred giant-query recovery Queueable.
+ *
+ * Queueable chaining is unavailable in test context, so these drive a single hop and
+ * assert its effect. generateDocumentGiantQuery runs synchronously for the (childless)
+ * test account and falls through to normal generation, which fails on the body-less test
+ * template — that failure is caught and logged by the job, which is the intended behavior
+ * (recovery dispatch is best-effort per record).
+ */
+@isTest
+private class DocGenBulkGiantFallbackJobTest {
+    private static Id newTemplate() {
+        DocGen_Template__c tpl = new DocGen_Template__c(
+            Name = 'Bulk Fallback Test Tpl',
+            Base_Object_API__c = 'Account',
+            Query_Config__c = 'Name'
+        );
+        insert tpl;
+        return tpl.Id;
+    }
+
+    private static Id newJob(Id templateId, String status) {
+        DocGen_Job__c job = new DocGen_Job__c(Template__c = templateId, Status__c = status);
+        insert job;
+        return job.Id;
+    }
+
+    private static Id anAccountId() {
+        Account a = new Account(Name = 'Fallback Acct');
+        insert a;
+        return a.Id;
+    }
+
+    @isTest
+    static void emptyListFinalizesParentJob() {
+        Id tplId = newTemplate();
+        Id jobId = newJob(tplId, 'Recovering');
+
+        Test.startTest();
+        System.enqueueJob(new DocGenBulkGiantFallbackJob(jobId, tplId, new List<Id>()));
+        Test.stopTest();
+
+        DocGen_Job__c job = [SELECT Status__c FROM DocGen_Job__c WHERE Id = :jobId];
+        System.assertEquals(
+            'Completed with Errors',
+            job.Status__c,
+            'Empty list → recovery dispatch is done → parent flips to Completed with Errors'
+        );
+    }
+
+    @isTest
+    static void lastRecordDispatchedFinalizesParentJob() {
+        Id tplId = newTemplate();
+        Id jobId = newJob(tplId, 'Recovering');
+        Id recId = anAccountId();
+
+        Test.startTest();
+        System.enqueueJob(new DocGenBulkGiantFallbackJob(jobId, tplId, new List<Id>{ recId }));
+        Test.stopTest();
+
+        DocGen_Job__c job = [SELECT Status__c FROM DocGen_Job__c WHERE Id = :jobId];
+        System.assertEquals(
+            'Completed with Errors',
+            job.Status__c,
+            'Single record dispatched → no more remaining → parent finalized'
+        );
+    }
+
+    @isTest
+    static void remainingRecordsDoNotFinalizeEarly() {
+        Id tplId = newTemplate();
+        Id jobId = newJob(tplId, 'Recovering');
+        Id recA = anAccountId();
+        Id recB = anAccountId();
+
+        Test.startTest();
+        // Two records, but chaining is suppressed in tests, so only one hop runs: it
+        // dispatches one record and would chain for the rest — it must NOT finalize yet.
+        System.enqueueJob(new DocGenBulkGiantFallbackJob(jobId, tplId, new List<Id>{ recA, recB }));
+        Test.stopTest();
+
+        DocGen_Job__c job = [SELECT Status__c FROM DocGen_Job__c WHERE Id = :jobId];
+        System.assertEquals(
+            'Recovering',
+            job.Status__c,
+            'With records still remaining, the parent stays Recovering (no premature finalize)'
+        );
+    }
+}

--- a/force-app/main/default/classes/DocGenBulkGiantFallbackJobTest.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenBulkGiantFallbackJobTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
## Fixes #155 — Bulk: deferred giant-query fallback for oversized records

### Problem
`DocGenBatch` already detects records that fail bulk generation with heap/oversize errors (too many related rows to render in one transaction) and flags them with "generate individually" guidance — but it can't auto-recover them, because Apex forbids launching a Batchable from inside a running batch's `start`/`execute`/`finish`. Today those records require manual one-by-one re-runs.

### Solution
The three parts from the issue:

1. **Collection** — `DocGenBatch.recordFailure()` now captures the oversized record Ids in a Stateful `List<Id>` (in addition to the existing count), capped at `MAX_FALLBACK_RECORDS = 100`. Overflow beyond the cap is counted and surfaced in `Error_Log__c` ("…N more must be generated individually by hand") — never silently dropped.
2. **Queueable fallback** — `DocGenBatch.finish()` enqueues a new `DocGenBulkGiantFallbackJob` when oversized records exist (non-merge path) and sets the parent job to `Recovering`. From a Queueable, launching the giant-query Batchable **is** allowed. The job processes **one** oversized record per hop via `DocGenController.generateDocumentGiantQuery` and self-chains for the rest ("one giant render per Queueable").
3. **Status management** — once all records are dispatched, the job flips the parent `DocGen_Job__c` to `Completed with Errors`.

### Design decisions (flagged for review)
- **(A) Concurrency.** Each recovered record launches an async giant-query Batchable, and the platform caps concurrent batch jobs. Before launching, the job checks how many batch jobs are in flight (`AsyncApexJob`, statuses Queued/Preparing/Processing); if ≥ `MAX_ACTIVE_BATCHES` (4, leaving headroom under the limit of 5), it **re-enqueues itself without consuming a record**, backing off until a slot frees — rather than risking a `LimitException`.
- **(B) Counter model.** Each giant render creates its own `DocGen_Job__c`, so we deliberately do **not** roll child results back into the parent's `Success_Count__c` (fragile cross-async bookkeeping for a P3). The parent reports `Recovering` → `Completed with Errors`; each child giant job reports its own completion.

### Scope notes
- **Merge-mode** oversized records remain flagged-only (out of scope) — mixing individual giant PDFs into a merged-PDF job is semantically odd; documented inline.
- No metadata changes. `Status__c` is an unrestricted picklist and the codebase already uses off-list values (e.g. `Completed with Errors`), so `Recovering` needs no picklist edit.

### Tests
- `DocGenBatchErrorLogTest` — oversized-Id collection, generic-failure exclusion, and the cap-overflow note.
- `DocGenBulkGiantFallbackJobTest` (new) — empty-list finalize, last-record finalize, and remaining-records-don't-finalize-early (single hop; Queueable chaining isn't available in test context).
- Targeted run: **10/10 pass**, `DocGenBulkGiantFallbackJob` 84% coverage. Full `RunLocalTests` result will be posted in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
