### PR TITLE
Fix #202: prune template-keyed (LWC-uploaded) image links from generation records

### DIFF
--- a/force-app/main/default/classes/DocGenMiscTests.cls
+++ b/force-app/main/default/classes/DocGenMiscTests.cls
@@ -9672,6 +9672,90 @@ private class DocGenMiscTests {
         System.assertEquals(1, activeStillLinked, 'Active version image link must be preserved for rendering.');
     }
 
+    @IsTest
+    static void testStaleTemplateKeyedLwcImageLinksArePruned() {
+        // #202: the LWC zip-upload flow (saveHtmlTemplateImage) titles images
+        // docgen_html_img_<templateId>_<epochMillis>_<name> — template-keyed, new
+        // CVs on every body re-upload, and typically a SINGLE version row. The
+        // v3.26 prune matched only version-keyed titles, so these links piled up
+        // on the record forever. A no-longer-referenced template-keyed image link
+        // must be pruned; the currently-referenced one must survive.
+        Account acc = new Account(Name = 'Stale LWC Image Link Prune');
+        insert acc;
+
+        DocGen_Template__c tpl = new DocGen_Template__c(
+            Name = 'Stale LWC Image Link Prune',
+            Base_Object_API__c = 'Account',
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF',
+            Query_Config__c = 'Name'
+        );
+        Database.insert(tpl, AccessLevel.SYSTEM_MODE);
+
+        // One version row for the whole test — the common HTML-template shape.
+        DocGen_Template_Version__c ver = new DocGen_Template_Version__c(
+            Template__c = tpl.Id,
+            Is_Active__c = true,
+            Type__c = 'HTML',
+            Base_Object_API__c = 'Account',
+            Output_Format__c = 'PDF'
+        );
+        Database.insert(ver, AccessLevel.SYSTEM_MODE);
+
+        // Upload 1's image, referenced and linked by a first generation.
+        ContentVersion imgOld = new ContentVersion(
+            Title = 'docgen_html_img_' + tpl.Id + '_1000000000001_logo.png',
+            PathOnClient = 'logo.png',
+            VersionData = Blob.valueOf('PNG1')
+        );
+        insert imgOld;
+        String html1 =
+            '<html><body><img src="/sfc/servlet.shepherd/version/download/' +
+            imgOld.Id +
+            '"/></body></html>';
+        DocGenService.ensureTemplateAssetImageAccessForPdf(tpl.Id, acc.Id, html1);
+        System.assertEquals(
+            1,
+            [
+                SELECT COUNT()
+                FROM ContentDocumentLink
+                WHERE LinkedEntityId = :acc.Id AND ContentDocument.Title LIKE 'docgen_html_img_%'
+            ],
+            'Upload-1 image should be linked after the first generation.'
+        );
+
+        // Body re-upload mints a new timestamped CV; the body now references it.
+        ContentVersion imgNew = new ContentVersion(
+            Title = 'docgen_html_img_' + tpl.Id + '_1000000000002_logo.png',
+            PathOnClient = 'logo.png',
+            VersionData = Blob.valueOf('PNG2')
+        );
+        insert imgNew;
+        String html2 =
+            '<html><body><img src="/sfc/servlet.shepherd/version/download/' +
+            imgNew.Id +
+            '"/></body></html>';
+
+        Test.startTest();
+        DocGenService.ensureTemplateAssetImageAccessForPdf(tpl.Id, acc.Id, html2);
+        Test.stopTest();
+
+        // Net: still 1 link (new referenced image), not 2 — the stale upload-1
+        // link is pruned even though it can't be matched to any version row.
+        List<ContentDocumentLink> remaining = [
+            SELECT ContentDocumentId
+            FROM ContentDocumentLink
+            WHERE LinkedEntityId = :acc.Id AND ContentDocument.Title LIKE 'docgen_html_img_%'
+        ];
+        System.assertEquals(1, remaining.size(), 'Stale template-keyed LWC image link must be pruned (#202).');
+        Id newDocId = [SELECT ContentDocumentId FROM ContentVersion WHERE Id = :imgNew.Id].ContentDocumentId;
+        System.assertEquals(
+            newDocId,
+            remaining[0].ContentDocumentId,
+            'The surviving link must be the currently-referenced image, not the stale one.'
+        );
+    }
+
     private static void assertGiantLauncherUsesInternalLoader(String body, String className) {
         Integer idx = body.indexOf('docgen_tmpl_xml_');
         System.assert(idx >= 0, className + ' should reference pre-decomposed template XML.');

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -2314,6 +2314,9 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             }
         }
         if (assetDocIds.isEmpty()) {
+            // Body no longer references any template-owned images — still prune
+            // links earlier generations left behind.
+            pruneStaleTemplateImageLinks(templateId, recordId, versionId, assetDocIds);
             return;
         }
 
