### PR TITLE
Fix: docx signature templates leak inline tags when not pre-decomposed

### DIFF
--- a/force-app/main/default/classes/DocGenSarahFixesTest.cls
+++ b/force-app/main/default/classes/DocGenSarahFixesTest.cls
@@ -348,4 +348,125 @@ private class DocGenSarahFixesTest {
             'Final CV title should NOT be the "<base> - Signed" fallback, got: ' + cvs[0].Title
         );
     }
+
+    // =========================================================================
+    // #9 — Word template with NO pre-decomposed XML CVs still yields placements.
+    //
+    //   SHWaiver bug: extractTemplatePlainText read its <w:t> text ONLY from the
+    //   pre-decomposed docgen_tmpl_xml_* CVs. A Word version that was never
+    //   (re-)decomposed — e.g. a docx replaced/re-saved during org build-out — has
+    //   none, so the parser returned 0 placements and the send silently fell back to
+    //   the synthetic "Signatures" block, leaking the authored {@Signature_*:inline}
+    //   tags as raw text. The parser now self-heals via
+    //   DocGenService.getActiveTemplateDocumentXml (on-demand read of the raw docx),
+    //   so placement detection no longer depends on decomposition having run.
+    //
+    //   The tag is deliberately SPLIT across multiple <w:r> runs (as Word emits it
+    //   when spell/grammar-check or formatting fragments a tag) to prove the <w:t>
+    //   concatenation still recovers the whole {@Signature_WaiverSigner:1:Full:inline}.
+    // =========================================================================
+    @IsTest
+    static void testWordTemplateWithoutDecompFindsPlacements() {
+        // Minimal valid .docx whose signature tag is run-split with a proofErr marker
+        // injected mid-tag — the shape that produced Sarah's leak.
+        String bodyXml =
+            '<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>' +
+            '<w:p><w:r><w:t>Signature</w:t></w:r>' +
+            '<w:r><w:t xml:space="preserve">{@Signature_WaiverSigner</w:t></w:r>' +
+            '<w:r><w:t>:</w:t></w:r><w:proofErr w:type="gramStart"/><w:r><w:t>1</w:t></w:r>' +
+            '<w:r><w:t>:Full</w:t></w:r><w:proofErr w:type="gramEnd"/>' +
+            '<w:r><w:t>:inline</w:t></w:r><w:r><w:t>}</w:t></w:r></w:p>' +
+            '<w:p><w:r><w:t>Date</w:t></w:r>' +
+            '<w:r><w:t xml:space="preserve">{@Signature_WaiverSigner</w:t></w:r>' +
+            '<w:r><w:t>:1:Date</w:t></w:r><w:r><w:t>:inline</w:t></w:r><w:r><w:t>}</w:t></w:r></w:p>' +
+            '</w:body></w:document>';
+
+        Compression.ZipWriter zw = new Compression.ZipWriter();
+        zw.addEntry(
+            '[Content_Types].xml',
+            Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+                    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+                    '<Default Extension="xml" ContentType="application/xml"/>' +
+                    '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+                    '</Types>'
+            )
+        );
+        zw.addEntry(
+            '_rels/.rels',
+            Blob.valueOf(
+                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+                    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+                    '</Relationships>'
+            )
+        );
+        zw.addEntry('word/document.xml', Blob.valueOf(bodyXml));
+
+        DocGen_Template__c tmpl = new DocGen_Template__c(
+            Name = 'SarahFix Word ' + Datetime.now().getTime() + Crypto.getRandomInteger(),
+            Type__c = 'Word',
+            Output_Format__c = 'PDF',
+            Base_Object_API__c = 'Contact',
+            Query_Config__c = 'Name'
+        );
+        insert tmpl;
+
+        ContentVersion cv = new ContentVersion(
+            Title = tmpl.Name + ' Docx',
+            PathOnClient = 'waiver.docx',
+            VersionData = zw.getArchive(),
+            FirstPublishLocationId = tmpl.Id
+        );
+        insert cv;
+        cv = [SELECT Id FROM ContentVersion WHERE Id = :cv.Id LIMIT 1];
+
+        insert new DocGen_Template_Version__c(
+            Template__c = tmpl.Id,
+            Content_Version_Id__c = cv.Id,
+            Is_Active__c = true,
+            Type__c = 'Word'
+        );
+
+        // No extractAndSaveTemplateImages call → zero docgen_tmpl_xml_* CVs (Sarah's state).
+        DocGen_Template_Version__c ver = [
+            SELECT Id
+            FROM DocGen_Template_Version__c
+            WHERE Template__c = :tmpl.Id AND Is_Active__c = TRUE
+            LIMIT 1
+        ];
+        Integer xmlCvCount = [
+            SELECT COUNT()
+            FROM ContentVersion
+            WHERE Title LIKE :('docgen_tmpl_xml_' + ver.Id + '_%')
+        ];
+        System.assertEquals(0, xmlCvCount, 'Precondition: template must have NO pre-decomposed XML CVs');
+
+        Test.startTest();
+        List<DocGenSignatureSenderController.PlacementInfo> placements = DocGenSignatureSenderController.getTemplateSignaturePlacements(
+            tmpl.Id
+        );
+        Test.stopTest();
+
+        // Self-heal: the on-demand document.xml read recovers the run-split inline tag.
+        System.assertEquals(
+            2,
+            placements.size(),
+            'Run-split inline tags must be found even with no pre-decomposed CVs (got ' + placements.size() + ')'
+        );
+        Boolean sawFull = false;
+        Boolean sawDate = false;
+        for (DocGenSignatureSenderController.PlacementInfo p : placements) {
+            if (p.placementType == 'Full') {
+                sawFull = true;
+            }
+            if (p.placementType == 'Date') {
+                sawDate = true;
+            }
+            System.assertEquals('WaiverSigner', p.role, 'Role must parse from the run-split tag');
+        }
+        System.assert(sawFull, 'Full placement must be parsed from the inline tag');
+        System.assert(sawDate, 'Date placement must be parsed from the inline tag');
+    }
 }

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -1770,6 +1770,60 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
     }
 
     /**
+     * Returns the raw word/document.xml for a template's active version, read on-demand
+     * straight from the template ContentVersion blob — NO pre-decomposed
+     * docgen_tmpl_xml_* ContentVersions required.
+     *
+     * The signature placement parser (DocGenSignatureSenderController.extractTemplatePlainText)
+     * normally reads its <w:t> text from those pre-decomposed CVs, which only exist once the
+     * async decomposition (extractAndSaveTemplateImages) has run for the active version. A
+     * template whose active version was never (re-)decomposed — e.g. a docx replaced/re-saved
+     * during org build-out — has none, so the parser finds zero {@Signature_*} placements and
+     * the send silently falls back to the synthetic "Signatures" block, leaking the authored
+     * inline {@Signature_*:inline} tags as raw text (Sarah's SHWaiver bug). This getter lets
+     * the parser self-heal by reading document.xml the same way the merge path already does.
+     *
+     * Returns null if there is no active version CV or the docx lacks word/document.xml.
+     */
+    public static String getActiveTemplateDocumentXml(Id templateId) {
+        DocGenFlsGuard.assertAccessible(
+            DocGen_Template_Version__c.sObjectType,
+            new Set<String>{ 'Content_Version_Id__c', 'Template__c', 'Is_Active__c' }
+        );
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<DocGen_Template_Version__c> vers = [
+            SELECT Content_Version_Id__c
+            FROM DocGen_Template_Version__c
+            WHERE Template__c = :templateId AND Is_Active__c = TRUE
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ]; // NOPMD ApexCRUDViolation - package-internal custom object
+        if (vers.isEmpty() || vers[0].Content_Version_Id__c == null) {
+            return null;
+        }
+        Id cvId = (Id) vers[0].Content_Version_Id__c;
+        DocGenFlsGuard.assertAccessible(ContentVersion.sObjectType, new Set<String>{ 'VersionData' });
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<ContentVersion> cvs = [
+            SELECT VersionData
+            FROM ContentVersion
+            WHERE Id = :cvId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ]; // NOPMD ApexCRUDViolation - package-internal CV read
+        if (cvs.isEmpty() || cvs[0].VersionData == null) {
+            return null;
+        }
+        Compression.ZipReader reader = new Compression.ZipReader(cvs[0].VersionData);
+        for (Compression.ZipEntry entry : reader.getEntries()) {
+            if (entry.getName() == 'word/document.xml') {
+                return reader.extract(entry.getName()).toString();
+            }
+        }
+        return null;
+    }
+
+    /**
      * Extracts images from a template DOCX/PPTX file and saves them as ContentVersion
      * records linked to the template version. These committed CVs provide stable URLs
      * for Blob.toPdf() which cannot render data URI images (Flying Saucer limitation).

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -255,6 +255,15 @@ public with sharing class DocGenSignatureSenderController {
                 break;
             }
         }
+        if (documentXml == null) {
+            // No pre-decomposed document.xml CV — the async decomposition never ran for
+            // this active version (e.g. the docx was replaced/re-saved during org build-out
+            // and the new version wasn't re-decomposed). Read document.xml on-demand from the
+            // raw template CV so placement parsing still finds the {@Signature_*:inline} tags
+            // instead of returning empty and silently falling back to the synthetic
+            // "Signatures" block (which leaks the inline tags as raw text). See SHWaiver bug.
+            documentXml = DocGenService.getActiveTemplateDocumentXml(templateId);
+        }
         if (documentXml == null)
             return null;
 


### PR DESCRIPTION
## Problem (Sarah's SHWaiver bug)

A Word signature template whose active version has **no pre-decomposed `docgen_tmpl_xml_*` ContentVersions** — e.g. a docx replaced/re-saved during org build-out and never re-decomposed — caused `getTemplateSignaturePlacements` to return **zero placements**. The send then silently fell back to the synthetic "Signatures" block, which **leaked the authored `{@Signature_*:inline}` tags as raw text** and appended a **spurious bottom block**. HTML templates were unaffected (body read directly, no decomposition step) — which is why "signatures render fine with HTML inputs but not docx."

## Root cause
`extractTemplatePlainText` read its `<w:t>` text **only** from the pre-decomposed XML CVs, which exist only after the async `extractAndSaveTemplateImages` decomposition has run.

## Fix
`extractTemplatePlainText` self-heals via new `DocGenService.getActiveTemplateDocumentXml()` — reads `word/document.xml` **on-demand** from the raw template CV (same as the merge path), so placement detection no longer depends on decomposition having run. `<w:t>` concatenation recovers run-split tags (Word fragments a tag across `<w:r>` runs with `<w:proofErr>` markers mid-tag).

## Verification (portwood-staging, real SHWaiver.docx)
| | Before | After |
|---|---|---|
| Placements parsed (no XML CVs) | 0 | **2** |
| Raw `{@Signature…}` leak | yes | **none** |
| Synthetic bottom block | yes | **gone** |
| Inline sentinels placed | no | **yes** |

- New regression test `DocGenSarahFixesTest.testWordTemplateWithoutDecompFindsPlacements`.
- 336 signature tests pass · e2e-01…08 + 07-syntax1…4 PASS/FAIL0 · RunLocalTests 1627/100%/77% · code-analyzer 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)