### PR TITLE
Feat #208: per-template default email message (+#209 Flow exposure verified)

### DIFF
--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -2330,7 +2330,8 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 'Page_Margins__c',
                 'Custom_Margins__c',
                 'Signer_Verification__c',
-                'Prefill_Signer_Email__c'
+                'Prefill_Signer_Email__c',
+                'Default_Email_Message__c'
             }
         );
         /* code-analyzer-suppress ApexFlsViolation */
@@ -2362,6 +2363,7 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 Custom_Margins__c,
                 Signer_Verification__c,
                 Prefill_Signer_Email__c,
+                Default_Email_Message__c,
                 (SELECT ContentDocumentId FROM ContentDocumentLinks ORDER BY ContentDocument.CreatedDate DESC LIMIT 1)
             FROM DocGen_Template__c
             WITH SYSTEM_MODE
@@ -2455,6 +2457,10 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             if (fields.containsKey('Prefill_Signer_Email__c')) {
                 template.Prefill_Signer_Email__c = (String) fields.get('Prefill_Signer_Email__c');
             }
+            // #208 — per-template default {Message} for signature emails
+            if (fields.containsKey('Default_Email_Message__c')) {
+                template.Default_Email_Message__c = (String) fields.get('Default_Email_Message__c');
+            }
             // #85 — Active flag. Default true on new records; only update when the
             // caller explicitly sends the field (so legacy save paths that omit it
             // don't accidentally toggle an existing template's active state).
@@ -2520,6 +2526,7 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                     'Custom_Margins__c',
                     'Signer_Verification__c',
                     'Prefill_Signer_Email__c',
+                    'Default_Email_Message__c',
                     'Is_Active__c',
                     'Is_Default__c'
                 }

--- a/force-app/main/default/classes/DocGenEmailTemplateTest.cls
+++ b/force-app/main/default/classes/DocGenEmailTemplateTest.cls
@@ -247,6 +247,54 @@ private class DocGenEmailTemplateTest {
         );
     }
 
