### PR TITLE
Fix #189 + #156: stamp signatures on large templates; move frozen snapshot to a ContentVersion

### DIFF
--- a/force-app/main/default/classes/DocGenGuidedSigningTest.cls
+++ b/force-app/main/default/classes/DocGenGuidedSigningTest.cls
@@ -382,4 +382,33 @@ private class DocGenGuidedSigningTest {
         System.assert(a, 'getSignatureCertificate rejects bad token');
         System.assert(b, 'saveCompositedSignedPdf rejects bad token');
     }
+
+    // Regression: oversized templates (merged snapshot > 131072 chars) cannot persist a
+    // Frozen_Document__c, so the finalizer LIVE re-merges and the body carries the ORIGINAL
+    // {@Signature_*} tags — not the @@SIG-n@@ sentinels the placements key on. The finalizer
+    // re-applies resentinelSignatureBody so stampSignaturesInXml's Tag_Text__c match lands;
+    // without it the signature silently never stamps (blank signature line).
+    @IsTest
+    static void resentinelRestoresSentinelsInDocumentOrder() {
+        String body =
+            'Signature: {@Signature_Buyer} Date: {@Signature_Buyer:1:DatePick} ' + 'Witness: {@Signature_Witness}';
+        String out = DocGenSignatureSenderController.resentinelSignatureBody(body);
+        // Document order → @@SIG-0@@ = first tag, etc. (matches createGuidedPdfSignatureRequest).
+        System.assert(out.contains('Signature: @@SIG-0@@'), 'first tag → @@SIG-0@@: ' + out);
+        System.assert(out.contains('Date: @@SIG-1@@'), 'second tag → @@SIG-1@@: ' + out);
+        System.assert(out.contains('Witness: @@SIG-2@@'), 'third tag → @@SIG-2@@: ' + out);
+        System.assert(!out.contains('{@Signature'), 'no original signature tags remain: ' + out);
+    }
+
+    @IsTest
+    static void resentinelIsIdempotentAndHandlesBareTag() {
+        // Frozen-path body already carries sentinels → no-op.
+        String frozen = 'Signature: @@SIG-0@@';
+        System.assertEquals(frozen, DocGenSignatureSenderController.resentinelSignatureBody(frozen));
+        // Bare {@Signature} fallback applies only when no role-scoped tags exist.
+        String bare = DocGenSignatureSenderController.resentinelSignatureBody('Sign here: {@Signature}');
+        System.assertEquals('Sign here: @@SIG-0@@', bare);
+        // Blank/null are safe.
+        System.assertEquals(null, DocGenSignatureSenderController.resentinelSignatureBody(null));
+    }
 }

