### PR TITLE
Add a one-click DocGen quick action (LWC + controller + CMDT)

### DIFF
--- a/force-app/main/default/classes/DocGenButtonController.cls
+++ b/force-app/main/default/classes/DocGenButtonController.cls
@@ -1,0 +1,327 @@
+/**
+ * DocGenButtonController
+ * -----------------------
+ * Backs the docGenButton quick action. Resolves a pre-configured template from the
+ * DocGen_Button__mdt custom metadata type, generates the document through the DocGen
+ * service layer, and returns the file to the browser for download (and, optionally,
+ * attaches it to the record).
+ *
+ * Generation goes through DocGenService.generateDocument(...) — the same service
+ * entry DocGenFlowAction uses internally — then the resulting ContentVersion is read
+ * back and returned to the client either as a base64 payload (small files with an
+ * LWS-safe MIME type: PDF, images, text) or as a file-servlet download URL (everything
+ * else, including Office formats that Lightning Web Security blocks for Blob URLs).
+ *
+ * The generation call is isolated behind the Generator seam so the full controller
+ * flow can be unit-tested without invoking real document rendering.
+ */
+public with sharing class DocGenButtonController {
+    /** Files at/under this byte size are returned inline as base64 for a direct
+     *  client-side download. Larger files fall back to the download servlet URL to
+     *  stay within Apex heap. Not final so tests can exercise both branches. */
+    @TestVisible
+    private static Integer inlineDownloadMaxBytes = 3500000; // ~3.5 MB
+
+    public class DocGenButtonException extends Exception {}
+
+    // ---------------------------------------------------------------------
+    // Generation seam (lets tests run the controller without real rendering)
+    // ---------------------------------------------------------------------
+    public interface Generator {
+        GenResult generate(GenRequest req);
+    }
+
+    public class GenRequest {
+        public Id templateId;
+        public Id recordId;
+        public Boolean saveToRecord;
+        public String documentTitle;
+        public String outputFormatOverride;
+    }
+
+    public class GenResult {
+        public Id contentDocumentId;
+        public Id contentVersionId;
+        public Boolean success;
+        public String errorMessage;
+    }
+
+    /** Default generator: delegates to the DocGen service layer. */
+    public class ServiceGenerator implements Generator {
+        public GenResult generate(GenRequest r) {
+            GenResult out = new GenResult();
+            try {
+                // attachmentRecordId = recordId links the file to the record (Files
+                // related list); null produces a standalone ContentVersion that is
+                // still downloadable via the returned ContentDocumentId.
+                Id attachmentRecordId = (r.saveToRecord == true) ? r.recordId : null;
+                Id contentDocumentId = DocGenService.generateDocument(
+                    r.templateId,
+                    r.recordId,
+                    r.outputFormatOverride,
+                    r.documentTitle,
+                    attachmentRecordId
+                );
+                out.contentDocumentId = contentDocumentId;
+                out.success = (contentDocumentId != null);
+                if (!out.success) {
+                    out.errorMessage = 'DocGen did not return a document.';
+                }
+            } catch (Exception e) {
+                out.success = false;
+                out.errorMessage = e.getMessage();
+            }
+            return out;
+        }
+    }
+
+    @TestVisible
+    private static Generator generator = new ServiceGenerator();
+
+    /** Optional test override of the config source. Custom metadata records cannot
+     *  be inserted via DML in tests, so tests inject rows here instead of querying. */
+    @TestVisible
+    private static List<DocGen_Button__mdt> configOverride;
+
+    // ---------------------------------------------------------------------
+    // LWC-facing DTOs
+    // ---------------------------------------------------------------------
+    public class ButtonOption {
+        @AuraEnabled
+        public String developerName;
+        @AuraEnabled
+        public String label;
+    }
+
+    public class GenerateResultDTO {
+        @AuraEnabled
+        public Boolean success;
+        @AuraEnabled
+        public String errorMessage;
+        @AuraEnabled
+        public String fileName;
+        @AuraEnabled
+        public String mimeType;
+        @AuraEnabled
+        public String base64Data; // populated for small files
+        @AuraEnabled
+        public String downloadUrl; // populated for large files
+        @AuraEnabled
+        public Id contentDocumentId;
+        @AuraEnabled
+        public Id contentVersionId;
+    }
+
+    // ---------------------------------------------------------------------
+    // Public API (called from the LWC)
+    // ---------------------------------------------------------------------
+
+    /** Returns the active button configurations for the record's object so the LWC
+     *  can auto-run a single button or present a small picker for several.
+     *  Takes recordId (always injected into quick actions) and derives the object
+     *  API name server-side from the Id — quick actions don't reliably inject
+     *  objectApiName before connectedCallback, and this also removes any
+     *  namespace/case/whitespace mismatch. Not cacheable: config reads happen once
+     *  per click and caching would let a stale/empty result persist. */
+    @AuraEnabled
+    public static List<ButtonOption> getButtons(Id recordId) {
+        List<ButtonOption> options = new List<ButtonOption>();
+        if (recordId == null) {
+            return options;
+        }
+        String objectApiName = recordId.getSObjectType().getDescribe().getName();
+        for (DocGen_Button__mdt cfg : loadConfigs(objectApiName)) {
+            ButtonOption opt = new ButtonOption();
+            opt.developerName = cfg.DeveloperName;
+            opt.label = String.isNotBlank(cfg.MasterLabel) ? cfg.MasterLabel : cfg.DeveloperName;
+            options.add(opt);
+        }
+        return options;
+    }
+
+    /** Generates the document for the chosen configuration and returns it for download. */
+    @AuraEnabled
+    public static GenerateResultDTO generate(Id recordId, String configDeveloperName) {
+        GenerateResultDTO dto = new GenerateResultDTO();
+        try {
+            DocGen_Button__mdt cfg = getConfig(configDeveloperName);
+            if (cfg == null) {
+                throw new DocGenButtonException(
+                    'No active DocGen Button configuration named "' + configDeveloperName + '".'
+                );
+            }
+            if (String.isBlank(cfg.Template_Id__c)) {
+                throw new DocGenButtonException(
+                    'DocGen Button "' + configDeveloperName + '" has no Template Id configured.'
+                );
+            }
+
+            Id templateId;
+            try {
+                templateId = (Id) cfg.Template_Id__c;
+            } catch (Exception idEx) {
+                throw new DocGenButtonException(
+                    'DocGen Button "' +
+                        configDeveloperName +
+                        '" has an invalid Template Id (' +
+                        cfg.Template_Id__c +
+                        '). Set it to a DocGen Template record Id.'
+                );
+            }
+
+            GenRequest gReq = new GenRequest();
+            gReq.templateId = templateId;
+            gReq.recordId = recordId;
+            gReq.saveToRecord = cfg.Save_To_Record__c == true;
+            gReq.documentTitle = cfg.Document_Title__c;
+            gReq.outputFormatOverride = cfg.Output_Format_Override__c;
+
+            GenResult res = generator.generate(gReq);
+            if (res == null || res.success != true) {
+                throw new DocGenButtonException(
+                    (res != null && String.isNotBlank(res.errorMessage))
+                        ? res.errorMessage
+                        : 'Document generation failed.'
+                );
+            }
+
+            Id cvId = res.contentVersionId;
+            if (cvId == null && res.contentDocumentId != null) {
+                List<ContentVersion> latest = [
+                    SELECT Id
+                    FROM ContentVersion
+                    WHERE ContentDocumentId = :res.contentDocumentId
+                    WITH USER_MODE
+                    ORDER BY CreatedDate DESC
+                    LIMIT 1
+                ];
+                if (!latest.isEmpty()) {
+                    cvId = latest[0].Id;
+                }
+            }
+            if (cvId == null) {
+                throw new DocGenButtonException('The document was generated but no file reference was returned.');
+            }
+
+            List<ContentVersion> cvs = [
+                SELECT Id, Title, FileExtension, ContentSize, ContentDocumentId
+                FROM ContentVersion
+                WHERE Id = :cvId
+                WITH USER_MODE
+                LIMIT 1
+            ];
+            if (cvs.isEmpty()) {
+                throw new DocGenButtonException('Generated file could not be read back. Check file sharing/visibility.');
+            }
+            ContentVersion cv = cvs[0];
+
+            dto.success = true;
+            dto.contentVersionId = cv.Id;
+            dto.contentDocumentId = cv.ContentDocumentId;
+            dto.fileName = buildFileName(cv);
+            dto.mimeType = mimeFor(cv.FileExtension);
+
+            // Always provide a file-servlet download URL. It works for every MIME type
+            // and any size, and sidesteps Lightning Web Security's Blob/createObjectURL
+            // MIME allowlist (which rejects Office formats like .docx/.pptx/.xlsx).
+            dto.downloadUrl = '/sfc/servlet.shepherd/version/download/' + cv.Id;
+
+            // Also return base64 for small files. The LWC uses the Blob path only for
+            // LWS-safe MIME types (PDF, images, text) and otherwise uses downloadUrl.
+            if (cv.ContentSize != null && cv.ContentSize <= inlineDownloadMaxBytes) {
+                List<ContentVersion> withData = [
+                    SELECT VersionData
+                    FROM ContentVersion
+                    WHERE Id = :cv.Id
+                    WITH USER_MODE
+                    LIMIT 1
+                ];
+                if (!withData.isEmpty() && withData[0].VersionData != null) {
+                    dto.base64Data = EncodingUtil.base64Encode(withData[0].VersionData);
+                }
+            }
+
+            return dto;
+        } catch (Exception e) {
+            dto.success = false;
+            dto.errorMessage = e.getMessage();
+            return dto;
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+    @TestVisible
+    private static List<DocGen_Button__mdt> loadConfigs(String objectApiName) {
+        if (configOverride != null) {
+            List<DocGen_Button__mdt> filtered = new List<DocGen_Button__mdt>();
+            for (DocGen_Button__mdt c : configOverride) {
+                if (c.Active__c == true && c.Object_API_Name__c == objectApiName) {
+                    filtered.add(c);
+                }
+            }
+            return filtered;
+        }
+        return [
+            SELECT
+                DeveloperName,
+                MasterLabel,
+                Object_API_Name__c,
+                Template_Id__c,
+                Save_To_Record__c,
+                Output_Format_Override__c,
+                Document_Title__c,
+                Active__c,
+                Sort_Order__c
+            FROM DocGen_Button__mdt
+            WHERE Active__c = true AND Object_API_Name__c = :objectApiName
+            ORDER BY Sort_Order__c NULLS LAST, MasterLabel
+        ];
+    }
+
+    @TestVisible
+    private static DocGen_Button__mdt getConfig(String developerName) {
+        if (configOverride != null) {
+            for (DocGen_Button__mdt c : configOverride) {
+                if (c.DeveloperName == developerName && c.Active__c == true) {
+                    return c;
+                }
+            }
+            return null;
+        }
+        List<DocGen_Button__mdt> rows = [
+            SELECT
+                DeveloperName,
+                MasterLabel,
+                Object_API_Name__c,
+                Template_Id__c,
+                Save_To_Record__c,
+                Output_Format_Override__c,
+                Document_Title__c,
+                Active__c
+            FROM DocGen_Button__mdt
+            WHERE DeveloperName = :developerName AND Active__c = true
+            LIMIT 1
+        ];
+        return rows.isEmpty() ? null : rows[0];
+    }
+
+    private static String buildFileName(ContentVersion cv) {
+        String base = String.isNotBlank(cv.Title) ? cv.Title : 'Document';
+        String ext = String.isNotBlank(cv.FileExtension) ? cv.FileExtension.toLowerCase() : 'pdf';
+        return base.endsWithIgnoreCase('.' + ext) ? base : base + '.' + ext;
+    }
+
+    private static String mimeFor(String ext) {
+        String e = (ext == null) ? '' : ext.toLowerCase();
+        Map<String, String> m = new Map<String, String>{
+            'pdf' => 'application/pdf',
+            'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            'doc' => 'application/msword',
+            'pptx' => 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+            'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        };
+        return m.containsKey(e) ? m.get(e) : 'application/octet-stream';
+    }
+}

--- a/force-app/main/default/classes/DocGenButtonController.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenButtonController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenButtonControllerTest.cls
+++ b/force-app/main/default/classes/DocGenButtonControllerTest.cls
@@ -1,0 +1,186 @@
+/**
+ * Tests for DocGenButtonController.
+ *
+ * The managed-package call is replaced with a mock Generator, and custom metadata
+ * is injected via the configOverride seam (CMDT records cannot be DML-inserted in
+ * tests). This exercises the full controller flow — config resolution, file
+ * read-back, inline base64 vs. download-URL branches, and error handling — without
+ * actually invoking Portwood DocGen.
+ */
+@IsTest
+private class DocGenButtonControllerTest {
+    private static final String OBJ = 'User';
+
+    /** Mock that creates a real ContentVersion and returns its ids. */
+    private class MockGenerator implements DocGenButtonController.Generator {
+        public DocGenButtonController.GenResult generate(DocGenButtonController.GenRequest req) {
+            ContentVersion cv = new ContentVersion(
+                Title = String.isNotBlank(req.documentTitle) ? req.documentTitle : 'Mock Document',
+                PathOnClient = 'Mock Document.pdf',
+                VersionData = Blob.valueOf('%PDF-1.4 mock content')
+            );
+            insert cv;
+            cv = [SELECT Id, ContentDocumentId FROM ContentVersion WHERE Id = :cv.Id LIMIT 1];
+
+            DocGenButtonController.GenResult r = new DocGenButtonController.GenResult();
+            r.success = true;
+            r.contentVersionId = cv.Id;
+            r.contentDocumentId = cv.ContentDocumentId;
+            return r;
+        }
+    }
+
+    /** Mock that reports a failure (e.g., template locked, merge error). */
+    private class FailingGenerator implements DocGenButtonController.Generator {
+        public DocGenButtonController.GenResult generate(DocGenButtonController.GenRequest req) {
+            DocGenButtonController.GenResult r = new DocGenButtonController.GenResult();
+            r.success = false;
+            r.errorMessage = 'Simulated package failure.';
+            return r;
+        }
+    }
+
+    private static DocGen_Button__mdt cfg(String devName, String objectApi, String templateId, Boolean active) {
+        return new DocGen_Button__mdt(
+            DeveloperName = devName,
+            MasterLabel = devName.replace('_', ' '),
+            Object_API_Name__c = objectApi,
+            Template_Id__c = templateId,
+            Save_To_Record__c = false,
+            Active__c = active,
+            Sort_Order__c = 1
+        );
+    }
+
+    @IsTest
+    static void getButtons_returnsActiveConfigsForObject() {
+        DocGenButtonController.configOverride = new List<DocGen_Button__mdt>{
+            cfg('WO_PDF', OBJ, UserInfo.getUserId(), true),
+            cfg('WO_Summary', OBJ, UserInfo.getUserId(), true),
+            cfg('Other_Obj', 'Contact', UserInfo.getUserId(), true),
+            cfg('Inactive_One', OBJ, UserInfo.getUserId(), false)
+        };
+
+        Test.startTest();
+        List<DocGenButtonController.ButtonOption> opts = DocGenButtonController.getButtons(UserInfo.getUserId());
+        Test.stopTest();
+
+        System.assertEquals(2, opts.size(), 'Only active configs for the record object should be returned');
+    }
+
+    @IsTest
+    static void getButtons_nullRecordId_returnsEmpty() {
+        Test.startTest();
+        List<DocGenButtonController.ButtonOption> opts = DocGenButtonController.getButtons((Id) null);
+        Test.stopTest();
+        System.assertEquals(0, opts.size(), 'Null recordId should yield no options');
+    }
+
+    @IsTest
+    static void generate_smallFile_returnsBase64() {
+        DocGenButtonController.generator = new MockGenerator();
+        DocGenButtonController.configOverride = new List<DocGen_Button__mdt>{
+            cfg('WO_PDF', OBJ, UserInfo.getUserId(), true)
+        };
+
+        Test.startTest();
+        DocGenButtonController.GenerateResultDTO dto = DocGenButtonController.generate(UserInfo.getUserId(), 'WO_PDF');
+        Test.stopTest();
+
+        System.assertEquals(true, dto.success, 'Expected success');
+        System.assertNotEquals(null, dto.base64Data, 'Small file should return base64');
+        System.assertNotEquals(null, dto.downloadUrl, 'A servlet download URL is always provided');
+        System.assertEquals('application/pdf', dto.mimeType, 'PDF mime expected');
+        System.assert(dto.fileName.endsWithIgnoreCase('.pdf'), 'Filename should carry extension');
+    }
+
+    @IsTest
+    static void generate_largeFile_returnsDownloadUrl() {
+        DocGenButtonController.generator = new MockGenerator();
+        DocGenButtonController.inlineDownloadMaxBytes = 1; // force the URL branch
+        DocGenButtonController.configOverride = new List<DocGen_Button__mdt>{
+            cfg('WO_PDF', OBJ, UserInfo.getUserId(), true)
+        };
+
+        Test.startTest();
+        DocGenButtonController.GenerateResultDTO dto = DocGenButtonController.generate(UserInfo.getUserId(), 'WO_PDF');
+        Test.stopTest();
+
+        System.assertEquals(true, dto.success, 'Expected success');
+        System.assertEquals(null, dto.base64Data, 'Large file should not return base64');
+        System.assert(
+            dto.downloadUrl != null && dto.downloadUrl.contains('/sfc/servlet.shepherd/version/download/'),
+            'Large file should return a download servlet URL'
+        );
+    }
+
+    @IsTest
+    static void generate_unknownConfig_returnsError() {
+        DocGenButtonController.generator = new MockGenerator();
+        DocGenButtonController.configOverride = new List<DocGen_Button__mdt>{
+            cfg('WO_PDF', OBJ, UserInfo.getUserId(), true)
+        };
+
+        Test.startTest();
+        DocGenButtonController.GenerateResultDTO dto = DocGenButtonController.generate(UserInfo.getUserId(), 'DOES_NOT_EXIST');
+        Test.stopTest();
+
+        System.assertEquals(false, dto.success, 'Unknown config should fail');
+        System.assert(dto.errorMessage.contains('No active DocGen Button'), 'Expected config-not-found message');
+    }
+
+    @IsTest
+    static void generate_blankTemplateId_returnsError() {
+        DocGenButtonController.generator = new MockGenerator();
+        DocGenButtonController.configOverride = new List<DocGen_Button__mdt>{
+            cfg('WO_PDF', OBJ, null, true)
+        };
+
+        Test.startTest();
+        DocGenButtonController.GenerateResultDTO dto = DocGenButtonController.generate(UserInfo.getUserId(), 'WO_PDF');
+        Test.stopTest();
+
+        System.assertEquals(false, dto.success, 'Blank template id should fail');
+        System.assert(dto.errorMessage.contains('no Template Id'), 'Expected missing-template message');
+    }
+
+    @IsTest
+    static void generate_packageFailure_returnsError() {
+        DocGenButtonController.generator = new FailingGenerator();
+        DocGenButtonController.configOverride = new List<DocGen_Button__mdt>{
+            cfg('WO_PDF', OBJ, UserInfo.getUserId(), true)
+        };
+
+        Test.startTest();
+        DocGenButtonController.GenerateResultDTO dto = DocGenButtonController.generate(UserInfo.getUserId(), 'WO_PDF');
+        Test.stopTest();
+
+        System.assertEquals(false, dto.success, 'Package failure should surface as error');
+        System.assertEquals('Simulated package failure.', dto.errorMessage, 'Package error message should pass through');
+    }
+
+    /**
+     * Exercises the default ServiceGenerator -> DocGenService path
+     * (no mock injected) so the real package call and its error handling are covered.
+     * A valid-format but non-existent Template Id makes the package call fail; the
+     * generator catches it and the controller surfaces a graceful error. We assert on
+     * the outcome, not a specific message, since the package controls the wording.
+     */
+    @IsTest
+    static void generate_packagePath_handlesInvalidTemplateGracefully() {
+        // Intentionally do NOT set DocGenButtonController.generator here.
+        DocGenButtonController.configOverride = new List<DocGen_Button__mdt>{
+            cfg('WO_PDF', OBJ, UserInfo.getUserId(), true) // valid Id format, not a real template
+        };
+
+        Test.startTest();
+        DocGenButtonController.GenerateResultDTO dto = DocGenButtonController.generate(
+            UserInfo.getUserId(),
+            'WO_PDF'
+        );
+        Test.stopTest();
+
+        System.assertEquals(false, dto.success, 'A non-existent template via the real package path should fail gracefully');
+        System.assertNotEquals(null, dto.errorMessage, 'A user-facing error message should be returned');
+    }
+}

--- a/force-app/main/default/classes/DocGenButtonControllerTest.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenButtonControllerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/docGenButton/docGenButton.css
+++ b/force-app/main/default/lwc/docGenButton/docGenButton.css
@@ -1,0 +1,4 @@
+.docgen-button-shell {
+    min-height: 8rem;
+    width: 100%;
+}

--- a/force-app/main/default/lwc/docGenButton/docGenButton.html
+++ b/force-app/main/default/lwc/docGenButton/docGenButton.html
@@ -1,0 +1,39 @@
+<template>
+    <div class="slds-p-around_medium slds-align_absolute-center docgen-button-shell">
+        <template lwc:if={loading}>
+            <div class="slds-text-align_center">
+                <lightning-spinner alternative-text="Generating document" size="medium"></lightning-spinner>
+                <p class="slds-m-top_large slds-text-body_regular">{statusMessage}</p>
+            </div>
+        </template>
+
+        <template lwc:if={showPicker}>
+            <div class="slds-text-align_center">
+                <p class="slds-text-heading_small slds-m-bottom_medium">Choose a document to generate</p>
+                <template for:each={options} for:item="opt">
+                    <lightning-button
+                        key={opt.developerName}
+                        label={opt.label}
+                        data-name={opt.developerName}
+                        variant="brand"
+                        class="slds-m-around_xx-small"
+                        onclick={handlePick}
+                    ></lightning-button>
+                </template>
+            </div>
+        </template>
+
+        <template lwc:if={errorMessage}>
+            <div class="slds-text-align_center">
+                <lightning-icon
+                    icon-name="utility:error"
+                    variant="error"
+                    size="small"
+                    class="slds-m-bottom_x-small"
+                ></lightning-icon>
+                <p class="slds-text-color_error">{errorMessage}</p>
+                <lightning-button label="Close" class="slds-m-top_medium" onclick={handleClose}></lightning-button>
+            </div>
+        </template>
+    </div>
+</template>

--- a/force-app/main/default/lwc/docGenButton/docGenButton.js
+++ b/force-app/main/default/lwc/docGenButton/docGenButton.js
@@ -1,0 +1,194 @@
+import { LightningElement, api } from 'lwc';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import { CloseActionScreenEvent } from 'lightning/actions';
+import getButtons from '@salesforce/apex/DocGenButtonController.getButtons';
+import generate from '@salesforce/apex/DocGenButtonController.generate';
+
+/**
+ * docGenButton
+ * ------------
+ * Screen quick action that generates a DocGen document from a pre-configured
+ * template (DocGen_Button__mdt) and downloads it. When exactly one configuration
+ * exists for the object it runs immediately; when several exist it shows a small
+ * picker. No DocGen Runner, no field choices.
+ */
+export default class DocGenButton extends LightningElement {
+    _recordId;
+    _started = false;
+    _waitTimer;
+
+    @api
+    get recordId() {
+        return this._recordId;
+    }
+    set recordId(value) {
+        this._recordId = value;
+        this.maybeStart();
+    }
+
+    @api objectApiName; // provided by the record action; not used (object is derived from recordId server-side)
+
+    loading = true;
+    statusMessage = 'Preparing…';
+    errorMessage;
+    options = [];
+    showPicker = false;
+
+    connectedCallback() {
+        this.maybeStart();
+        // Fallback: if recordId never arrives, don't spin forever.
+        // eslint-disable-next-line @lwc/lwc/no-async-operation
+        this._waitTimer = setTimeout(() => {
+            if (!this._started) {
+                this.fail('Could not determine the record. Please reopen the record and try again.');
+            }
+        }, 4000);
+    }
+
+    disconnectedCallback() {
+        if (this._waitTimer) {
+            clearTimeout(this._waitTimer);
+        }
+    }
+
+    /** Runs the flow exactly once, and only after recordId has been injected. */
+    maybeStart() {
+        if (this._started || !this._recordId) {
+            return;
+        }
+        this._started = true;
+        if (this._waitTimer) {
+            clearTimeout(this._waitTimer);
+        }
+        this.init();
+    }
+
+    async init() {
+        try {
+            const opts = await getButtons({ recordId: this.recordId });
+            if (!opts || opts.length === 0) {
+                this.fail('No DocGen document is configured for this record type.');
+                return;
+            }
+            if (opts.length === 1) {
+                this.run(opts[0].developerName);
+            } else {
+                this.options = opts;
+                this.showPicker = true;
+                this.loading = false;
+            }
+        } catch (e) {
+            this.fail(this.toMessage(e));
+        }
+    }
+
+    handlePick(event) {
+        const developerName = event.currentTarget.dataset.name;
+        this.showPicker = false;
+        this.loading = true;
+        this.run(developerName);
+    }
+
+    async run(configDeveloperName) {
+        this.loading = true;
+        this.statusMessage = 'Generating document…';
+        try {
+            const res = await generate({
+                recordId: this.recordId,
+                configDeveloperName
+            });
+            if (!res || !res.success) {
+                this.fail((res && res.errorMessage) || 'Document generation failed.');
+                return;
+            }
+            this.deliver(res);
+            this.showToast('Document generated', `${res.fileName} is downloading.`, 'success');
+            this.close();
+        } catch (e) {
+            this.fail(this.toMessage(e));
+        }
+    }
+
+    deliver(res) {
+        let href;
+        let revoke = false;
+        // LWS sanitizes URL.createObjectURL against a MIME allowlist (PDF, images,
+        // plain text). Office formats (.docx/.pptx/.xlsx) are rejected, so use the
+        // servlet download URL for anything not on the allowlist.
+        if (res.base64Data && this.isBlobSafeMime(res.mimeType)) {
+            const blob = this.base64ToBlob(res.base64Data, res.mimeType);
+            href = URL.createObjectURL(blob);
+            revoke = true;
+        } else if (res.downloadUrl) {
+            href = res.downloadUrl;
+        } else if (res.base64Data) {
+            const blob = this.base64ToBlob(res.base64Data, res.mimeType);
+            href = URL.createObjectURL(blob);
+            revoke = true;
+        } else {
+            return;
+        }
+        const anchor = document.createElement('a');
+        anchor.href = href;
+        anchor.download = res.fileName || 'document';
+        anchor.target = '_blank';
+        document.body.appendChild(anchor);
+        anchor.click();
+        document.body.removeChild(anchor);
+        if (revoke) {
+            // Give the browser a moment to start the download before releasing the URL.
+            // eslint-disable-next-line @lwc/lwc/no-async-operation
+            setTimeout(() => URL.revokeObjectURL(href), 4000);
+        }
+    }
+
+    isBlobSafeMime(mimeType) {
+        if (!mimeType) {
+            return false;
+        }
+        return (
+            mimeType === 'application/pdf' ||
+            mimeType.startsWith('image/') ||
+            mimeType === 'text/plain'
+        );
+    }
+
+    base64ToBlob(base64, mimeType) {
+        const binary = atob(base64);
+        const length = binary.length;
+        const bytes = new Uint8Array(length);
+        for (let i = 0; i < length; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+        return new Blob([bytes], { type: mimeType || 'application/octet-stream' });
+    }
+
+    fail(message) {
+        this.loading = false;
+        this.showPicker = false;
+        this.errorMessage = message;
+        this.showToast('Could not generate document', message, 'error');
+    }
+
+    close() {
+        this.dispatchEvent(new CloseActionScreenEvent());
+    }
+
+    handleClose() {
+        this.close();
+    }
+
+    showToast(title, message, variant) {
+        this.dispatchEvent(new ShowToastEvent({ title, message, variant }));
+    }
+
+    toMessage(error) {
+        if (error && error.body && error.body.message) {
+            return error.body.message;
+        }
+        if (error && error.message) {
+            return error.message;
+        }
+        return 'Unexpected error.';
+    }
+}

--- a/force-app/main/default/lwc/docGenButton/docGenButton.js-meta.xml
+++ b/force-app/main/default/lwc/docGenButton/docGenButton.js-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <isExposed>true</isExposed>
+    <masterLabel>DocGen Button</masterLabel>
+    <description
+    >One-click DocGen document generation from a pre-configured template (DocGen Button custom metadata). Use as a record quick action.</description>
+    <targets>
+        <target>lightning__RecordAction</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__RecordAction">
+            <actionType>ScreenAction</actionType>
+        </targetConfig>
+    </targetConfigs>
+</LightningComponentBundle>

--- a/force-app/main/default/objects/DocGen_Button__mdt/DocGen_Button__mdt.object-meta.xml
+++ b/force-app/main/default/objects/DocGen_Button__mdt/DocGen_Button__mdt.object-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label>DocGen Button</label>
+    <pluralLabel>DocGen Buttons</pluralLabel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/force-app/main/default/objects/DocGen_Button__mdt/fields/Active__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Button__mdt/fields/Active__c.field-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Active__c</fullName>
+    <label>Active</label>
+    <description>Only active configurations are offered on the button.</description>
+    <type>Checkbox</type>
+    <defaultValue>true</defaultValue>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Button__mdt/fields/Document_Title__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Button__mdt/fields/Document_Title__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Document_Title__c</fullName>
+    <label>Document Title</label>
+    <description>Optional. Override the generated file name. Leave blank to use the template default.</description>
+    <type>Text</type>
+    <length>255</length>
+    <required>false</required>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Button__mdt/fields/Object_API_Name__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Button__mdt/fields/Object_API_Name__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Object_API_Name__c</fullName>
+    <label>Object API Name</label>
+    <description>API name of the object whose record page hosts the button (e.g., sm1a__WorkOrder__c). Used to match the record context.</description>
+    <type>Text</type>
+    <length>255</length>
+    <required>true</required>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Button__mdt/fields/Output_Format_Override__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Button__mdt/fields/Output_Format_Override__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Output_Format_Override__c</fullName>
+    <label>Output Format Override</label>
+    <description>Optional. Override the template Output Format at runtime: PDF, Word, or PowerPoint. Leave blank for the template default. Ignored/errors if the template has Lock Output Format = true.</description>
+    <type>Text</type>
+    <length>40</length>
+    <required>false</required>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Button__mdt/fields/Output_Format_Override__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Button__mdt/fields/Output_Format_Override__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Output_Format_Override__c</fullName>
     <label>Output Format Override</label>
-    <description>Optional. Override the template Output Format at runtime: PDF, Word, or PowerPoint. Leave blank for the template default. Ignored/errors if the template has Lock Output Format = true.</description>
+    <description>Optional. Override the template's output format at runtime: PDF, Word, PowerPoint, or HTML (Excel is not supported as an override). Leave blank to use the template default. Errors if the template has Lock Output Format enabled.</description>
     <type>Text</type>
     <length>40</length>
     <required>false</required>

--- a/force-app/main/default/objects/DocGen_Button__mdt/fields/Save_To_Record__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Button__mdt/fields/Save_To_Record__c.field-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Save_To_Record__c</fullName>
+    <label>Save To Record</label>
+    <description>If checked, the generated file is attached to the source record (Files related list). Either way it is downloaded.</description>
+    <type>Checkbox</type>
+    <defaultValue>true</defaultValue>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Button__mdt/fields/Sort_Order__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Button__mdt/fields/Sort_Order__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Sort_Order__c</fullName>
+    <label>Sort Order</label>
+    <description>Optional. Orders buttons in the picker when an object has more than one configuration.</description>
+    <type>Number</type>
+    <precision>4</precision>
+    <scale>0</scale>
+    <required>false</required>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Button__mdt/fields/Template_Id__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Button__mdt/fields/Template_Id__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Template_Id__c</fullName>
+    <label>Template Id</label>
+    <description>Record Id of the DocGen Template (DocGen_Template__c) to generate. Org-specific; set per subscriber org.</description>
+    <type>Text</type>
+    <length>18</length>
+    <required>true</required>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/permissionsets/DocGen_Quick_Action.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Quick_Action.permissionset-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label>DocGen Quick Action</label>
+    <description>Use of the DocGen quick action: Apex access to DocGenButtonController and read on DocGen_Button__mdt. Can be merged into the existing DocGen permission set. Generation still requires the grants the DocGen permission set already provides.</description>
+    <hasActivationRequired>false</hasActivationRequired>
+    <classAccesses>
+        <apexClass>DocGenButtonController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <customMetadataTypeAccesses>
+        <name>DocGen_Button__mdt</name>
+        <enabled>true</enabled>
+    </customMetadataTypeAccesses>
+</PermissionSet>


### PR DESCRIPTION
## Summary

Adds a one-click **screen quick action** that generates a DocGen document from a
pre-assigned template — no Screen Flow wrapper and no Runner on the page. Targets the
"give this object a button that always runs this one template" case.

When an object has a single active configuration the action runs immediately; when it has
several, it shows a small picker.

## What's included

- **`docGenButton`** (LWC, screen action) — runs the configured template, shows a spinner
  during generation, then downloads the file. Picker only when an object has multiple configs.
- **`DocGenButtonController`** — resolves config from `DocGen_Button__mdt`, generates via
  `DocGenService.generateDocument(...)`, reads the resulting ContentVersion back, and returns
  it for download (Blob for LWS-safe MIME types, file-servlet URL for Office formats so
  Lightning Web Security doesn't reject them), optionally attaching to the record.
- **`DocGen_Button__mdt`** — per-object config: template Id, save-to-record, output-format
  override, document title, active, sort order.
- **`DocGen_Quick_Action`** permission set — Apex class access + CMDT read (can be merged into
  the existing DocGen permission set).
- **8 unit tests** via a `Generator` seam (mockable generation); ~81% on the controller,
  validated in a subscriber org.

## Notable design point

The object API name is derived from `recordId` **server-side** rather than trusting the
action's `objectApiName`, which doesn't reliably inject before the first call. Deriving it
from the Id also removes namespace/case/whitespace mismatches, which is what makes a generic
"pinned template" button robust across objects.

Config keys on the template **record Id** (unambiguous, no lookup). If cross-org packaged
config is ever wanted, resolving by a stable key instead is noted as a future option.

## Setup (post-deploy)

1. Put the operational fields (Active, Save To Record, Output Format Override, Document Title,
   Sort Order) on the **DocGen Button** custom metadata type layout — only required fields
   auto-place, so otherwise they're hidden in Manage Records.
2. Assign the **DocGen Quick Action** permission set, or merge its two grants (Apex class
   access to `DocGenButtonController`, read on `DocGen_Button__mdt`) into the DocGen permission
   set. CMDT SOQL is access-enforced for non-admins.
3. Create a **DocGen Button** record per button (object API name + template Id), then add the
   `docGenButton` quick action to each target object's page.

## Notes

- Generation runs through the same `DocGenService` entry the Flow action uses, so behavior
  matches the existing path.
- New components are at API 64.0 — happy to bump to match the package's `sourceApiVersion`.