+    // ---- #208: per-template default message resolution ----
+    @IsTest
+    static void templateDefaultMessage_resolvesFromRequestTemplate() {
+        DocGen_Template__c tpl = new DocGen_Template__c(
+            Name = 'Quote Template',
+            Base_Object_API__c = 'Account',
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF',
+            Default_Email_Message__c = 'Please see the attached proposal — reply with any questions.'
+        );
+        insert tpl;
+        DocGen_Signature_Request__c withTpl = new DocGen_Signature_Request__c(Status__c = 'Sent', Template__c = tpl.Id);
+        DocGen_Signature_Request__c noTpl = new DocGen_Signature_Request__c(Status__c = 'Sent');
+        insert new List<DocGen_Signature_Request__c>{ withTpl, noTpl };
+
+        Test.startTest();
+        String resolved = DocGenSignatureEmailService.templateDefaultMessage(withTpl.Id);
+        String withoutTemplate = DocGenSignatureEmailService.templateDefaultMessage(noTpl.Id);
+        String nullRequest = DocGenSignatureEmailService.templateDefaultMessage(null);
+        Test.stopTest();
+
+        System.assertEquals(
+            'Please see the attached proposal — reply with any questions.',
+            resolved,
+            'template default must resolve through the request lookup'
+        );
+        System.assertEquals(null, withoutTemplate, 'doc-based request (no template) yields null');
+        System.assertEquals(null, nullRequest, 'null requestId yields null');
+    }
+
+    // ---- #208: blank template default falls through to the type default ----
+    @IsTest
+    static void templateDefaultMessage_blankFieldYieldsNull() {
+        DocGen_Template__c tpl = new DocGen_Template__c(
+            Name = 'No Default Template',
+            Base_Object_API__c = 'Account',
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF'
+        );
+        insert tpl;
+        DocGen_Signature_Request__c req = new DocGen_Signature_Request__c(Status__c = 'Sent', Template__c = tpl.Id);
+        insert req;
+        System.assert(
+            String.isBlank(DocGenSignatureEmailService.templateDefaultMessage(req.Id)),
+            'blank field must not shadow the generic type default'
+        );
+    }
+
     // ---- Service: Full HTML mode sends the admin's document with no chrome ----
     @IsTest
     static void fullHtmlMode_skipsChrome() {

--- a/force-app/main/default/classes/DocGenSignatureEmailService.cls
+++ b/force-app/main/default/classes/DocGenSignatureEmailService.cls
@@ -77,6 +77,32 @@ public with sharing class DocGenSignatureEmailService {
         sendRequestLikeEmails(signers, documentTitle, requestId, null, DocGenEmailTemplateService.TYPE_REMINDER, null);
     }
 
+    /**
+     * #208 — the request's document template's Default_Email_Message__c, or null.
+     * FLS-guard + SYSTEM_MODE (internal config read; USER_MODE on a new packaged
+     * field breaks the namespaced build and guest senders lack template read).
+     */
+    @TestVisible
+    private static String templateDefaultMessage(Id requestId) {
+        if (requestId == null) {
+            return null;
+        }
+        DocGenFlsGuard.assertAccessible(DocGen_Signature_Request__c.sObjectType, new Set<String>{ 'Template__c' });
+        DocGenFlsGuard.assertAccessible(DocGen_Template__c.sObjectType, new Set<String>{ 'Default_Email_Message__c' });
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<DocGen_Signature_Request__c> reqs = [
+            SELECT Template__c, Template__r.Default_Email_Message__c
+            FROM DocGen_Signature_Request__c
+            WHERE Id = :requestId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (reqs.isEmpty() || reqs[0].Template__c == null) {
+            return null;
+        }
+        return reqs[0].Template__r.Default_Email_Message__c;
+    }
+
     private static void sendRequestLikeEmails(
         List<SignerEmail> signers,
         String documentTitle,
@@ -104,6 +130,15 @@ public with sharing class DocGenSignatureEmailService {
         }
 
         String defaultMessage = DocGenEmailTemplateService.defaultMessage(templateType);
+        // #208 — when the sender supplied no message, a Default_Email_Message__c on
+        // the request's document template beats the generic type default. A send-time
+        // override (handled inside render) still wins over both.
+        if (String.isBlank(messageOverride)) {
+            String tplDefault = templateDefaultMessage(requestId);
+            if (String.isNotBlank(tplDefault)) {
+                defaultMessage = tplDefault;
+            }
+        }
 
         List<Messaging.SingleEmailMessage> emails = new List<Messaging.SingleEmailMessage>();
         for (SignerEmail signer : signers) {

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -63,7 +63,8 @@ public with sharing class DocGenSignatureSenderController {
                 'Specific_Record_Ids__c',
                 'Required_Permission_Sets__c',
                 'Record_Filter__c',
-                'Base_Object_API__c'
+                'Base_Object_API__c',
+                'Default_Email_Message__c'
             }
         );
         /* code-analyzer-suppress ApexFlsViolation */
@@ -76,7 +77,8 @@ public with sharing class DocGenSignatureSenderController {
                 Specific_Record_Ids__c,
                 Required_Permission_Sets__c,
                 Record_Filter__c,
-                Base_Object_API__c
+                Base_Object_API__c,
+                Default_Email_Message__c
             FROM DocGen_Template__c
             WITH SYSTEM_MODE
             ORDER BY Sort_Order__c ASC NULLS LAST, Name ASC

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1222,6 +1222,15 @@
                                         field-level-help="When verification is on, auto-send the code to the signer's known email and skip the 'type your email' step. Inherit uses the org default."
                                         class="slds-var-m-top_small"
                                     ></lightning-combobox>
+                                    <!-- #208 — per-template default email message -->
+                                    <lightning-textarea
+                                        label="Default Email Message (e-sign)"
+                                        value={editTemplateDefaultEmailMessage}
+                                        onchange={handleDefaultEmailMessageChange}
+                                        max-length="4000"
+                                        field-level-help="Default text for the {Message} token in signature request emails sent from this template. Pre-filled for the sender; a message typed at send time always wins. Blank uses the generic default."
+                                        class="slds-var-m-top_small"
+                                    ></lightning-textarea>
                                 </div>
                             </div>
                             <div class="slds-var-p-horizontal_small">

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -133,6 +133,11 @@ const F = {
     // #verification — template-level defaults
     SignerVerification: SIGNER_VERIFICATION_FIELD.fieldApiName,
     PrefillSignerEmail: PREFILL_SIGNER_EMAIL_FIELD.fieldApiName,
+    // #208 — per-template default {Message} for signature emails; namespace
+    // resolved from an already-imported field (same pattern as FormFieldsConfig).
+    DefaultEmailMessage:
+        QUERY_CONFIG_FIELD.fieldApiName.slice(0, QUERY_CONFIG_FIELD.fieldApiName.length - 'Query_Config__c'.length) +
+        'Default_Email_Message__c',
     // Version fields
     VerIsActive: VER_IS_ACTIVE_FIELD.fieldApiName,
     VerCvId: VER_CV_ID_FIELD.fieldApiName,
@@ -303,6 +308,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     editTemplateLockOutputFormat = false;
     // #verification — template-level defaults (tri-state: Inherit / Required|Off / Yes|No)
     @track editTemplateSignerVerification = 'Inherit';
+    // #208 — per-template default {Message} for signature emails
+    @track editTemplateDefaultEmailMessage = '';
     @track editTemplatePrefillSignerEmail = 'Inherit';
     editTemplateSpecificRecordIds;
     editTemplateRequiredPermissionSets;
@@ -2539,6 +2546,10 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     handleSignerVerificationChange(event) {
         this.editTemplateSignerVerification = event.detail.value;
     }
+
+    handleDefaultEmailMessageChange(event) {
+        this.editTemplateDefaultEmailMessage = event.detail.value || '';
+    }
     handlePrefillSignerEmailChange(event) {
         this.editTemplatePrefillSignerEmail = event.detail.value;
     }
@@ -2841,6 +2852,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             this.editTemplateLockOutputFormat = row[F.LockOutputFormat] || false;
             this.editTemplateSignerVerification = row[F.SignerVerification] || 'Inherit';
             this.editTemplatePrefillSignerEmail = row[F.PrefillSignerEmail] || 'Inherit';
+            this.editTemplateDefaultEmailMessage = row[F.DefaultEmailMessage] || '';
             this.editTemplateSpecificRecordIds = row[F.SpecificRecordIds];
             this.editTemplateRequiredPermissionSets = row[F.RequiredPermSets];
             this.editTemplateRecordFilter = row[F.RecordFilter];
@@ -3240,7 +3252,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             Page_Margins__c: this.editTemplatePageMargins,
             Custom_Margins__c: this.editTemplateCustomMargins,
             Signer_Verification__c: this.editTemplateSignerVerification,
-            Prefill_Signer_Email__c: this.editTemplatePrefillSignerEmail
+            Prefill_Signer_Email__c: this.editTemplatePrefillSignerEmail,
+            Default_Email_Message__c: this.editTemplateDefaultEmailMessage
         };
         this.editTemplateQuery = fields['Query_Config__c'];
 
@@ -3287,7 +3300,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             Page_Margins__c: this.editTemplatePageMargins,
             Custom_Margins__c: this.editTemplateCustomMargins,
             Signer_Verification__c: this.editTemplateSignerVerification,
-            Prefill_Signer_Email__c: this.editTemplatePrefillSignerEmail
+            Prefill_Signer_Email__c: this.editTemplatePrefillSignerEmail,
+            Default_Email_Message__c: this.editTemplateDefaultEmailMessage
         };
         this.editTemplateQuery = fields['Query_Config__c'];
 

--- a/force-app/main/default/lwc/docGenSignatureSender/docGenSignatureSender.js
+++ b/force-app/main/default/lwc/docGenSignatureSender/docGenSignatureSender.js
@@ -74,7 +74,9 @@ export default class DocGenSignatureSender extends LightningElement {
         if (data) {
             this.docGenTemplateOptions = data.map((t) => ({
                 label: t.Name,
-                value: t.Id
+                value: t.Id,
+                // #208 — namespace-aware read: prefixed in subscriber orgs, bare in dev.
+                defaultMessage: t.Default_Email_Message__c || t.portwoodglobal__Default_Email_Message__c || ''
             }));
         } else if (error) {
             this.docGenTemplateOptions = [];
@@ -246,6 +248,9 @@ export default class DocGenSignatureSender extends LightningElement {
     // (isSingleTemplate getter is defined above, shared with the #verification controls.)
     handleEmailMessageChange(event) {
         this.emailMessage = event.detail.value || '';
+        // #208 — once the sender types (or clears) the message, stop auto-filling
+        // template defaults for this send.
+        this._messageTouched = true;
     }
 
     handleEmailSubjectChange(event) {
@@ -281,6 +286,18 @@ export default class DocGenSignatureSender extends LightningElement {
         try {
             const opt = this.docGenTemplateOptions.find((t) => t.value === templateId);
             if (!opt) return;
+
+            // #208 — pre-fill the send-time message with the template's default so
+            // the sender sees exactly what will go out. Only when they haven't
+            // typed their own text, and only for the first selected template.
+            if (
+                !this._messageTouched &&
+                !this.emailMessage &&
+                this.selectedTemplates.length === 0 &&
+                opt.defaultMessage
+            ) {
+                this.emailMessage = opt.defaultMessage;
+            }
 
             // Scan template for placements
             let placements = [];
@@ -330,6 +347,11 @@ export default class DocGenSignatureSender extends LightningElement {
         const idx = parseInt(event.currentTarget.dataset.index, 10);
         this.selectedTemplates = this.selectedTemplates.filter((_, i) => i !== idx);
         this._refreshAggregatedPlacements();
+        // #208 — an auto-filled (never-touched) message belongs to the removed
+        // template; clear it so the next selection can pre-fill its own default.
+        if (!this._messageTouched && this.selectedTemplates.length === 0) {
+            this.emailMessage = '';
+        }
     }
 
     handleMoveTemplateUp(event) {

--- a/force-app/main/default/objects/DocGen_Template__c/fields/Default_Email_Message__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Template__c/fields/Default_Email_Message__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Default_Email_Message__c</fullName>
+    <description
+    >Default prose for the {Message} token in signature/notification emails sent for documents generated from this template. Pre-filled for the sender and used by Flow sends when no send-time message is supplied; a send-time message always wins. Blank = the email template type's generic default.</description>
+    <label>Default Email Message</label>
+    <length>4000</length>
+    <type>LongTextArea</type>
+    <visibleLines>4</visibleLines>
+</CustomField>

--- a/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
@@ -439,6 +439,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>DocGen_Template__c.Default_Email_Message__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>DocGen_Template__c.Prefill_Signer_Email__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
@@ -427,6 +427,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Template__c.Default_Email_Message__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>DocGen_Template__c.Prefill_Signer_Email__c</field>
         <readable>true</readable>


### PR DESCRIPTION
Fixes #208, closes #209.

The email-template GA gate from the contributor DM: per-template defaults for the `{Message}` token.

## What changed

- **New field** `DocGen_Template__c.Default_Email_Message__c` (long text, 4000) + `DocGen_Admin` (edit) / `DocGen_User` (read) grants
- **One canonical resolution point** — `DocGenSignatureEmailService.sendRequestLikeEmails`: send-time override → template default → type default. UI sends, resends, Flow sends, and reminders all funnel through it, so every route inherits the behavior with no per-caller wiring. Lookup uses FLS-guard + SYSTEM_MODE (the USER_MODE-on-new-packaged-field build trap)
- **Command Hub**: "Default Email Message (e-sign)" textarea in the template editor, namespace-aware field map entry, threaded through `saveTemplate` (conditional setter — partial saves don't clear it)
- **Sender LWC**: pre-fills the message box from the first selected template's default so the sender sees exactly what will go out; sender-typed text is never clobbered; removing the template clears an untouched pre-fill

## #209 verification (all pass)

1. `emailMessage` invocable is `global`, labeled "Custom Email Message" with description — visible in Flow Builder
2. Pass-through chain intact: Flow action → `createGuidedPdfSignatureRequest` → `createSignersAndNotify` → `sendSignatureRequestEmails` → `render()` `{Message}` replacement
3. Blank input falls back cleanly — existing no-leftover-token assertions cover leakage

## Validation

- DocGenEmailTemplateTest 18/18 (2 new: resolution through the request lookup; blank field falls through to type default)
- DocGenSignatureFlowActionTest + DocGenSignatureSenderControllerTest 224/224
- DocGenControllerTests 224/224
- Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)