### PR TITLE
Polish: signature-settings contrast, Visit spacing, nav icon, Error Logs app tab (PHD-13/PHD-11)

### DIFF
--- a/force-app/main/default/applications/DocGen.app-meta.xml
+++ b/force-app/main/default/applications/DocGen.app-meta.xml
@@ -19,5 +19,6 @@
     <tabs>DocGen_Signature_Request__c</tabs>
     <tabs>DocGen_Signer__c</tabs>
     <tabs>DocGen_Signature_Audit__c</tabs>
+    <tabs>DocGen_Error_Log__c</tabs>
     <uiType>Lightning</uiType>
 </CustomApplication>

--- a/force-app/main/default/lwc/docGenCommandHub/docGenCommandHub.html
+++ b/force-app/main/default/lwc/docGenCommandHub/docGenCommandHub.html
@@ -12,7 +12,7 @@
 
             <div class="nav-links">
                 <button class={templatesTabClass} onclick={handleShowTemplates}>
-                    <lightning-icon icon-name="utility:template" size="x-small" class="nav-icon"></lightning-icon>
+                    <lightning-icon icon-name="utility:file" size="x-small" class="nav-icon"></lightning-icon>
                     <span>My Templates</span>
                 </button>
                 <button class={bulkTabClass} onclick={handleShowBulk}>
@@ -133,8 +133,10 @@
                                     Open the User Guide ↗
                                 </a>
                                 <p class="guide-redirect-fineprint">
-                                    Need implementation help or training? Visit
-                                    <a href="https://portwood.dev/support" target="_blank" rel="noopener noreferrer"
+                                    Need implementation help or training? Visit&nbsp;<a
+                                        href="https://portwood.dev/support"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
                                         >portwood.dev/support</a
                                     >.
                                 </p>

--- a/force-app/main/default/lwc/docGenSignatureSettings/docGenSignatureSettings.html
+++ b/force-app/main/default/lwc/docGenSignatureSettings/docGenSignatureSettings.html
@@ -22,9 +22,10 @@
                         <template if:true={setupChecksLoaded}>
                             <template if:true={allChecksPassed}>
                                 <div
-                                    class="slds-box slds-theme_success slds-m-bottom_small"
+                                    class="slds-box slds-m-bottom_small"
                                     style="
                                         background: #e6f9e6;
+                                        color: #181818;
                                         border: 1px solid #2e844a;
                                         border-radius: 6px;
                                         padding: 12px 16px;


### PR DESCRIPTION
Four small community-reported fixes (Jira PHD-13 and PHD-11):

1. **Signature Settings success box** — `slds-theme_success` (white text) stacked with an inline pale-green background made the "all setup checks passed" message near-invisible. Theme class dropped; dark text pinned.
2. **Learning Center** — "Visitportwood.dev/support" ran together (LWC strips inter-element whitespace); non-breaking space added.
3. **My Templates nav icon** — `utility:template` isn't a real SLDS utility icon, so it rendered blank; swapped to `utility:file`.
4. **Error Logs tab** — the tab existed in the package but wasn't in the DocGen app's navigation; added.

Deployed to Portwood Dev; metadata/markup only, no Apex changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)