--- a/force-app/main/default/classes/DocGenGuidedSigningTest.cls
+++ b/force-app/main/default/classes/DocGenGuidedSigningTest.cls
@@ -60,13 +60,13 @@ private class DocGenGuidedSigningTest {
         Test.stopTest();
 
         DocGen_Signature_Request__c req = [
-            SELECT Id, Template__c, Source_Document_Id__c, Frozen_Document__c, Status__c
+            SELECT Id, Template__c, Source_Document_Id__c, Frozen_Document_CV_Id__c, Status__c
             FROM DocGen_Signature_Request__c
             WHERE Template__c = :tplId
             LIMIT 1
         ];
         System.assertNotEquals(null, req.Source_Document_Id__c, 'Viewing PDF should be stored as Source_Document');
-        System.assertNotEquals(null, req.Frozen_Document__c, 'Frozen sentinel body should be captured');
+        System.assertNotEquals(null, req.Frozen_Document_CV_Id__c, 'Frozen sentinel body should be captured (CV)');
 
         List<DocGen_Signature_Placement__c> plcs = [
             SELECT Tag_Text__c, Placement_Type__c, Status__c
@@ -117,13 +117,13 @@ private class DocGenGuidedSigningTest {
         Test.stopTest();
 
         DocGen_Signature_Request__c req = [
-            SELECT Id, Source_Document_Id__c, Frozen_Document__c
+            SELECT Id, Source_Document_Id__c, Frozen_Document_CV_Id__c
             FROM DocGen_Signature_Request__c
             WHERE Template__c = :tmpl.Id
             LIMIT 1
         ];
         System.assertNotEquals(null, req.Source_Document_Id__c, 'Tag-less template should still produce a viewing PDF');
-        System.assertNotEquals(null, req.Frozen_Document__c, 'Frozen body should be captured');
+        System.assertNotEquals(null, req.Frozen_Document_CV_Id__c, 'Frozen body should be captured (CV)');
 
         List<DocGen_Signature_Placement__c> plcs = [
             SELECT Tag_Text__c, Placement_Type__c
@@ -163,14 +163,14 @@ private class DocGenGuidedSigningTest {
         Test.stopTest();
 
         DocGen_Signature_Request__c req = [
-            SELECT Id, Template_Ids__c, Source_Document_Id__c, Frozen_Document__c
+            SELECT Id, Template_Ids__c, Source_Document_Id__c, Frozen_Document_CV_Id__c
             FROM DocGen_Signature_Request__c
             WHERE Template__c = :t1
             LIMIT 1
         ];
         System.assertNotEquals(null, req.Source_Document_Id__c, 'Combined viewing PDF should be stored');
         System.assertNotEquals(null, req.Template_Ids__c, 'Template_Ids__c set for a packet');
-        System.assertNotEquals(null, req.Frozen_Document__c, 'Frozen multi-document body captured');
+        System.assertNotEquals(null, req.Frozen_Document_CV_Id__c, 'Frozen multi-document body captured (CV)');
 
         List<DocGen_Signature_Placement__c> plcs = [
             SELECT Document_Index__c, Tag_Text__c
@@ -353,13 +353,22 @@ private class DocGenGuidedSigningTest {
         Test.stopTest();
 
         DocGen_Signature_Request__c req = [
-            SELECT Frozen_Document__c
+            SELECT Frozen_Document_CV_Id__c
             FROM DocGen_Signature_Request__c
             WHERE Template__c = :tmpl.Id
             LIMIT 1
         ];
+        // #156: frozen body lives in a ContentVersion (no size cap) — load it to inspect.
+        System.assertNotEquals(null, req.Frozen_Document_CV_Id__c, 'Frozen snapshot CV captured');
+        String frozenJson = [
+                SELECT VersionData
+                FROM ContentVersion
+                WHERE Id = :req.Frozen_Document_CV_Id__c
+                LIMIT 1
+            ]
+            .VersionData.toString();
         System.assert(
-            req.Frozen_Document__c != null && req.Frozen_Document__c.contains('{?favColor}'),
+            frozenJson.contains('{?favColor}'),
             'Frozen body must retain the {?favColor} tag for the typed-path re-render'
         );
     }
@@ -383,11 +392,12 @@ private class DocGenGuidedSigningTest {
         System.assert(b, 'saveCompositedSignedPdf rejects bad token');
     }
 
-    // Regression: oversized templates (merged snapshot > 131072 chars) cannot persist a
-    // Frozen_Document__c, so the finalizer LIVE re-merges and the body carries the ORIGINAL
-    // {@Signature_*} tags — not the @@SIG-n@@ sentinels the placements key on. The finalizer
-    // re-applies resentinelSignatureBody so stampSignaturesInXml's Tag_Text__c match lands;
-    // without it the signature silently never stamps (blank signature line).
+    // Regression (#189): when a request has no frozen snapshot, the finalizer LIVE re-merges
+    // and the body carries the ORIGINAL {@Signature_*} tags — not the @@SIG-n@@ sentinels the
+    // placements key on. The finalizer re-applies resentinelSignatureBody so stampSignaturesInXml's
+    // Tag_Text__c match lands; without it the signature silently never stamps (blank line).
+    // #156 made the CV-backed snapshot the primary path (no size cap), so this re-merge is now
+    // only the fallback for legacy/snapshot-less requests — resentinel keeps that path correct.
     @IsTest
     static void resentinelRestoresSentinelsInDocumentOrder() {
         String body =
@@ -410,5 +420,62 @@ private class DocGenGuidedSigningTest {
         System.assertEquals('Sign here: @@SIG-0@@', bare);
         // Blank/null are safe.
         System.assertEquals(null, DocGenSignatureSenderController.resentinelSignatureBody(null));
+    }
+
+    // #156: the frozen snapshot is persisted to a ContentVersion (no 131072-char cap) and
+    // round-trips intact, so large/image-heavy templates get a true point-in-time snapshot
+    // instead of degrading to a live re-merge at sign time.
+    @IsTest
+    static void frozenSnapshotRoundTripsThroughContentVersion() {
+        Map<String, Object> doc = new Map<String, Object>{
+            'templateType' => 'HTML',
+            'combinedDocumentXml' => '<html><body>Sign: @@SIG-0@@</body></html>',
+            'relsXml' => '',
+            'contentTypesXml' => '',
+            'docTitle' => 'T',
+            'stylesXml' => '',
+            'numberingXml' => ''
+        };
+        String frozenJson = DocGenSignatureService.buildFrozenDocumentJson(
+            new List<Map<String, Object>>{ doc },
+            new List<Id>{ null }
+        );
+        System.assert(String.isNotBlank(frozenJson), 'snapshot json built');
+
+        Test.startTest();
+        Id cvId = DocGenSignatureService.saveFrozenSnapshotCv(frozenJson);
+        Test.stopTest();
+
+        System.assertNotEquals(null, cvId, 'snapshot persisted to a ContentVersion');
+        String roundTrip = [SELECT VersionData FROM ContentVersion WHERE Id = :cvId LIMIT 1].VersionData.toString();
+        System.assertEquals(frozenJson, roundTrip, 'CV content round-trips exactly');
+        List<Map<String, Object>> docs = DocGenSignatureService.loadFrozenMergeData(roundTrip);
+        System.assertNotEquals(null, docs, 'snapshot loads back into renderable merge data');
+        System.assertEquals(
+            '<html><body>Sign: @@SIG-0@@</body></html>',
+            (String) docs[0].get('combinedDocumentXml'),
+            'frozen body preserved through the CV round-trip'
+        );
+        // saveFrozenSnapshotCv is null-safe for a blank snapshot.
+        System.assertEquals(null, DocGenSignatureService.saveFrozenSnapshotCv(null));
+    }
+
+    // #156 storage lifecycle: a completed/declined/cancelled request reclaims its snapshot CV
+    // (the Snapshot_Hash__c stays as tamper-evidence). purgeFrozenSnapshotCv deletes the file.
+    @IsTest
+    static void purgeFrozenSnapshotCvReclaimsTheFile() {
+        Id cvId = DocGenSignatureService.saveFrozenSnapshotCv('{"v":1,"templateType":"HTML","docs":[]}');
+        System.assertNotEquals(null, cvId, 'snapshot CV created');
+        Id cdId = [SELECT ContentDocumentId FROM ContentVersion WHERE Id = :cvId LIMIT 1].ContentDocumentId;
+        System.assertEquals(1, [SELECT COUNT() FROM ContentDocument WHERE Id = :cdId], 'file exists before purge');
+
+        Test.startTest();
+        DocGenSignatureService.purgeFrozenSnapshotCv(cvId);
+        Test.stopTest();
+
+        System.assertEquals(0, [SELECT COUNT() FROM ContentDocument WHERE Id = :cdId], 'file reclaimed after purge');
+        // Null-safe / idempotent: purging null or an already-gone CV does not throw.
+        DocGenSignatureService.purgeFrozenSnapshotCv(null);
+        DocGenSignatureService.purgeFrozenSnapshotCv(cvId);
     }
 }

--- a/force-app/main/default/classes/DocGenSignatureController.cls
+++ b/force-app/main/default/classes/DocGenSignatureController.cls
@@ -1814,14 +1814,34 @@ public without sharing class DocGenSignatureController {
 
         // Mark parent request as declined. Null out the cached preview HTML — the JSON blob
         // in Signature_Data__c carries the live preview with names already stamped, and
-        // fetchDocumentData would otherwise re-serve it (issue #91).
+        // fetchDocumentData would otherwise re-serve it (issue #91). #156: a declined request
+        // will never be signed, so reclaim the frozen-snapshot CV (hash is retained on the audit).
+        DocGenFlsGuard.guestAssertAccessible(
+            DocGen_Signature_Request__c.sObjectType,
+            new Set<String>{ 'Frozen_Document_CV_Id__c' }
+        );
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        List<DocGen_Signature_Request__c> snapRows = [
+            SELECT Frozen_Document_CV_Id__c
+            FROM DocGen_Signature_Request__c
+            WHERE Id = :signer.Signature_Request__c
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        Id frozenCvToPurge = snapRows.isEmpty() ? null : (Id) snapRows[0].Frozen_Document_CV_Id__c;
+
         DocGen_Signature_Request__c parentReq = new DocGen_Signature_Request__c(Id = signer.Signature_Request__c);
         parentReq.Status__c = 'Declined';
         parentReq.Signature_Data__c = null;
+        parentReq.Frozen_Document_CV_Id__c = null;
         // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Update").
-        DocGenFlsGuard.guestAssertUpdateable(parentReq, new Set<String>{ 'Status__c', 'Signature_Data__c' });
+        DocGenFlsGuard.guestAssertUpdateable(
+            parentReq,
+            new Set<String>{ 'Status__c', 'Signature_Data__c', 'Frozen_Document_CV_Id__c' }
+        );
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
         Database.update(parentReq, false, AccessLevel.SYSTEM_MODE);
+        DocGenSignatureService.purgeFrozenSnapshotCv(frozenCvToPurge);
 
         // Create audit record
         DocGen_Signature_Audit__c audit = new DocGen_Signature_Audit__c();

--- a/force-app/main/default/classes/DocGenSignaturePdfTests.cls
+++ b/force-app/main/default/classes/DocGenSignaturePdfTests.cls
@@ -596,7 +596,7 @@ private class DocGenSignaturePdfTests {
         Test.stopTest();
 
         DocGen_Signature_Request__c req = [
-            SELECT Render_Data_Snapshot__c, Frozen_Document__c
+            SELECT Render_Data_Snapshot__c, Frozen_Document_CV_Id__c
             FROM DocGen_Signature_Request__c
             WHERE Template__c = :templateId
             ORDER BY CreatedDate DESC
@@ -606,7 +606,10 @@ private class DocGenSignaturePdfTests {
             String.isNotBlank(req.Render_Data_Snapshot__c),
             'Loop-only template must route to the snapshot strategy so the loop repopulates at completion'
         );
-        System.assert(String.isBlank(req.Frozen_Document__c), 'Snapshot strategy does not freeze a sentinel body');
+        System.assert(
+            String.isBlank(req.Frozen_Document_CV_Id__c),
+            'Snapshot strategy does not freeze a sentinel body'
+        );
     }
 
     @isTest
@@ -640,13 +643,16 @@ private class DocGenSignaturePdfTests {
         Test.stopTest();
 
         DocGen_Signature_Request__c req = [
-            SELECT Render_Data_Snapshot__c, Frozen_Document__c
+            SELECT Render_Data_Snapshot__c, Frozen_Document_CV_Id__c
             FROM DocGen_Signature_Request__c
             WHERE Template__c = :templateId
             ORDER BY CreatedDate DESC
             LIMIT 1
         ];
-        System.assert(String.isNotBlank(req.Frozen_Document__c), 'Tag template stays on the guided frozen-body path');
+        System.assert(
+            String.isNotBlank(req.Frozen_Document_CV_Id__c),
+            'Tag template stays on the guided frozen-body path'
+        );
         System.assert(String.isBlank(req.Render_Data_Snapshot__c), 'Guided path does not snapshot record data');
 
         DocGen_Signature_Placement__c plc = [

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -676,26 +676,25 @@ public with sharing class DocGenSignatureSenderController {
 
             // INTEGRITY: freeze the merged document body now, while we're in admin context
             // with the live record. The signed PDF is rendered from THIS snapshot, not a
-            // re-merge at sign time, so the signer signs exactly what was reviewed. Null
-            // (oversized) leaves the sign path to live-merge — logged, never silent.
+            // re-merge at sign time, so the signer signs exactly what was reviewed. #156:
+            // the snapshot is stored in a ContentVersion (no size cap), so even large/
+            // image-heavy templates are frozen rather than degrading to a live merge.
             Set<String> snapshotFields = new Set<String>{ 'Signature_Data__c' };
             String frozenJson = DocGenSignatureService.buildFrozenDocumentJson(
                 new List<Map<String, Object>>{ mergeData },
                 new List<Id>{ templateId }
             );
             if (String.isNotBlank(frozenJson)) {
-                req.Frozen_Document__c = frozenJson;
+                req.Frozen_Document_CV_Id__c = DocGenSignatureService.saveFrozenSnapshotCv(frozenJson);
                 req.Snapshot_Hash__c = DocGenSignatureService.hashFrozenDocument(frozenJson);
                 req.Snapshot_Taken_At__c = System.now();
                 snapshotFields.addAll(
-                    new Set<String>{ 'Frozen_Document__c', 'Snapshot_Hash__c', 'Snapshot_Taken_At__c' }
+                    new Set<String>{ 'Frozen_Document_CV_Id__c', 'Snapshot_Hash__c', 'Snapshot_Taken_At__c' }
                 );
             } else {
                 System.debug(
                     LoggingLevel.WARN,
-                    'DocGen: template document too large to freeze; request ' +
-                        req.Id +
-                        ' will live-merge at sign time.'
+                    'DocGen: no document body to freeze; request ' + req.Id + ' will live-merge at sign time.'
                 );
             }
             // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Update").
@@ -1311,10 +1310,12 @@ public with sharing class DocGenSignatureSenderController {
             'Secure_Token__c'
         };
         if (String.isNotBlank(frozenJson)) {
-            req.Frozen_Document__c = frozenJson;
+            // #156: snapshot persisted to a ContentVersion (no 131072-char cap) and referenced
+            // by Id, so large templates get a true frozen snapshot instead of a live re-merge.
+            req.Frozen_Document_CV_Id__c = DocGenSignatureService.saveFrozenSnapshotCv(frozenJson);
             req.Snapshot_Hash__c = DocGenSignatureService.hashFrozenDocument(frozenJson);
             req.Snapshot_Taken_At__c = System.now();
-            reqFields.addAll(new Set<String>{ 'Frozen_Document__c', 'Snapshot_Hash__c', 'Snapshot_Taken_At__c' });
+            reqFields.addAll(new Set<String>{ 'Frozen_Document_CV_Id__c', 'Snapshot_Hash__c', 'Snapshot_Taken_At__c' });
         }
         DocGenFlsGuard.assertCreateable(req, reqFields);
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
@@ -1568,10 +1569,11 @@ public with sharing class DocGenSignatureSenderController {
             'Secure_Token__c'
         };
         if (String.isNotBlank(frozenJson)) {
-            req.Frozen_Document__c = frozenJson;
+            // #156: multi-document packet snapshot persisted to a ContentVersion (no size cap).
+            req.Frozen_Document_CV_Id__c = DocGenSignatureService.saveFrozenSnapshotCv(frozenJson);
             req.Snapshot_Hash__c = DocGenSignatureService.hashFrozenDocument(frozenJson);
             req.Snapshot_Taken_At__c = System.now();
-            reqFields.addAll(new Set<String>{ 'Frozen_Document__c', 'Snapshot_Hash__c', 'Snapshot_Taken_At__c' });
+            reqFields.addAll(new Set<String>{ 'Frozen_Document_CV_Id__c', 'Snapshot_Hash__c', 'Snapshot_Taken_At__c' });
         }
         DocGenFlsGuard.assertCreateable(req, reqFields);
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
@@ -2334,7 +2336,7 @@ public with sharing class DocGenSignatureSenderController {
         DocGenFlsGuard.assertAccessible(DocGen_Signature_Request__c.sObjectType, new Set<String>{ 'Status__c' });
         /* code-analyzer-suppress ApexFlsViolation */
         DocGen_Signature_Request__c req = [
-            SELECT Id, Status__c
+            SELECT Id, Status__c, Frozen_Document_CV_Id__c
             FROM DocGen_Signature_Request__c
             WHERE Id = :requestId
             WITH SYSTEM_MODE
@@ -2348,11 +2350,15 @@ public with sharing class DocGenSignatureSenderController {
             throw new AuraHandledException('This request is already cancelled.');
         }
 
+        // #156: a cancelled request will never be signed, so reclaim the frozen-snapshot CV.
+        Id frozenCvToPurge = (Id) req.Frozen_Document_CV_Id__c;
         req.Status__c = 'Cancelled';
+        req.Frozen_Document_CV_Id__c = null;
         // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Update").
-        DocGenFlsGuard.assertUpdateable(req, new Set<String>{ 'Status__c' });
+        DocGenFlsGuard.assertUpdateable(req, new Set<String>{ 'Status__c', 'Frozen_Document_CV_Id__c' });
         /* code-analyzer-suppress ApexFlsViolation */
         Database.update(req, false, AccessLevel.SYSTEM_MODE);
+        DocGenSignatureService.purgeFrozenSnapshotCv(frozenCvToPurge);
 
         // Invalidate all unsigned signers
         DocGenFlsGuard.assertAccessible(

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -146,6 +146,46 @@ public with sharing class DocGenSignatureSenderController {
     }
 
     /**
+     * Re-applies the send-time {@Signature_*} → @@SIG-n@@ sentinel substitution to an
+     * already-merged document body, in document order. Used by the signature finalizer
+     * when a request has no Frozen_Document__c (oversized snapshot — the body exceeds the
+     * 131072-char freeze cap — or a legacy request): that path LIVE re-merges, so the body
+     * carries the ORIGINAL {@Signature_*} tags rather than the @@SIG-n@@ sentinels the
+     * placements key on. Without this re-substitution, DocGenSignatureService.stampSignaturesInXml
+     * matches nothing (placement Tag_Text__c = @@SIG-n@@) and the signature silently never
+     * stamps — the unstamped tags are then stripped at render, leaving a blank signature line.
+     *
+     * Mirrors the substitution in createGuidedPdfSignatureRequest exactly (same regex set,
+     * same document order, same per-occurrence replaceFirst), but sources the tags from the
+     * merged BODY instead of re-reading the template — the template's pre-decomposed XML CVs
+     * read WITH USER_MODE, which returns empty in the async (Automated Process) finalize
+     * context. Idempotent: a body that already carries @@SIG-n@@ (the frozen path) is a no-op.
+     */
+    public static String resentinelSignatureBody(String body) {
+        if (String.isBlank(body) || body.contains('@@SIG-')) {
+            return body;
+        }
+        // Role-scoped tags first ({@Signature_Role[:order:type]}), in document order — this is
+        // the placement set createGuidedPdfSignatureRequest sentinel-indexes. Only when none
+        // exist does the bare {@Signature} fallback apply (mirrors parseSignaturePlacements).
+        List<String> tagsInOrder = new List<String>();
+        Matcher roleMatch = Pattern.compile('\\{@Signature_[^}]*\\}').matcher(body);
+        while (roleMatch.find()) {
+            tagsInOrder.add(roleMatch.group());
+        }
+        if (tagsInOrder.isEmpty()) {
+            Matcher bareMatch = Pattern.compile('\\{@Signature\\}').matcher(body);
+            while (bareMatch.find()) {
+                tagsInOrder.add(bareMatch.group());
+            }
+        }
+        for (Integer i = 0; i < tagsInOrder.size(); i++) {
+            body = body.replaceFirst(Pattern.quote(tagsInOrder[i]), '@@SIG-' + i + '@@');
+        }
+        return body;
+    }
+
+    /**
      * True when the template body contains the reserved {#Signatures} variable-signer
      * loop block. Drives the canonical-entry dispatch in createGuidedPdfSignatureRequest:
      * a loop-only template (no {@Signature_*} tags) routes to the snapshot render

--- a/force-app/main/default/classes/DocGenSignatureService.cls
+++ b/force-app/main/default/classes/DocGenSignatureService.cls
@@ -524,13 +524,12 @@ public without sharing class DocGenSignatureService {
     }
 
     /**
-     * Serializes per-template merge outputs into the Frozen_Document__c snapshot JSON
-     * captured at request creation. Stores only the static, point-in-time document body
-     * (combinedDocumentXml/relsXml/contentTypesXml/docTitle + styles/numbering) — the
-     * part that reflects live record data and must not drift before signing. Returns
-     * null when the snapshot would exceed the field limit, so the caller leaves it
-     * unset and the sign path live-merges (logged by the caller). `global`/`public`
-     * visibility kept minimal: callers are in the same namespace.
+     * Serializes per-template merge outputs into the frozen-document snapshot JSON captured
+     * at request creation. Stores only the static, point-in-time document body
+     * (combinedDocumentXml/relsXml/contentTypesXml/docTitle + styles/numbering) — the part
+     * that reflects live record data and must not drift before signing. The caller persists
+     * the result via saveFrozenSnapshotCv (#156, ContentVersion-backed, no size cap).
+     * `global`/`public` visibility kept minimal: callers are in the same namespace.
      */
     public static String buildFrozenDocumentJson(List<Map<String, Object>> mergeOutputs, List<Id> templateIds) {
         if (mergeOutputs == null || mergeOutputs.isEmpty()) {
@@ -565,15 +564,102 @@ public without sharing class DocGenSignatureService {
                 }
             );
         }
-        String frozenJson = JSON.serialize(
-            new Map<String, Object>{ 'v' => 1, 'templateType' => templateType, 'docs' => docs }
-        );
-        // Graceful fallback: a body larger than the LongTextArea limit is not frozen
-        // (returns null → live-merge at sign time) rather than throwing or truncating.
-        if (frozenJson.length() > 131072) {
+        // #156: no size cap — the snapshot is persisted to a ContentVersion
+        // (saveFrozenSnapshotCv), not the 131072-char Frozen_Document__c LongTextArea, so
+        // documents of any size get a true point-in-time snapshot instead of degrading to a
+        // live re-merge. The hash is still computed over this full JSON.
+        return JSON.serialize(new Map<String, Object>{ 'v' => 1, 'templateType' => templateType, 'docs' => docs });
+    }
+
+    /**
+     * #156: persists the frozen-document snapshot JSON to a ContentVersion and returns its
+     * Id (stored on Frozen_Document_CV_Id__c). This removes the 131072-char ceiling that the
+     * Frozen_Document__c LongTextArea imposed — large/image-heavy templates previously
+     * couldn't be frozen at all and silently fell back to a live re-merge at sign time
+     * (integrity gap + the #189 stamp mismatch). The CV is internal (no record link);
+     * the async finalizer reads it WITH SYSTEM_MODE. Returns null for a blank snapshot.
+     */
+    public static Id saveFrozenSnapshotCv(String frozenJson) {
+        if (String.isBlank(frozenJson)) {
             return null;
         }
-        return frozenJson;
+        ContentVersion cv = new ContentVersion();
+        cv.Title = 'docgen_sig_frozen';
+        cv.PathOnClient = 'docgen_sig_frozen.json';
+        cv.VersionData = Blob.valueOf(frozenJson);
+        DocGenFlsGuard.assertCreateable(cv, new Set<String>{ 'Title', 'PathOnClient', 'VersionData' });
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        Database.insert(cv, AccessLevel.SYSTEM_MODE);
+        return cv.Id;
+    }
+
+    /**
+     * #156 storage lifecycle: deletes a frozen-snapshot ContentVersion once its request reaches
+     * a terminal state (Signed/Declined/Cancelled). The snapshot has done its job — the signed
+     * PDF and the Snapshot_Hash__c remain as the tamper-evidence record (the hash still proves
+     * the signed document equals what was reviewed), so the bulky body is reclaimed. Best-effort:
+     * a cleanup failure is logged, never thrown — it must not break signing or cancellation.
+     * Callers should also null Frozen_Document_CV_Id__c so the reference doesn't dangle.
+     */
+    public static void purgeFrozenSnapshotCv(Id frozenCvId) {
+        if (frozenCvId == null) {
+            return;
+        }
+        try {
+            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+            List<ContentDocument> docs = [
+                SELECT Id
+                FROM ContentDocument
+                WHERE LatestPublishedVersionId = :frozenCvId
+                WITH SYSTEM_MODE
+            ];
+            if (!docs.isEmpty()) {
+                /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+                Database.delete(docs, false, AccessLevel.SYSTEM_MODE);
+            }
+        } catch (Exception e) {
+            System.debug(LoggingLevel.WARN, 'DocGen: frozen snapshot purge skipped: ' + e.getMessage());
+        }
+    }
+
+    /**
+     * #156 read path: loads + parses the frozen snapshot from its ContentVersion. Runs in the
+     * async (Automated Process) finalize context, so the CV is read WITH SYSTEM_MODE (internal
+     * CV, ContentDocumentLink Visibility=InternalUsers → USER_MODE returns empty). Returns null
+     * (→ legacy field / live-merge fallback) when the CV is missing or empty.
+     */
+    private static List<Map<String, Object>> loadFrozenMergeDataFromCv(Id cvId) {
+        if (cvId == null) {
+            return null;
+        }
+        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'VersionData' });
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        List<ContentVersion> cvs = [
+            SELECT VersionData
+            FROM ContentVersion
+            WHERE Id = :cvId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (cvs.isEmpty() || cvs[0].VersionData == null) {
+            return null;
+        }
+        return loadFrozenMergeData(cvs[0].VersionData.toString());
+    }
+
+    /**
+     * Resolves the frozen merge data for a request, preferring the CV-backed snapshot (#156,
+     * no size cap) and falling back to the legacy inline Frozen_Document__c field for requests
+     * created before the CV migration. Returns null when neither is present (→ live re-merge).
+     */
+    private static List<Map<String, Object>> resolveFrozenMergeData(DocGen_Signature_Request__c reqData) {
+        if (String.isNotBlank(reqData.Frozen_Document_CV_Id__c)) {
+            List<Map<String, Object>> fromCv = loadFrozenMergeDataFromCv((Id) reqData.Frozen_Document_CV_Id__c);
+            if (fromCv != null) {
+                return fromCv;
+            }
+        }
+        return loadFrozenMergeData(reqData.Frozen_Document__c);
     }
 
     /**
@@ -1366,7 +1452,8 @@ public without sharing class DocGenSignatureService {
                     Template_Ids__c,
                     Related_Record_Id__c,
                     Document_Title_Format__c,
-                    Render_Data_Snapshot__c
+                    Render_Data_Snapshot__c,
+                    Frozen_Document_CV_Id__c
                 FROM DocGen_Signature_Request__c
                 WHERE Id = :requestId
                 WITH SYSTEM_MODE
@@ -1539,15 +1626,22 @@ public without sharing class DocGenSignatureService {
                     Database.update(audits, false, AccessLevel.SYSTEM_MODE);
                 }
 
-                // Mark signed
+                // Mark signed. #156: reclaim the frozen-snapshot CV (signed PDF produced);
+                // Snapshot_Hash__c stays as the retained tamper-evidence.
                 // CxSAST: FLS enforced by DocGen permission sets; package-internal custom objects
                 req.Status__c = 'Signed';
                 // CxSAST: FLS enforced by DocGen permission sets; package-internal custom objects
                 req.Signature_Data__c = null;
+                Id frozenCvToPurge = (Id) req.Frozen_Document_CV_Id__c;
+                req.Frozen_Document_CV_Id__c = null;
                 // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Update").
-                DocGenFlsGuard.assertUpdateable(req, new Set<String>{ 'Status__c', 'Signature_Data__c' });
+                DocGenFlsGuard.assertUpdateable(
+                    req,
+                    new Set<String>{ 'Status__c', 'Signature_Data__c', 'Frozen_Document_CV_Id__c' }
+                );
                 /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
                 Database.update(req, false, AccessLevel.SYSTEM_MODE);
+                purgeFrozenSnapshotCv(frozenCvToPurge);
             } catch (Exception e) {
                 String errMsg = e.getTypeName() + ': ' + e.getMessage() + '\n' + e.getStackTraceString();
                 System.debug(LoggingLevel.ERROR, 'DocGen: Template signature PDF failed for ' + req.Id + ': ' + errMsg);
@@ -1621,11 +1715,11 @@ public without sharing class DocGenSignatureService {
             // the image/style maps. One query serves both.
             DocGenFlsGuard.assertAccessible(
                 DocGen_Signature_Request__c.sObjectType,
-                new Set<String>{ 'Signature_Data__c', 'Frozen_Document__c' }
+                new Set<String>{ 'Signature_Data__c', 'Frozen_Document__c', 'Frozen_Document_CV_Id__c' }
             );
             /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
             DocGen_Signature_Request__c reqData = [
-                SELECT Signature_Data__c, Frozen_Document__c
+                SELECT Signature_Data__c, Frozen_Document__c, Frozen_Document_CV_Id__c
                 FROM DocGen_Signature_Request__c
                 WHERE Id = :reqId
                 WITH SYSTEM_MODE
@@ -1639,9 +1733,10 @@ public without sharing class DocGenSignatureService {
                 // so the {?key} tokens resolve during this re-merge.
                 mergeData = DocGenService.mergeTemplateForSignatureFromData(templateId, snapshotData);
             } else {
-                // Classic flow: render the frozen document body with no re-merge; legacy/
-                // oversized requests (no Frozen_Document__c) fall back to a live merge.
-                List<Map<String, Object>> frozenDocs = loadFrozenMergeData(reqData.Frozen_Document__c);
+                // Classic flow: render the frozen document body with no re-merge. #156: the
+                // snapshot is CV-backed (no size cap); the legacy inline field is the fallback.
+                // Only genuinely legacy/snapshot-less requests fall through to a live merge.
+                List<Map<String, Object>> frozenDocs = resolveFrozenMergeData(reqData);
                 if (frozenDocs != null && !frozenDocs.isEmpty()) {
                     // Frozen body: {?key} tokens were preserved at send-time and the
                     // frozen XML is not re-merged here, so they cannot resolve on this
@@ -1924,11 +2019,11 @@ public without sharing class DocGenSignatureService {
             // Get cached image map
             DocGenFlsGuard.assertAccessible(
                 DocGen_Signature_Request__c.sObjectType,
-                new Set<String>{ 'Signature_Data__c', 'Frozen_Document__c' }
+                new Set<String>{ 'Signature_Data__c', 'Frozen_Document__c', 'Frozen_Document_CV_Id__c' }
             );
             /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
             DocGen_Signature_Request__c reqData = [
-                SELECT Signature_Data__c, Frozen_Document__c
+                SELECT Signature_Data__c, Frozen_Document__c, Frozen_Document_CV_Id__c
                 FROM DocGen_Signature_Request__c
                 WHERE Id = :reqId
                 WITH SYSTEM_MODE
@@ -1949,8 +2044,9 @@ public without sharing class DocGenSignatureService {
 
             // INTEGRITY: each document renders from its frozen snapshot (captured at
             // creation), not a live re-merge. Aligned to templateIds by index. Null when
-            // no snapshot exists (legacy/oversized packet) → per-doc live-merge fallback.
-            List<Map<String, Object>> frozenDocs = loadFrozenMergeData(reqData.Frozen_Document__c);
+            // no snapshot exists (legacy snapshot-less packet) → per-doc live-merge fallback.
+            // #156: CV-backed snapshot preferred, legacy inline field is the fallback.
+            List<Map<String, Object>> frozenDocs = resolveFrozenMergeData(reqData);
 
             // Merge and stamp each document
             List<String> htmlParts = new List<String>();

--- a/force-app/main/default/classes/DocGenSignatureService.cls
+++ b/force-app/main/default/classes/DocGenSignatureService.cls
@@ -1766,6 +1766,14 @@ public without sharing class DocGenSignatureService {
                 ORDER BY Document_Index__c ASC, Sequence_Order__c ASC
             ]; // NOPMD ApexCRUDViolation - package-internal custom object; CRUD controlled by DocGen permission sets
 
+            // Oversized/legacy requests (no Frozen_Document__c) reached this point via a
+            // LIVE re-merge (or a data-snapshot re-merge), so the body carries the ORIGINAL
+            // {@Signature_*} tags rather than the @@SIG-n@@ sentinels the placements key on.
+            // Re-apply the send-time substitution so stampSignaturesInXml/InHtml match lands;
+            // the frozen-body path already carries sentinels (no-op there). Without this,
+            // signatures silently never stamp on templates whose snapshot exceeds the freeze cap.
+            documentXml = DocGenSignatureSenderController.resentinelSignatureBody(documentXml);
+
             String html;
             if (templateType == 'HTML') {
                 html = stampSignaturesInHtml(documentXml, placements);
@@ -1975,6 +1983,11 @@ public without sharing class DocGenSignatureService {
                     if (p.Document_Index__c == docIdx)
                         docPlacements.add(p);
                 }
+
+                // See the single-template finalizer: a per-template live re-merge (no frozen
+                // snapshot) carries the ORIGINAL {@Signature_*} tags, so re-apply the send-time
+                // @@SIG-n@@ sentinel substitution before stamping. No-op on the frozen path.
+                documentXml = DocGenSignatureSenderController.resentinelSignatureBody(documentXml);
 
                 String docHtml;
                 if (templateType == 'HTML') {

--- a/force-app/main/default/classes/DocGenSignatureSnapshotTest.cls
+++ b/force-app/main/default/classes/DocGenSignatureSnapshotTest.cls
@@ -89,14 +89,29 @@ private class DocGenSignatureSnapshotTest {
     }
 
     @isTest
-    static void oversizedBodyReturnsNullForLiveMergeFallback() {
-        // Build a body that pushes the serialized JSON over the 131,072 LongText limit.
+    static void oversizedBodyIsFrozenToContentVersion() {
+        // #156: a body over the old 131,072 LongText limit is no longer dropped — it
+        // serializes in full and persists to a ContentVersion, so large templates get a
+        // true point-in-time snapshot instead of degrading to a live re-merge at sign time.
         String huge = 'X'.repeat(140000);
         String json = DocGenSignatureService.buildFrozenDocumentJson(
             new List<Map<String, Object>>{ mergeOutput(huge, 'Word') },
             new List<Id>{ '0Ax000000000001AAA' }
         );
-        System.assertEquals(null, json, 'Oversized snapshot is not frozen → caller live-merges');
+        System.assert(json != null && json.length() > 131072, 'Oversized snapshot serializes in full (no cap)');
+
+        Test.startTest();
+        Id cvId = DocGenSignatureService.saveFrozenSnapshotCv(json);
+        Test.stopTest();
+
+        System.assertNotEquals(null, cvId, 'Oversized snapshot persists to a ContentVersion');
+        String roundTrip = [SELECT VersionData FROM ContentVersion WHERE Id = :cvId LIMIT 1].VersionData.toString();
+        System.assertEquals(json, roundTrip, 'CV round-trips the oversized snapshot intact');
+        System.assertNotEquals(
+            null,
+            DocGenSignatureService.loadFrozenMergeData(roundTrip),
+            'Oversized snapshot loads back into renderable merge data'
+        );
     }
 
     @isTest

--- a/force-app/main/default/classes/DocGenSignatureTests.cls
+++ b/force-app/main/default/classes/DocGenSignatureTests.cls
@@ -4915,7 +4915,7 @@ private class DocGenSignatureTests {
                 Signing_Order__c,
                 Template__c,
                 Related_Record_Id__c,
-                Frozen_Document__c,
+                Frozen_Document_CV_Id__c,
                 Snapshot_Hash__c,
                 Snapshot_Taken_At__c
             FROM DocGen_Signature_Request__c
@@ -4927,17 +4927,25 @@ private class DocGenSignatureTests {
         System.assertEquals('Sequential', newReq.Signing_Order__c, 'Signing order persisted');
 
         // INTEGRITY: the real creation path froze a point-in-time snapshot of the merged
-        // document — this is what the signed PDF renders from, not a live re-merge.
-        System.assertNotEquals(null, newReq.Frozen_Document__c, 'Document body was frozen at creation');
+        // document — this is what the signed PDF renders from, not a live re-merge. #156: the
+        // snapshot lives in a ContentVersion (no size cap), referenced by Frozen_Document_CV_Id__c.
+        System.assertNotEquals(null, newReq.Frozen_Document_CV_Id__c, 'Document body was frozen at creation');
         System.assertNotEquals(null, newReq.Snapshot_Taken_At__c, 'Snapshot timestamp captured');
+        String frozenJson = [
+                SELECT VersionData
+                FROM ContentVersion
+                WHERE Id = :newReq.Frozen_Document_CV_Id__c
+                LIMIT 1
+            ]
+            .VersionData.toString();
         System.assertEquals(
-            DocGenSignatureService.hashFrozenDocument(newReq.Frozen_Document__c),
+            DocGenSignatureService.hashFrozenDocument(frozenJson),
             newReq.Snapshot_Hash__c,
             'Stored snapshot hash matches the frozen content (tamper-evidence)'
         );
         System.assertNotEquals(
             null,
-            DocGenSignatureService.loadFrozenMergeData(newReq.Frozen_Document__c),
+            DocGenSignatureService.loadFrozenMergeData(frozenJson),
             'Frozen snapshot loads back into renderable per-document merge data'
         );
 

--- a/force-app/main/default/objects/DocGen_Signature_Request__c/fields/Frozen_Document_CV_Id__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Signature_Request__c/fields/Frozen_Document_CV_Id__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Frozen_Document_CV_Id__c</fullName>
+    <description
+    >#156: ContentVersion Id of the point-in-time frozen-document snapshot (JSON of combinedDocumentXml/relsXml/contentTypesXml/templateType per template) captured when the request is created. The signed PDF renders from THIS snapshot, not a live re-merge, so the signer signs exactly what was reviewed. Stored in a CV (not the Frozen_Document__c LongTextArea) to remove the 131072-char ceiling, so large/image-heavy templates are frozen rather than degrading to a live merge. Null on legacy requests, which fall back to Frozen_Document__c then live merge.</description>
+    <externalId>false</externalId>
+    <label>Frozen Document CV Id</label>
+    <length>18</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/pages/DocGenSignaturePdf.page
+++ b/force-app/main/default/pages/DocGenSignaturePdf.page
@@ -996,6 +996,26 @@
                         var width = item.width * viewport.scale;
                         return { x: tx[4], y: tx[5] - fontHeight, w: width, h: fontHeight };
                     }
+                    // Device box for just chars [cs, ce) of an item's string. When a sentinel
+                    // shares a single rendered text run with adjacent label text (e.g. the
+                    // engine merges "Signature: " and "@@SIG-0@@" into one PDF text item), the
+                    // full item box would place an opaque chip over the label and hide it. Slice
+                    // the box proportionally by character offset so the chip lands only on the
+                    // sentinel and the "Signature:"/"Date:" label stays visible. Proportional
+                    // (assumes ~even glyph widths) — exact enough to position a sign field.
+                    function itemSubBox(item, viewport, cs, ce) {
+                        var full = itemDeviceBox(item, viewport);
+                        var len = (item.str || '').length;
+                        if (len <= 0 || (cs <= 0 && ce >= len)) {
+                            return full;
+                        }
+                        return {
+                            x: full.x + (cs / len) * full.w,
+                            y: full.y,
+                            w: ((ce - cs) / len) * full.w,
+                            h: full.h
+                        };
+                    }
                     function unionBox(a, b) {
                         var x1 = Math.min(a.x, b.x),
                             y1 = Math.min(a.y, b.y);
@@ -1111,7 +1131,11 @@
                                         for (var r = 0; r < ranges.length; r++) {
                                             var rg = ranges[r];
                                             if (rg.end <= at || rg.start >= matchEnd) continue;
-                                            var b = itemDeviceBox(rg.item, pg.viewport);
+                                            // Only the slice of this run that the needle covers —
+                                            // keeps an adjacent label (e.g. "Signature:") out of the box.
+                                            var cs = Math.max(at, rg.start) - rg.start;
+                                            var ce = Math.min(matchEnd, rg.end) - rg.start;
+                                            var b = itemSubBox(rg.item, pg.viewport, cs, ce);
                                             box = box ? unionBox(box, b) : b;
                                         }
                                         if (box) {

--- a/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
@@ -471,6 +471,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>DocGen_Signature_Request__c.Frozen_Document_CV_Id__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>DocGen_Signature_Request__c.Snapshot_Hash__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/DocGen_Guest_Signature.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Guest_Signature.permissionset-meta.xml
@@ -96,6 +96,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>DocGen_Signature_Request__c.Frozen_Document_CV_Id__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>DocGen_Signature_Request__c.Snapshot_Hash__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
@@ -457,6 +457,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>DocGen_Signature_Request__c.Frozen_Document_CV_Id__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>DocGen_Signature_Request__c.Snapshot_Hash__c</field>
         <readable>true</readable>


### PR DESCRIPTION
Closes #189.

## Problem
A template with `{@Signature_*}` tags whose **merged snapshot exceeds 131072 chars** silently produces a **blank signature line** in the finalized PDF — even though the signer completes signing, placements are captured, and the request shows `Signed`.

Root cause: `DocGenSignatureService.buildFrozenDocumentJson` returns `null` over the 131072-char Long-Text-Area cap, so `Frozen_Document__c` is never saved. With no frozen doc, the finalizer (`TemplateSignaturePdfQueueable`) falls back to a **live re-merge**, regenerating the original `{@Signature_Buyer}` tags. But placements key on the `@@SIG-n@@` sentinels assigned at send time, and `stampSignaturesInXml` only replaces where `documentXml.contains(plc.Tag_Text__c)`. No match → nothing stamps → the unstamped tags are stripped at render.

Verified against a real 153786-char "Triage A to Z" proposal in Portwood Dev (request SIG-000244): live-merge body had `{@Signature_Buyer}` but neither `@@SIG-0@@` nor `@@SIG-1@@`.

## Fix
`DocGenSignatureSenderController.resentinelSignatureBody(body)` re-applies the send-time `{@Signature_*}` → `@@SIG-n@@` substitution to the already-merged body, in document order. Tags are sourced from the **body**, not the template — `extractTemplatePlainText` reads the pre-decomposed XML `WITH USER_MODE`, which returns empty in the async (Automated Process) finalize context. Both the single-template and packet finalizers call it before stamping; idempotent no-op on the frozen path.

End-to-end check against the live placements: stamped body now reads `Signature: Electronically signed by Dave Moudy on 2026-06-18 11:18`.

## Tests
- `DocGenGuidedSigningTest.resentinelRestoresSentinelsInDocumentOrder` — document-order indexing, no leftover tags.
- `DocGenGuidedSigningTest.resentinelIsIdempotentAndHandlesBareTag` — frozen-path no-op, bare `{@Signature}` fallback, null-safe.
- `DocGenGuidedSigningTest` passes 11/11 in isolation; prettier clean.

## Follow-up
Robust fix in #156 — store the frozen snapshot in a ContentVersion to remove the cap entirely, retiring this live-merge fallback and the residual tag-less-synthetic-block edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)