### PR TITLE
Fix #187: stamp document hash on guided composited signing audit

### DIFF
--- a/force-app/main/default/classes/DocGenGuidedSigningTest.cls
+++ b/force-app/main/default/classes/DocGenGuidedSigningTest.cls
@@ -304,6 +304,55 @@ private class DocGenGuidedSigningTest {
     }
 
     @IsTest
+    static void compositedPath_stampsDocumentHashOnAudit() {
+        // Regression #187: the guided composited path (saveCompositedSignedPdf) stores the
+        // PDF client-side and never publishes DocGen_Signature_PDF__e, so the async finalizer
+        // that back-fills Document_Hash_SHA256__c never runs — the audit was left with a null
+        // hash. The fix hashes the composited bytes directly at audit insert. Assert the audit
+        // now carries the SHA-256 of exactly the bytes that were signed.
+        Id tplId = createTaggedTemplate();
+        Account a = [SELECT Id FROM Account LIMIT 1];
+        DocGenSignatureSenderController.createGuidedPdfSignatureRequest(tplId, a.Id, signersJson(), 'Parallel', null);
+
+        DocGen_Signer__c signer = [
+            SELECT Id, Secure_Token__c, Signature_Request__c
+            FROM DocGen_Signer__c
+            WHERE Signature_Request__r.Template__c = :tplId
+            LIMIT 1
+        ];
+        signer.PIN_Verified_At__c = System.now();
+        update signer;
+
+        String b64 = EncodingUtil.base64Encode(Blob.valueOf('%PDF-1.4 composited audit-hash test bytes'));
+        String expectedHash = EncodingUtil.convertToHex(
+            Crypto.generateDigest('SHA-256', EncodingUtil.base64Decode(b64))
+        );
+
+        Test.startTest();
+        DocGenSignatureController.saveCompositedSignedPdf(
+            signer.Secure_Token__c,
+            b64,
+            true,
+            '1.2.3.4',
+            'JUnit/1.0',
+            null
+        );
+        Test.stopTest();
+
+        List<DocGen_Signature_Audit__c> audits = [
+            SELECT Document_Hash_SHA256__c
+            FROM DocGen_Signature_Audit__c
+            WHERE Signature_Request__c = :signer.Signature_Request__c AND Signer__c = :signer.Id
+        ];
+        System.assertEquals(1, audits.size(), 'Exactly one audit for the composited signer');
+        System.assertEquals(
+            expectedHash,
+            audits[0].Document_Hash_SHA256__c,
+            'Composited path must stamp the SHA-256 of the signed bytes on the audit (#187)'
+        );
+    }
+
+    @IsTest
     static void formFieldViewingSentinels_hideTagLeaveLocatable() {
         // The viewing PDF must NOT show the literal {?key} tag; it leaves a white,
         // PDF.js-locatable @@FF-<key>@@ sentinel for the drawn-path client to stamp.

--- a/force-app/main/default/classes/DocGenSignatureController.cls
+++ b/force-app/main/default/classes/DocGenSignatureController.cls
@@ -2627,6 +2627,14 @@ public without sharing class DocGenSignatureController {
         audit.User_Agent__c = String.isNotBlank(userAgent) ? userAgent.left(255) : 'Unknown';
         audit.Consent_Captured__c = true;
         audit.PIN_Verified_At__c = signer.PIN_Verified_At__c;
+        // #187 — capture the tamper-evidence hash directly from the composited bytes.
+        // This guided drawn/typed path stores the PDF client-side and never publishes
+        // DocGen_Signature_PDF__e, so the async finalizer (which back-fills the hash on
+        // the typed/snapshot path) never runs here — leaving Document_Hash_SHA256__c
+        // null. We already hold the final bytes (base64Pdf), so hash them now.
+        audit.Document_Hash_SHA256__c = EncodingUtil.convertToHex(
+            Crypto.generateDigest('SHA-256', EncodingUtil.base64Decode(base64Pdf))
+        );
         DocGenFlsGuard.guestAssertCreateable(
             audit,
             new Set<String>{
@@ -2639,7 +2647,8 @@ public without sharing class DocGenSignatureController {
                 'IP_Address__c',
                 'User_Agent__c',
                 'Consent_Captured__c',
-                'PIN_Verified_At__c'
+                'PIN_Verified_At__c',
+                'Document_Hash_SHA256__c'
             }
         );
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */


### PR DESCRIPTION
Closes #187.

## Problem
On the guided composited signing path (`DocGenSignatureController.saveCompositedSignedPdf`), the audit record's `Document_Hash_SHA256__c` was left **null**. Observed on a real Portwood Dev signature: request `Signed`, signed PDF attached, audit hash NULL, no `SYSTEM` error audit.

## Root cause
The document hash is normally back-filled by the async finalizer in `DocGenSignatureService` (driven by the `DocGen_Signature_PDF__e` platform event). But the composited path stores the client-composited PDF directly and **never publishes that event** (by design — see its own comment), so the finalizer never runs and the hash is never set on this path. Independent of `DocGenSignaturePdfTrigger` health.

## Fix
`saveCompositedSignedPdf` already holds the final composited bytes (`base64Pdf`). Hash them at audit insert and add `Document_Hash_SHA256__c` to the `guestAssertCreateable` allowlist. Deterministic; no dependency on the PE trigger / async finalizer.

```apex
audit.Document_Hash_SHA256__c =
    EncodingUtil.convertToHex(Crypto.generateDigest('SHA-256', EncodingUtil.base64Decode(base64Pdf)));
```

## Test
`DocGenGuidedSigningTest.compositedPath_stampsDocumentHashOnAudit` — asserts the audit carries the SHA-256 of exactly the signed bytes. **DocGenGuidedSigningTest 10/10 pass** on a scratch org.

## Validation
- Targeted test pass (10/10). Full RunLocalTests + browser re-verify to follow before merge/next release.
- Ships in a release **after** v3.22.0 (per the deferral on #187).

🤖 Generated with [Claude Code](https://claude.com/claude-code)