@@ -2352,15 +2355,25 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
 
     /**
      * Removes orphaned template-image ContentDocumentLinks that earlier
-     * generations attached to this record for OLD (non-active) versions of this
-     * template. `ensureTemplateAssetImageAccessForPdf` links the active version's
-     * embedded images to the record so Blob.toPdf can read them, but every
-     * template re-save mints a new version with freshly-decomposed image CVs —
-     * the prior version's links stay behind and pile up in the record's Files
-     * (the "hundreds of images on the record" report). We never touch the active
-     * version's links (`keepDocIds`), so rendering is unaffected; we only drop
-     * links whose backing CV title is a DocGen template image (`docgen_html_img_`
-     * / `docgen_tmpl_img_`) belonging to a DIFFERENT version of THIS template.
+     * generations attached to this record. `ensureTemplateAssetImageAccessForPdf`
+     * links the body's referenced images to the record so Blob.toPdf can read
+     * them, but stale links pile up in the record's Files (the "hundreds of
+     * images on the record" report) via two naming schemes:
+     *
+     *   1. Version-keyed (`docgen_(html|tmpl)_img_<versionId>_<name>`, server-side
+     *      decomposition): every template re-save mints a new version with fresh
+     *      image CVs; links for OLD versions of THIS template are stale.
+     *   2. Template-keyed (`docgen_html_img_<templateId>_<epochMillis>_<name>`,
+     *      DocGenController.saveHtmlTemplateImage — the LWC zip-upload flow):
+     *      every body re-upload mints new timestamped CVs regardless of version
+     *      rows, so staleness can't be determined from version membership at all.
+     *      Any link with THIS template's id in the title that the current body no
+     *      longer references is stale. (#202 — v3.26 only handled scheme 1, so
+     *      LWC-uploaded images were never pruned.)
+     *
+     * Links whose docs the current body references (`keepDocIds`) are never
+     * touched, so rendering is unaffected; other templates' images and
+     * user-attached files never match either scheme's title scope.
      */
     private static void pruneStaleTemplateImageLinks(
         Id templateId,
@@ -2378,9 +2391,10 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             WITH SYSTEM_MODE
         ];
         Set<Id> templateVersionIds = new Map<Id, DocGen_Template_Version__c>(templateVersions).keySet();
-        if (templateVersionIds.size() <= 1) {
-            return; // only the active version exists — nothing stale to prune
-        }
+
+        // 15-char id prefix matches both 15- and 18-char stored title forms, and
+        // cannot collide with another record's 18-char id.
+        String templateKeyedPrefix = 'docgen_html_img_' + String.valueOf(templateId).substring(0, 15);
 
         /* code-analyzer-suppress ApexFlsViolation */
         List<ContentDocumentLink> recordImgLinks = [
@@ -2396,12 +2410,16 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         List<ContentDocumentLink> staleLinks = new List<ContentDocumentLink>();
         for (ContentDocumentLink link : recordImgLinks) {
             if (keepDocIds.contains(link.ContentDocumentId)) {
-                continue; // active version's image — required for rendering
+                continue; // referenced by the body being rendered — required
             }
-            // Title shape: docgen_(html|tmpl)_img_<versionId>_<...>
-            List<String> parts = (link.ContentDocument.Title == null)
-                ? new List<String>()
-                : link.ContentDocument.Title.split('_');
+            String title = link.ContentDocument.Title == null ? '' : link.ContentDocument.Title;
+            // Scheme 2: LWC-uploaded image of THIS template, no longer referenced.
+            if (title.startsWith(templateKeyedPrefix)) {
+                staleLinks.add(link);
+                continue;
+            }
+            // Scheme 1 — title shape: docgen_(html|tmpl)_img_<versionId>_<...>
+            List<String> parts = title.split('_');
             if (parts.size() < 5) {
                 continue;
             }


### PR DESCRIPTION
Fixes #202.

## Root cause

Two naming schemes exist for HTML template images, and the v3.26 `pruneStaleTemplateImageLinks` only handled one:

| Scheme | Minted by | Title | Prunable by v3.26? |
|---|---|---|---|
| Version-keyed | `DocGenService.extractAndSaveHtmlTemplateAssets` (server-side zip) | `docgen_html_img_<versionId>_<name>` | ✅ |
| Template-keyed | `DocGenController.saveHtmlTemplateImage` (LWC client-side zip-break-apart) | `docgen_html_img_<templateId>_<epochMillis>_<name>` | ❌ never |

The prune parsed `parts[3]` of the title and deleted the link only if it was a **version Id of this template**. For LWC-uploaded images `parts[3]` is the *template* Id — never in the version set — so those links were structurally immortal. Every body re-upload mints new timestamped CVs, each generation links the new set to the record, the old set stays. A second hole: `templateVersionIds.size() <= 1` early-returned before pruning anything, and single-version rows are the common shape for LWC-uploaded HTML templates.

This is why the v3.26 fix appeared to work (generating repeatedly without re-uploading adds no links) and then "regressed" once the customer resumed iterating on the template.

## Fix

- Prune any `docgen_html_img_<templateId15>_*` link the current body no longer references. `keepDocIds` still protects everything the render needs; the 15-char id prefix matches both stored title forms and can't collide with another record's id.
- Remove the `size() <= 1` early return.
- Run the prune even when the new body references no template-owned images at all.

Audited all other `ContentDocumentLink` creation sites (controller/flow/giant/stitch/signature paths): all are the generated document itself or signature-lifecycle shares — by design, no other generation-time image-link source. Chart PNGs are transient with their own delete + reaper. All three render paths (Word→PDF, HTML→PDF, giant-query) route through the same `ensureTemplateAssetImageAccessForPdf`, so the fix covers each.

## Validation

- New regression test `testStaleTemplateKeyedLwcImageLinksArePruned` mirrors the customer workflow (single version row, two timestamped uploads, second generation must net exactly one link) — fails before the fix (early return), passes after
- Targeted run on Portwood Dev: 37/37 (3 link/prune tests + DocGenImageTagTests)
- Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)