### PR TITLE
Fix #195: honor sendEmails=false on the signature Flow action

### DIFF
--- a/force-app/main/default/classes/DocGenSignatureFlowAction.cls
+++ b/force-app/main/default/classes/DocGenSignatureFlowAction.cls
@@ -125,7 +125,7 @@ global with sharing class DocGenSignatureFlowAction { // NOPMD AvoidGlobalModifi
 
         @InvocableVariable(
             label='Send Branded Emails'
-            description='Set to TRUE to have DocGen send branded invitation emails automatically (requires Org-Wide Email Address in DocGen settings). Set to FALSE (default) if your Flow sends its own emails using the Signer URLs output.'
+            description='Set to FALSE if your Flow sends its own emails using the Signer URLs output — DocGen will create the request and URLs without emailing signers. Leave blank or TRUE (default) to have DocGen send branded invitation emails automatically (requires an Org-Wide Email Address in DocGen settings).'
         )
         global Boolean sendEmails;
 
@@ -275,7 +275,8 @@ global with sharing class DocGenSignatureFlowAction { // NOPMD AvoidGlobalModifi
                 req.emailMessage, // #193 — optional send-time custom message
                 req.emailSubject, // #193 — optional send-time custom subject
                 req.requireEmailVerification, // #verification — null = inherit template/org
-                req.prefillSignerEmail
+                req.prefillSignerEmail,
+                req.sendEmails // #195 — false suppresses DocGen's invites (Flow sends its own)
             );
 
             // Find the request ID

--- a/force-app/main/default/classes/DocGenSignatureFlowActionTest.cls
+++ b/force-app/main/default/classes/DocGenSignatureFlowActionTest.cls
@@ -27,7 +27,9 @@ private class DocGenSignatureFlowActionTest {
     @isTest
     static void testGenerate_defaultSilent() {
         DocGenSignatureFlowAction.Request req = buildRequest();
-        // sendEmails left null — should default to false
+        // sendEmails left null — sends like every pre-#195 release (so existing
+        // subscriber Flows keep emailing signers); in this OWA-less test context
+        // the send path bails before Messaging.sendEmail, so invocations stay 0.
 
         Integer emailsBefore = Limits.getEmailInvocations();
 
@@ -89,6 +91,41 @@ private class DocGenSignatureFlowActionTest {
         System.assertEquals(1, results.size());
         System.assertNotEquals(null, results[0].signatureRequestId);
         System.assertEquals(2, results[0].signerUrls.size());
+    }
+
+    // =========================================================================
+    // #195 — explicit sendEmails = false suppresses the branded invites entirely
+    // =========================================================================
+
+    @isTest
+    static void testGenerate_sendEmailsFalse_suppressesInvites() {
+        DocGenSignatureFlowAction.Request req = buildRequest();
+        req.sendEmails = false;
+
+        Integer emailsBefore = Limits.getEmailInvocations();
+
+        Test.startTest();
+        List<DocGenSignatureFlowAction.Result> results = DocGenSignatureFlowAction.generate(
+            new List<DocGenSignatureFlowAction.Request>{ req }
+        );
+        Test.stopTest();
+
+        System.assertEquals(Limits.getEmailInvocations(), emailsBefore, 'sendEmails=false must not send');
+        System.assertEquals(1, results.size());
+        DocGenSignatureFlowAction.Result r = results[0];
+        System.assertNotEquals(null, r.signatureRequestId, 'request still created');
+        System.assertEquals(2, r.signerUrls.size(), 'signer URLs still returned for the Flow to send itself');
+
+        // The email block must be skipped ENTIRELY — not just fail on a missing
+        // OWA. A send attempt would write Email_Status__c (either 'Sent' or the
+        // no-OWA error); suppression leaves it untouched.
+        DocGen_Signature_Request__c persisted = [
+            SELECT Email_Status__c
+            FROM DocGen_Signature_Request__c
+            WHERE Id = :r.signatureRequestId
+            LIMIT 1
+        ];
+        System.assertEquals(null, persisted.Email_Status__c, 'no send attempt when sendEmails=false');
     }
 
     // =========================================================================

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -987,6 +987,33 @@ public with sharing class DocGenSignatureSenderController {
         Boolean requireVerification,
         Boolean prefillSignerEmail
     ) {
+        return createTemplateSnapshotRequest(
+            templateId,
+            relatedRecordId,
+            signersJson,
+            signingOrder,
+            documentTitleFormat,
+            emailMessage,
+            emailSubject,
+            requireVerification,
+            prefillSignerEmail,
+            null
+        );
+    }
+
+    /** 10-arg canonical — #195: see createGuidedPdfSignatureRequest. */
+    public static List<SignerResult> createTemplateSnapshotRequest(
+        Id templateId,
+        String relatedRecordId,
+        String signersJson,
+        String signingOrder,
+        String documentTitleFormat,
+        String emailMessage,
+        String emailSubject,
+        Boolean requireVerification,
+        Boolean prefillSignerEmail,
+        Boolean sendEmails
+    ) {
         if (templateId == null) {
             throw new AuraHandledException('A template Id is required.');
         }
@@ -1101,7 +1128,8 @@ public with sharing class DocGenSignatureSenderController {
             null,
             fileTitle,
             signerInputs,
-            true,
+            sendEmails !=
+            false, // #195 — null/true sends; explicit false suppresses
             getSigningPdfPagePath(),
             emailMessage,
             emailSubject,
@@ -1333,6 +1361,37 @@ public with sharing class DocGenSignatureSenderController {
         Boolean requireVerification,
         Boolean prefillSignerEmail
     ) {
+        return createGuidedPdfSignatureRequest(
+            templateId,
+            relatedRecordId,
+            signersJson,
+            signingOrder,
+            documentTitleFormat,
+            emailMessage,
+            emailSubject,
+            requireVerification,
+            prefillSignerEmail,
+            null
+        );
+    }
+
+    /**
+     * 10-arg canonical — #195: sendEmails=false suppresses the branded invitation
+     * emails so a Flow can send its own using the returned signer URLs. null/true
+     * sends (the long-standing behavior; every pre-existing caller delegates null).
+     */
+    public static List<SignerResult> createGuidedPdfSignatureRequest(
+        Id templateId,
+        String relatedRecordId,
+        String signersJson,
+        String signingOrder,
+        String documentTitleFormat,
+        String emailMessage,
+        String emailSubject,
+        Boolean requireVerification,
+        Boolean prefillSignerEmail,
+        Boolean sendEmails
+    ) {
         List<DocGen_Template__c> tpls = [
             SELECT Id, Name, Document_Title_Format__c
             FROM DocGen_Template__c
@@ -1400,7 +1459,8 @@ public with sharing class DocGenSignatureSenderController {
                     emailMessage,
                     emailSubject,
                     requireVerification,
-                    prefillSignerEmail
+                    prefillSignerEmail,
+                    sendEmails
                 );
             }
         }
@@ -1527,7 +1587,8 @@ public with sharing class DocGenSignatureSenderController {
             null,
             fileTitle,
             signerInputs,
-            true,
+            sendEmails !=
+            false, // #195 — null/true sends; explicit false suppresses
             getSigningPdfPagePath(),
             emailMessage,
             emailSubject,


### PR DESCRIPTION
Fixes #195 (= Jira PHD-14, reported by a customer building custom email delivery around signer URLs).

## Root cause

`Request.sendEmails` was **never read** — and even if it had been, the guided/snapshot canonicals in `DocGenSignatureSenderController` hardcode `true` into `createSignersAndNotify`. Since the v3.21 one-path consolidation, every send funnels through those canonicals, so no route honored the flag.

## Fix

- New 10-arg canonicals (`createGuidedPdfSignatureRequest`, `createTemplateSnapshotRequest`) with trailing `Boolean sendEmails`; existing 9-arg `@AuraEnabled` entries delegate with `null` so the sender LWC is untouched; guided→snapshot dispatch threads it through
- **Default semantics decision**: `null`/`true` ⇒ send. The invocable's description claimed FALSE was the default, but runtime has always sent when an OWA exists — subscriber Flows built since v3.14/3.21 depend on signers receiving links, so flipping the default would silently break signing for them. Explicit `false` now skips the email block entirely (request + signer URLs still returned for the Flow to send its own). Description corrected.
- The report's secondary symptom (PIN verification fails without an OWA) is a hard dependency for guest-context email sends, not part of this bug — the sender should keep an OWA configured when using PIN verification even with `sendEmails=false`.

## Validation

Synchronous runs on Portwood Dev (parallel run hit unrelated `UNABLE_TO_LOCK_ROW` contention on shared test setup): FlowActionTest 20/20 (incl. new suppression test asserting `Email_Status__c` stays null — a no-OWA bail would have written an error, so the assertion proves true suppression), SignaturePdfTests 28/28, GuidedSigningTest 13/13, SarahFixesTest 9/9, VerificationTest 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)