### PR TITLE
Fix #200: Shield-org install failure — remove SOQL filters on encryptable standard fields

### DIFF
--- a/force-app/main/default/classes/DocGenBulkFlowActionTest.cls
+++ b/force-app/main/default/classes/DocGenBulkFlowActionTest.cls
@@ -76,7 +76,7 @@ private class DocGenBulkFlowActionTest {
 
     @IsTest
     static void testBuildEffectiveCondition_idsOnly() {
-        Account a = [SELECT Id FROM Account WHERE Name = 'Test Account 1' LIMIT 1];
+        Account a = TestDataFactory.accountByName('Test Account 1');
         String result = DocGenBulkFlowAction.buildEffectiveCondition(null, new List<String>{ a.Id });
         System.assert(result.startsWith('Id IN ('), 'Should start with Id IN, got: ' + result);
         System.assert(result.contains(a.Id), 'Should include the supplied ID');
@@ -84,7 +84,7 @@ private class DocGenBulkFlowActionTest {
 
     @IsTest
     static void testBuildEffectiveCondition_idsAndCondition_combine() {
-        Account a = [SELECT Id FROM Account WHERE Name = 'Test Account 1' LIMIT 1];
+        Account a = TestDataFactory.accountByName('Test Account 1');
         String result = DocGenBulkFlowAction.buildEffectiveCondition('Industry = \'Tech\'', new List<String>{ a.Id });
         // Expect the user condition to be parenthesized then AND-ed with Id IN
         System.assert(result.contains('Industry'), 'Should preserve user condition');
@@ -109,7 +109,7 @@ private class DocGenBulkFlowActionTest {
 
     @IsTest
     static void testBuildEffectiveCondition_blanksSkipped() {
-        Account a = [SELECT Id FROM Account WHERE Name = 'Test Account 1' LIMIT 1];
+        Account a = TestDataFactory.accountByName('Test Account 1');
         String result = DocGenBulkFlowAction.buildEffectiveCondition(null, new List<String>{ '', null, a.Id, '   ' });
         System.assertEquals('Id IN (\'' + a.Id + '\')', result, 'Blanks should be skipped silently');
     }

--- a/force-app/main/default/classes/DocGenGiantQueryTest.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryTest.cls
@@ -89,7 +89,7 @@ private class DocGenGiantQueryTest {
     static void testScoutChildCounts() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
             DocGen_Template__c tpl = [
                 SELECT Query_Config__c
                 FROM DocGen_Template__c
@@ -214,7 +214,7 @@ private class DocGenGiantQueryTest {
     static void testGiantQueryBatchExecution() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
             DocGen_Template__c tpl = [
                 SELECT Id, Output_Format__c
                 FROM DocGen_Template__c
@@ -281,7 +281,7 @@ private class DocGenGiantQueryTest {
     static void testGiantQuerySnapshotChromePreserved() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
             DocGen_Template__c tpl = [SELECT Id FROM DocGen_Template__c WHERE Name = 'Giant Query Test' LIMIT 1];
             DocGen_Template_Version__c ver = [
                 SELECT Id
@@ -359,7 +359,7 @@ private class DocGenGiantQueryTest {
     static void testGiantQueryAuthoredWidthSingleColgroup() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
             DocGen_Template__c tpl = [SELECT Id FROM DocGen_Template__c WHERE Name = 'Giant Query Test' LIMIT 1];
             DocGen_Template_Version__c ver = [
                 SELECT Id
@@ -435,7 +435,7 @@ private class DocGenGiantQueryTest {
     static void testGiantQueryRepeatHeaderCaptured() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
             DocGen_Template__c tpl = [SELECT Id FROM DocGen_Template__c WHERE Name = 'Giant Query Test' LIMIT 1];
             DocGen_Template_Version__c ver = [
                 SELECT Id
@@ -507,7 +507,7 @@ private class DocGenGiantQueryTest {
     static void testGiantQueryRepeatHeaderWithLoopRowInsideThead() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
             DocGen_Template__c tpl = [SELECT Id FROM DocGen_Template__c WHERE Name = 'Giant Query Test' LIMIT 1];
             DocGen_Template_Version__c ver = [
                 SELECT Id
@@ -574,7 +574,7 @@ private class DocGenGiantQueryTest {
     static void testStitchJobExecution() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
             DocGen_Template__c tpl = [SELECT Id FROM DocGen_Template__c WHERE Name = 'Giant Query Test' LIMIT 1];
 
             // Create a Job record
@@ -631,7 +631,7 @@ private class DocGenGiantQueryTest {
     static void testStitchJobHonorsDocumentTitleFormat() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
             DocGen_Template__c tpl = [SELECT Id FROM DocGen_Template__c WHERE Name = 'Giant Query Test' LIMIT 1];
             tpl.Document_Title_Format__c = 'XXXX-premium-{Name}';
             Database.update(tpl, AccessLevel.SYSTEM_MODE);
@@ -703,7 +703,7 @@ private class DocGenGiantQueryTest {
     static void testGenerateDocumentGiantQueryFallthrough() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
             DocGen_Template__c tpl = [SELECT Id FROM DocGen_Template__c WHERE Name = 'Giant Query Test' LIMIT 1];
 
             Test.startTest();
@@ -790,7 +790,7 @@ private class DocGenGiantQueryTest {
     static void testGetSortedChildIds() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
 
             Test.startTest();
             List<Id> sortedIds = DocGenController.getSortedChildIds(
@@ -810,7 +810,7 @@ private class DocGenGiantQueryTest {
     static void testGetSortedChildIdsWithWhere() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
             Test.startTest();
             List<Id> sortedIds = DocGenController.getSortedChildIds(
                 'Contact',
@@ -829,7 +829,7 @@ private class DocGenGiantQueryTest {
     static void testGiantQueryBatchWithWhere() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
             DocGen_Template__c tpl = [SELECT Id FROM DocGen_Template__c WHERE Name = 'Giant Query Test' LIMIT 1];
             DocGen_Job__c job = new DocGen_Job__c(
                 Status__c = 'Draft',
@@ -948,7 +948,7 @@ private class DocGenGiantQueryTest {
     static void testV1FlatConfigGiantQueryScout() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
             String v1Config = 'Name, (SELECT FirstName, LastName FROM Contacts ORDER BY LastName ASC)';
 
             Test.startTest();
@@ -1000,7 +1000,7 @@ private class DocGenGiantQueryTest {
     static void testGiantQueryBatchWithOrderBy() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
             DocGen_Template__c tpl = [
                 SELECT Id, Output_Format__c
                 FROM DocGen_Template__c
@@ -1343,7 +1343,7 @@ private class DocGenGiantQueryTest {
     static void testGiantAggregateCountTag() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
             DocGen_Template__c tpl = [SELECT Id FROM DocGen_Template__c WHERE Name = 'Giant Query Test' LIMIT 1];
             DocGen_Job__c job = new DocGen_Job__c(
                 Template__c = tpl.Id,
@@ -1368,7 +1368,7 @@ private class DocGenGiantQueryTest {
     static void testGiantAggregateSumTag() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
             DocGen_Template__c tpl = [SELECT Id FROM DocGen_Template__c WHERE Name = 'Giant Query Test' LIMIT 1];
 
             // Set numeric field on contacts so SUM has something to aggregate
@@ -1437,7 +1437,7 @@ private class DocGenGiantQueryTest {
         // assembler's constructor directly — no config re-parsing for the happy path.
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
             DocGen_Template__c tpl = [SELECT Id FROM DocGen_Template__c WHERE Name = 'Giant Query Test' LIMIT 1];
 
             // V1 flat config (legacy format — does NOT start with '{')
@@ -1487,7 +1487,7 @@ private class DocGenGiantQueryTest {
         // as rendered columns in the query config.
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
             DocGen_Template__c tpl = [SELECT Id FROM DocGen_Template__c WHERE Name = 'Giant Query Test' LIMIT 1];
 
             // Template config declares Contact's FirstName only as a rendered column —
@@ -1573,7 +1573,7 @@ private class DocGenGiantQueryTest {
         // format suffixes, so these rendered as unformatted raw values.
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
             acc.AnnualRevenue = 1234567;
             update acc;
 
@@ -1658,7 +1658,7 @@ private class DocGenGiantQueryTest {
     static void testGiantAggregateNonMatchingRelationshipIgnored() {
         User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
         System.runAs(u) {
-            Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+            Account acc = TestDataFactory.accountByName('Giant Query Test Account');
             DocGen_Template__c tpl = [SELECT Id FROM DocGen_Template__c WHERE Name = 'Giant Query Test' LIMIT 1];
             DocGen_Job__c job = new DocGen_Job__c(
                 Template__c = tpl.Id,
@@ -1750,7 +1750,7 @@ private class DocGenGiantQueryTest {
     // helper directly (cheap, no Blob.toPdf) to lock the contract.
     @IsTest
     static void computeDocTitleHonorsDocumentTitleFormat() {
-        Account acc = [SELECT Id, Name FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+        Account acc = TestDataFactory.accountByName('Giant Query Test Account');
         DocGen_Template__c tpl = [SELECT Id FROM DocGen_Template__c WHERE Name = 'Giant Query Test' LIMIT 1];
         tpl.Document_Title_Format__c = 'XXXX-premium-{Name}';
         Database.update(tpl, AccessLevel.SYSTEM_MODE);
@@ -1767,7 +1767,7 @@ private class DocGenGiantQueryTest {
 
     @IsTest
     static void computeDocTitleReturnsNullWhenFormatBlank() {
-        Account acc = [SELECT Id FROM Account WHERE Name = 'Giant Query Test Account' LIMIT 1];
+        Account acc = TestDataFactory.accountByName('Giant Query Test Account');
         DocGen_Template__c tpl = [SELECT Id FROM DocGen_Template__c WHERE Name = 'Giant Query Test' LIMIT 1];
         tpl.Document_Title_Format__c = null;
         Database.update(tpl, AccessLevel.SYSTEM_MODE);

--- a/force-app/main/default/classes/TestDataFactory.cls
+++ b/force-app/main/default/classes/TestDataFactory.cls
@@ -116,8 +116,34 @@ public class TestDataFactory {
     // Helper getters — retrieve standard test data by known names
     // =========================================================================
 
+    /**
+     * #200 — Shield-safe Account lookup. Shield-encrypted standard fields
+     * (Account.Name, Opportunity.Name) cannot appear in a SOQL WHERE clause,
+     * and every packaged class is recompiled at install time — a `WHERE Name =`
+     * filter here failed the whole package install in a Shield org. Query
+     * without the filter and match in Apex instead (test data is tiny).
+     */
+    public static Account accountByName(String name) {
+        for (Account a : [SELECT Id, Name FROM Account ORDER BY CreatedDate DESC LIMIT 200]) {
+            if (a.Name == name) {
+                return a;
+            }
+        }
+        throw new DocGenException('Test account not found: ' + name);
+    }
+
+    /** #200 — Shield-safe Opportunity lookup (see accountByName). */
+    public static Opportunity opportunityByName(String name) {
+        for (Opportunity o : [SELECT Id, Name FROM Opportunity ORDER BY CreatedDate DESC LIMIT 200]) {
+            if (o.Name == name) {
+                return o;
+            }
+        }
+        throw new DocGenException('Test opportunity not found: ' + name);
+    }
+
     public static Account getTestAccount() {
-        return [SELECT Id, Name FROM Account WHERE Name = 'DocGen Test Account' LIMIT 1];
+        return accountByName('DocGen Test Account');
     }
 
     public static DocGen_Template__c getTestTemplate() {
@@ -141,15 +167,17 @@ public class TestDataFactory {
     }
 
     public static List<Contact> getTestContacts() {
+        // #200 — filter on the AccountId lookup (always filterable), not the
+        // Shield-encryptable Account.Name.
         return [
             SELECT Id, FirstName, LastName, Email, AccountId
             FROM Contact
-            WHERE Account.Name = 'DocGen Test Account'
+            WHERE AccountId = :getTestAccount().Id
         ];
     }
 
     public static Opportunity getTestOpportunity() {
-        return [SELECT Id, Name FROM Opportunity WHERE Name = 'DocGen Test Opp' LIMIT 1];
+        return opportunityByName('DocGen Test Opp');
     }
 
     public static DocGen_Template_Version__c getTestTemplateVersion() {


### PR DESCRIPTION
Fixes #200.

## Root cause

Shield Platform Encryption makes encrypted fields unfilterable in SOQL, and package installation recompiles every packaged class (including `@IsTest`). Any inline `WHERE Name = '...'` against Account failed compilation in the reporter's Shield org (Account.Name encrypted), aborting the install of the README-advertised version.

## Fix

Scanner over all inline SOQL on Account/Contact/Opportunity with WHERE filters on encryptable fields found **28 sites in 3 files** — now zero:

- `TestDataFactory`: new Shield-safe `accountByName` / `opportunityByName` (query unfiltered, match in Apex — test data is tiny; throws `DocGenException` when absent to preserve the old no-rows fail-fast). `getTestContacts` filters on the `AccountId` lookup instead of `Account.Name`.
- `DocGenGiantQueryTest` (22 sites) + `DocGenBulkFlowActionTest` (3 sites): mechanical swap to the helper.

DocGen custom-object `Name` filters untouched — subscribers can't encrypt managed-package fields (and the reporter's error cites only Account.Name).

## Validation

- Re-scan: 0 unsafe filters remain
- DocGenGiantQueryTest + DocGenBulkFlowActionTest + DocGenAuthenticatorControllerTest: 67/67 on Portwood Dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)