### PR TITLE
Post-render image-link sweep (#219) + Template API Name wipe fix (#220)

### DIFF
--- a/force-app/main/default/classes/DocGenAssetTest.cls
+++ b/force-app/main/default/classes/DocGenAssetTest.cls
@@ -227,6 +227,41 @@ private class DocGenAssetTest {
     }
 
     @IsTest
+    static void setAssetCategorySetsClearsAndLists() {
+        Map<String, Object> created = DocGenController.createAsset('Header Logo', 'header-logo');
+        Id assetId = (Id) created.get('id');
+
+        Test.startTest();
+        DocGenController.setAssetCategory(assetId, '  Logos  ');
+        Test.stopTest();
+
+        DocGen_Asset__c after = [SELECT Category__c FROM DocGen_Asset__c WHERE Id = :assetId];
+        System.assertEquals('Logos', after.Category__c, 'setAssetCategory trims and stores the category');
+
+        List<Map<String, Object>> assets = DocGenController.getAssets();
+        Boolean found = false;
+        for (Map<String, Object> row : assets) {
+            if (assetId == (Id) row.get('id')) {
+                found = true;
+                System.assertEquals('Logos', row.get('category'), 'getAssets exposes the category');
+            }
+        }
+        System.assert(found, 'getAssets includes the categorized asset');
+
+        // Blank clears it.
+        DocGenController.setAssetCategory(assetId, '   ');
+        after = [SELECT Category__c FROM DocGen_Asset__c WHERE Id = :assetId];
+        System.assertEquals(null, after.Category__c, 'Blank category clears the field');
+
+        try {
+            DocGenController.setAssetCategory(null, 'Logos');
+            System.assert(false, 'Null assetId must throw');
+        } catch (AuraHandledException expected) {
+            System.assertNotEquals(null, expected.getMessage(), 'Friendly error expected');
+        }
+    }
+
+    @IsTest
     static void controllerNullArgsThrow() {
         Integer thrown = 0;
         try {

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -6975,7 +6975,7 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
     public static List<Map<String, Object>> getAssets() {
         DocGenFlsGuard.assertAccessible(
             DocGen_Asset__c.sObjectType,
-            new Set<String>{ 'Name', 'Asset_Key__c', 'Asset_Type__c', 'Is_Active__c' }
+            new Set<String>{ 'Name', 'Asset_Key__c', 'Asset_Type__c', 'Category__c', 'Is_Active__c' }
         );
         // Read SYSTEM_MODE behind the assertAccessible guard above — matches the asset
         // catalog's other reads (resolveAssetCvIds + the reads below) and the package's
@@ -6990,6 +6990,7 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                 Name,
                 Asset_Key__c,
                 Asset_Type__c,
+                Category__c,
                 Is_Active__c,
                 (
                     SELECT ContentDocument.LatestPublishedVersionId, ContentDocument.LastModifiedDate
@@ -7042,6 +7043,7 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
                     'name' => a.Name,
                     'assetKey' => a.Asset_Key__c,
                     'assetType' => a.Asset_Type__c,
+                    'category' => a.Category__c,
                     'isActive' => a.Is_Active__c,
                     'mergeTag' => '{%asset:' +
                     a.Asset_Key__c +
@@ -7291,6 +7293,28 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             Database.update(asset, AccessLevel.SYSTEM_MODE);
         } catch (Exception e) {
             throw DocGenService.ahe(e, 'Error renaming asset.');
+        }
+    }
+
+    /**
+     * Sets (or clears — blank is allowed) an asset's free-text Category__c, the
+     * grouping label the Assets tab filters on. A separate method rather than a
+     * createAsset/renameAsset parameter because @AuraEnabled methods can't be
+     * overloaded and the existing signatures are called throughout the tests.
+     */
+    @AuraEnabled
+    public static void setAssetCategory(Id assetId, String category) {
+        if (assetId == null) {
+            throw DocGenService.ahe('Asset Id is required.');
+        }
+        try {
+            String trimmed = String.isBlank(category) ? null : category.trim();
+            DocGen_Asset__c asset = new DocGen_Asset__c(Id = assetId, Category__c = trimmed);
+            DocGenFlsGuard.assertUpdateable(asset, new Set<String>{ 'Category__c' });
+            /* code-analyzer-suppress ApexFlsViolation */
+            Database.update(asset, AccessLevel.SYSTEM_MODE);
+        } catch (Exception e) {
+            throw DocGenService.ahe(e, 'Error setting asset category.');
         }
     }
 

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -2491,8 +2491,11 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
             if (fields.containsKey('Prefill_Signer_Email__c')) {
                 template.Prefill_Signer_Email__c = (String) fields.get('Prefill_Signer_Email__c');
             }
-            // PHD-9 — stable developer key for Flow lookups
-            if (fields.containsKey('API_Name__c')) {
+            // PHD-9 — stable developer key for Flow lookups. Blank means "leave
+            // unchanged": Flows/buttons reference this key, and the create-wizard's
+            // follow-up saves (which don't re-collect the API name) must never wipe
+            // the value the wizard just persisted.
+            if (fields.containsKey('API_Name__c') && String.isNotBlank((String) fields.get('API_Name__c'))) {
                 template.API_Name__c = (String) fields.get('API_Name__c');
             }
             // #208 — per-template default {Message} for signature emails

--- a/force-app/main/default/classes/DocGenControllerTests.cls
+++ b/force-app/main/default/classes/DocGenControllerTests.cls
@@ -183,6 +183,59 @@ private class DocGenControllerTests {
     }
 
     // -----------------------------------------------------------------------
+    // saveTemplate — blank API_Name__c must not wipe the stored value. The
+    // create wizard persists the API name via createRecord, then its follow-up
+    // "Save as New Version"/"Save Details" posts the full field map; a blank
+    // API_Name__c there means "not re-collected", not "clear the key Flows
+    // reference".
+    // -----------------------------------------------------------------------
+    @IsTest
+    static void testSaveTemplateBlankApiNameDoesNotWipeValue() {
+        User u = [SELECT Id FROM User WHERE Id = :UserInfo.getUserId()];
+        System.runAs(u) {
+            DocGen_Template__c tpl = TestDataFactory.getTestTemplate();
+            tpl.API_Name__c = 'Wizard_Created_Key';
+            update tpl;
+
+            Map<String, Object> fields = new Map<String, Object>{
+                'Id' => tpl.Id,
+                'Name' => 'Renamed Template',
+                'Category__c' => 'Legal',
+                'Type__c' => 'Word',
+                'Base_Object_API__c' => 'Account',
+                'Description__c' => 'Updated description',
+                'Query_Config__c' => 'Name',
+                'Test_Record_Id__c' => null,
+                'Document_Title_Format__c' => '{Name}_Doc',
+                'Output_Format__c' => 'PDF',
+                'API_Name__c' => ''
+            };
+
+            Test.startTest();
+            DocGenController.saveTemplate(fields, false, null);
+            Test.stopTest();
+
+            DocGen_Template__c updated = [SELECT Name, API_Name__c FROM DocGen_Template__c WHERE Id = :tpl.Id];
+            System.assertEquals('Renamed Template', updated.Name, 'Other fields should still save');
+            System.assertEquals(
+                'Wizard_Created_Key',
+                updated.API_Name__c,
+                'A blank API_Name__c in the save payload must leave the stored developer key unchanged'
+            );
+
+            // A real value still updates the key.
+            fields.put('API_Name__c', 'Renamed_Key');
+            DocGenController.saveTemplate(fields, false, null);
+            updated = [SELECT API_Name__c FROM DocGen_Template__c WHERE Id = :tpl.Id];
+            System.assertEquals(
+                'Renamed_Key',
+                updated.API_Name__c,
+                'A non-blank API_Name__c must still update the key'
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // saveTemplate (update with version creation)
     // -----------------------------------------------------------------------
     @IsTest

--- a/force-app/main/default/classes/DocGenGiantQueryAssembler.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryAssembler.cls
@@ -160,6 +160,9 @@ public with sharing class DocGenGiantQueryAssembler implements Queueable {
             return;
         }
         html = null;
+        // #202 follow-up — the image links exist only for the toPdf fetch above;
+        // the PDF embeds the bytes, so don't leave image Files on the record.
+        DocGenService.removeTemplateImageLinksAfterRender(templateId, recordId);
 
         // v1.90 — honor template Document_Title_Format__c. Pre-fix the title was
         // hardcoded to docgen_giant_<jobId>_final, which is what users saw in

--- a/force-app/main/default/classes/DocGenGiantQueryAssembler.cls
+++ b/force-app/main/default/classes/DocGenGiantQueryAssembler.cls
@@ -157,6 +157,8 @@ public with sharing class DocGenGiantQueryAssembler implements Queueable {
             pdfBlob = null;
             renderMultiPartPdf(html, htmlTemplate);
             html = null;
+            // Failed render still linked its images — don't leave them as Files.
+            DocGenService.removeTemplateImageLinksAfterRender(templateId, recordId);
             return;
         }
         html = null;

--- a/force-app/main/default/classes/DocGenMiscTests.cls
+++ b/force-app/main/default/classes/DocGenMiscTests.cls
@@ -9926,6 +9926,107 @@ private class DocGenMiscTests {
         );
     }
 
+    @IsTest
+    static void testRemoveTemplateImageLinksAfterRenderClearsCurrentSet() {
+        // #202 follow-up: the prune-with-keep pass can never remove the CURRENT
+        // body's image links, so the first generation on a fresh record stranded
+        // the full image set as Files on the record. After Blob.toPdf returns the
+        // links have served their purpose (the PDF embeds the bytes), and the
+        // post-render sweep must remove every template-image link — both naming
+        // schemes — while leaving user-attached files alone.
+        Account acc = new Account(Name = 'Post-Render Image Link Sweep');
+        insert acc;
+
+        DocGen_Template__c tpl = new DocGen_Template__c(
+            Name = 'Post-Render Image Link Sweep',
+            Base_Object_API__c = 'Account',
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF',
+            Query_Config__c = 'Name'
+        );
+        Database.insert(tpl, AccessLevel.SYSTEM_MODE);
+        DocGen_Template_Version__c ver = new DocGen_Template_Version__c(
+            Template__c = tpl.Id,
+            Is_Active__c = true,
+            Type__c = 'HTML',
+            Base_Object_API__c = 'Account',
+            Output_Format__c = 'PDF'
+        );
+        Database.insert(ver, AccessLevel.SYSTEM_MODE);
+
+        // Scheme 2 (template-keyed, LWC zip upload) + scheme 1 (version-keyed,
+        // active version) — both referenced by the current body.
+        ContentVersion imgTplKeyed = new ContentVersion(
+            Title = 'docgen_html_img_' + tpl.Id + '_1000000000001_logo.png',
+            PathOnClient = 'logo.png',
+            VersionData = Blob.valueOf('PNG1')
+        );
+        ContentVersion imgVerKeyed = new ContentVersion(
+            Title = 'docgen_tmpl_img_' + ver.Id + '_rIdBanner',
+            PathOnClient = 'banner.png',
+            VersionData = Blob.valueOf('PNG2')
+        );
+        insert new List<ContentVersion>{ imgTplKeyed, imgVerKeyed };
+
+        // A user's own attached file must survive the sweep untouched.
+        ContentVersion userFile = new ContentVersion(
+            Title = 'Customer Contract',
+            PathOnClient = 'contract.pdf',
+            VersionData = Blob.valueOf('PDF')
+        );
+        insert userFile;
+        Id userDocId = [SELECT ContentDocumentId FROM ContentVersion WHERE Id = :userFile.Id].ContentDocumentId;
+        insert new ContentDocumentLink(
+            ContentDocumentId = userDocId,
+            LinkedEntityId = acc.Id,
+            ShareType = 'V',
+            Visibility = 'AllUsers'
+        );
+
+        String html =
+            '<html><body><img src="/sfc/servlet.shepherd/version/download/' +
+            imgTplKeyed.Id +
+            '"/><img src="/sfc/servlet.shepherd/version/download/' +
+            imgVerKeyed.Id +
+            '"/></body></html>';
+
+        Test.startTest();
+        // Mirrors renderPdf's sequence: link for the toPdf fetch, then sweep.
+        DocGenService.ensureTemplateAssetImageAccessForPdf(tpl.Id, acc.Id, html);
+        System.assertEquals(
+            2,
+            [
+                SELECT COUNT()
+                FROM ContentDocumentLink
+                WHERE
+                    LinkedEntityId = :acc.Id
+                    AND (ContentDocument.Title LIKE 'docgen_html_img_%'
+                    OR ContentDocument.Title LIKE 'docgen_tmpl_img_%')
+            ],
+            'Both current-body images should be linked for the Blob.toPdf fetch.'
+        );
+        DocGenService.removeTemplateImageLinksAfterRender(tpl.Id, acc.Id);
+        Test.stopTest();
+
+        System.assertEquals(
+            0,
+            [
+                SELECT COUNT()
+                FROM ContentDocumentLink
+                WHERE
+                    LinkedEntityId = :acc.Id
+                    AND (ContentDocument.Title LIKE 'docgen_html_img_%'
+                    OR ContentDocument.Title LIKE 'docgen_tmpl_img_%')
+            ],
+            'Post-render sweep must remove every template-image link, including the current body set (#202 follow-up).'
+        );
+        System.assertEquals(
+            1,
+            [SELECT COUNT() FROM ContentDocumentLink WHERE LinkedEntityId = :acc.Id AND ContentDocumentId = :userDocId],
+            'User-attached files must never be touched by the sweep.'
+        );
+    }
+
     private static void assertGiantLauncherUsesInternalLoader(String body, String className) {
         Integer idx = body.indexOf('docgen_tmpl_xml_');
         System.assert(idx >= 0, className + ' should reference pre-decomposed template XML.');

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -2411,6 +2411,25 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
     }
 
     /**
+     * #202 follow-up: the links ensureTemplateAssetImageAccessForPdf creates are
+     * only needed while Blob.toPdf() fetches the shepherd URLs inside the same
+     * transaction — the rendered PDF embeds the image bytes. Once the render
+     * completes, remove EVERY template-image link on the record (the current
+     * body's set included) so generation never leaves image Files on the target
+     * record — the prune-with-keep pass alone can never remove the current set,
+     * which is why a first generation on a fresh record still stranded the full
+     * image set. Null active version + empty keep-set make the prune treat the
+     * whole title-scoped set as stale, which also sweeps links stranded on the
+     * record by earlier package versions.
+     */
+    public static void removeTemplateImageLinksAfterRender(Id templateId, Id recordId) {
+        if (templateId == null || recordId == null) {
+            return;
+        }
+        pruneStaleTemplateImageLinks(templateId, recordId, null, new Set<Id>());
+    }
+
+    /**
      * Removes orphaned template-image ContentDocumentLinks that earlier
      * generations attached to this record. `ensureTemplateAssetImageAccessForPdf`
      * links the body's referenced images to the record so Blob.toPdf can read
@@ -2548,7 +2567,9 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             if (mr.templateType == 'HTML') {
                 ensureTemplateAssetImageAccessForPdf(templateId, recordId, mr.documentXml);
                 lastRenderedHtml = mr.documentXml;
-                return Blob.toPdf(mr.documentXml);
+                Blob htmlPdf = Blob.toPdf(mr.documentXml);
+                removeTemplateImageLinksAfterRender(templateId, recordId);
+                return htmlPdf;
             }
 
             Map<String, String> pdfImages = buildPdfImageMap(mr, templateId);
@@ -2562,7 +2583,9 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             ensureTemplateAssetImageAccessForPdf(templateId, recordId, html);
             lastRenderedHtml = html;
 
-            return Blob.toPdf(html);
+            Blob docxPdf = Blob.toPdf(html);
+            removeTemplateImageLinksAfterRender(templateId, recordId);
+            return docxPdf;
         } finally {
             DocGenHtmlRenderer.orientationOverride = null;
             DocGenHtmlRenderer.pageSizeOverride = null;

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -2757,6 +2757,10 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 [F.CustomMargins]: this.newTemplateCustomMargins,
                 [F.BaseObject]: this.newTemplateObject,
                 [F.Desc]: this.newTemplateDesc,
+                // Must carry the API name into the edit modal — resetForm() clears the
+                // wizard value, and an edit modal opened without it would post
+                // API_Name__c: '' on the next save, wiping what createRecord just wrote.
+                [F.ApiName]: this.newTemplateApiName || null,
                 [F.QueryConfig]: this.newTemplateQuery,
                 [F.TestRecordId]: this.newTemplateSampleRecordId || null,
                 [F.DocTitleFormat]: null,

--- a/force-app/main/default/lwc/docGenAssets/docGenAssets.css
+++ b/force-app/main/default/lwc/docGenAssets/docGenAssets.css
@@ -7,3 +7,7 @@
     max-height: 60vh;
     overflow: auto;
 }
+
+.category-filter {
+    min-width: 12rem;
+}

--- a/force-app/main/default/lwc/docGenAssets/docGenAssets.css
+++ b/force-app/main/default/lwc/docGenAssets/docGenAssets.css
@@ -1,0 +1,6 @@
+/* Keep the asset table inside the tab: scroll horizontally instead of
+   pushing the page wide when merge tags / names are long. */
+.asset-table-container {
+    max-width: 100%;
+    overflow-x: auto;
+}

--- a/force-app/main/default/lwc/docGenAssets/docGenAssets.css
+++ b/force-app/main/default/lwc/docGenAssets/docGenAssets.css
@@ -1,6 +1,9 @@
-/* Keep the asset table inside the tab: scroll horizontally instead of
-   pushing the page wide when merge tags / names are long. */
+/* Keep the asset table inside its card: cap the height so a long asset
+   list scrolls vertically inside the container instead of growing the tab,
+   and scroll horizontally instead of pushing the page wide when merge
+   tags / names are long. */
 .asset-table-container {
     max-width: 100%;
-    overflow-x: auto;
+    max-height: 60vh;
+    overflow: auto;
 }

--- a/force-app/main/default/lwc/docGenAssets/docGenAssets.html
+++ b/force-app/main/default/lwc/docGenAssets/docGenAssets.html
@@ -1,8 +1,8 @@
 <template>
     <div class="slds-var-p-around_small">
         <!-- Toolbar -->
-        <div class="slds-grid slds-grid_align-spread slds-var-m-bottom_small">
-            <div class="slds-text-body_small slds-text-color_weak">
+        <div class="slds-grid slds-grid_align-spread slds-var-m-bottom_x-small">
+            <div class="slds-text-body_small slds-text-color_weak slds-align-middle">
                 Upload a logo or footer once, then reference it in any template with its merge tag.
             </div>
             <lightning-button
@@ -12,6 +12,31 @@
                 onclick={handleOpenCreate}
             ></lightning-button>
         </div>
+        <template if:true={hasAssets}>
+            <div class="slds-grid slds-gutters_x-small slds-var-m-bottom_small">
+                <div class="slds-col slds-grow">
+                    <lightning-input
+                        type="search"
+                        label="Search"
+                        variant="label-hidden"
+                        placeholder="Search by name, tag, or category…"
+                        value={searchTerm}
+                        onchange={handleSearchChange}
+                    ></lightning-input>
+                </div>
+                <template if:true={showCategoryFilter}>
+                    <div class="slds-col slds-grow-none category-filter">
+                        <lightning-combobox
+                            label="Category"
+                            variant="label-hidden"
+                            value={categoryFilter}
+                            options={categoryOptions}
+                            onchange={handleCategoryFilterChange}
+                        ></lightning-combobox>
+                    </div>
+                </template>
+            </div>
+        </template>
 
         <!-- Empty state -->
         <template if:false={hasAssets}>
@@ -28,18 +53,23 @@
             </div>
         </template>
 
-        <!-- Asset list. The wrapper scrolls horizontally when the tab is narrow
-             so the table never bleeds past its container. -->
-        <template if:true={hasAssets}>
+        <!-- Asset list. The wrapper caps height (long lists scroll inside the
+             card) and scrolls horizontally when the tab is narrow. -->
+        <template if:true={hasVisibleAssets}>
             <div class="asset-table-container">
                 <c-doc-gen-image-datatable
                     key-field="id"
-                    data={assets}
+                    data={visibleAssets}
                     columns={columns}
                     onrowaction={handleRowAction}
                     hide-checkbox-column
                 >
                 </c-doc-gen-image-datatable>
+            </div>
+        </template>
+        <template if:true={showNoMatches}>
+            <div class="slds-box slds-theme_shade slds-text-align_center slds-var-p-around_medium">
+                <p class="slds-text-body_regular">No assets match your search.</p>
             </div>
         </template>
     </div>
@@ -64,6 +94,14 @@
                         onchange={handleCreateNameChange}
                         placeholder="e.g. Primary Footer"
                         required
+                    ></lightning-input>
+                    <lightning-input
+                        class="slds-var-m-top_x-small"
+                        label="Category"
+                        value={createCategory}
+                        onchange={handleCreateCategoryChange}
+                        placeholder="e.g. Logos"
+                        field-level-help="Optional grouping label used to filter the asset list. Type anything — categories are free text."
                     ></lightning-input>
 
                     <template if:false={createdAssetId}>
@@ -164,7 +202,7 @@
                         class="slds-modal__close"
                         onclick={handleCloseRename}
                     ></lightning-button-icon>
-                    <h2 class="slds-text-heading_medium">Rename Asset</h2>
+                    <h2 class="slds-text-heading_medium">Edit Asset</h2>
                 </header>
                 <div class="slds-modal__content slds-var-p-around_medium">
                     <lightning-input
@@ -172,6 +210,14 @@
                         value={renameValue}
                         onchange={handleRenameChange}
                         required
+                    ></lightning-input>
+                    <lightning-input
+                        class="slds-var-m-top_x-small"
+                        label="Category"
+                        value={renameCategory}
+                        onchange={handleRenameCategoryChange}
+                        placeholder="e.g. Logos"
+                        field-level-help="Optional grouping label used to filter the asset list. Leave blank to remove the category."
                     ></lightning-input>
                 </div>
                 <footer class="slds-modal__footer">

--- a/force-app/main/default/lwc/docGenAssets/docGenAssets.html
+++ b/force-app/main/default/lwc/docGenAssets/docGenAssets.html
@@ -28,16 +28,19 @@
             </div>
         </template>
 
-        <!-- Asset list -->
+        <!-- Asset list. The wrapper scrolls horizontally when the tab is narrow
+             so the table never bleeds past its container. -->
         <template if:true={hasAssets}>
-            <lightning-datatable
-                key-field="id"
-                data={assets}
-                columns={columns}
-                onrowaction={handleRowAction}
-                hide-checkbox-column
-            >
-            </lightning-datatable>
+            <div class="asset-table-container">
+                <c-doc-gen-image-datatable
+                    key-field="id"
+                    data={assets}
+                    columns={columns}
+                    onrowaction={handleRowAction}
+                    hide-checkbox-column
+                >
+                </c-doc-gen-image-datatable>
+            </div>
         </template>
     </div>
 

--- a/force-app/main/default/lwc/docGenAssets/docGenAssets.js
+++ b/force-app/main/default/lwc/docGenAssets/docGenAssets.js
@@ -9,6 +9,7 @@ import createAsset from '@salesforce/apex/DocGenController.createAsset';
 import checkAssetKey from '@salesforce/apex/DocGenController.checkAssetKey';
 import addAssetVersion from '@salesforce/apex/DocGenController.addAssetVersion';
 import renameAsset from '@salesforce/apex/DocGenController.renameAsset';
+import setAssetCategory from '@salesforce/apex/DocGenController.setAssetCategory';
 import deactivateAsset from '@salesforce/apex/DocGenController.deactivateAsset';
 import getLatestContentVersionId from '@salesforce/apex/DocGenController.getLatestContentVersionId';
 
@@ -30,6 +31,7 @@ function slugify(value) {
 
 const COLUMNS = [
     { label: 'Name', fieldName: 'name' },
+    { label: 'Category', fieldName: 'category', initialWidth: 130 },
     {
         label: 'Merge Tag',
         fieldName: 'mergeTag',
@@ -77,7 +79,7 @@ const COLUMNS = [
         typeAttributes: {
             rowActions: [
                 { label: 'Upload New Version', name: 'uploadVersion' },
-                { label: 'Rename', name: 'rename' },
+                { label: 'Edit', name: 'rename' },
                 { label: 'Preview', name: 'preview' },
                 { label: 'Deactivate', name: 'deactivate' }
             ]
@@ -98,6 +100,7 @@ export default class DocGenAssets extends LightningElement {
     @track isCreateModalOpen = false;
     @track createName = '';
     @track createKey = '';
+    @track createCategory = '';
     @track createdAssetId = null;
     @track isUploading = false;
     // Live key validation
@@ -113,10 +116,15 @@ export default class DocGenAssets extends LightningElement {
     @track versionAssetId = null;
     @track versionAssetName = '';
 
-    // Rename modal state
+    // Rename/edit modal state
     @track isRenameModalOpen = false;
     @track renameAssetId = null;
     @track renameValue = '';
+    @track renameCategory = '';
+
+    // List filtering state
+    @track searchTerm = '';
+    @track categoryFilter = '';
 
     @wire(getAssets)
     wiredAssets(result) {
@@ -145,6 +153,61 @@ export default class DocGenAssets extends LightningElement {
 
     get hasAssets() {
         return this.assets && this.assets.length > 0;
+    }
+
+    // Rows after the search box + category dropdown are applied. Client-side:
+    // asset lists are admin-scale (tens, not thousands), so no server round-trip.
+    get visibleAssets() {
+        const term = (this.searchTerm || '').trim().toLowerCase();
+        return this.assets.filter((row) => {
+            if (this.categoryFilter === '__none__') {
+                if (row.category) {
+                    return false;
+                }
+            } else if (this.categoryFilter && row.category !== this.categoryFilter) {
+                return false;
+            }
+            if (!term) {
+                return true;
+            }
+            return [row.name, row.assetKey, row.mergeTag, row.category].some(
+                (v) => v && String(v).toLowerCase().includes(term)
+            );
+        });
+    }
+
+    get hasVisibleAssets() {
+        return this.visibleAssets.length > 0;
+    }
+
+    get showNoMatches() {
+        return this.hasAssets && !this.hasVisibleAssets;
+    }
+
+    // Distinct categories present in the data, for the filter dropdown.
+    get categoryOptions() {
+        const distinct = [...new Set(this.assets.map((r) => r.category).filter(Boolean))].sort((a, b) =>
+            a.localeCompare(b)
+        );
+        const options = [{ label: 'All Categories', value: '' }];
+        distinct.forEach((c) => options.push({ label: c, value: c }));
+        if (this.assets.some((r) => !r.category)) {
+            options.push({ label: 'Uncategorized', value: '__none__' });
+        }
+        return options;
+    }
+
+    get showCategoryFilter() {
+        // Only meaningful once at least one asset is categorized.
+        return this.assets.some((r) => r.category);
+    }
+
+    handleSearchChange(event) {
+        this.searchTerm = event.target.value;
+    }
+
+    handleCategoryFilterChange(event) {
+        this.categoryFilter = event.detail.value;
     }
 
     get isCreateDisabled() {
@@ -184,6 +247,7 @@ export default class DocGenAssets extends LightningElement {
         } else if (actionName === 'rename') {
             this.renameAssetId = row.id;
             this.renameValue = row.name;
+            this.renameCategory = row.category || '';
             this.isRenameModalOpen = true;
         } else if (actionName === 'preview') {
             if (row.thumbnailUrl) {
@@ -220,6 +284,7 @@ export default class DocGenAssets extends LightningElement {
     handleOpenCreate() {
         this.createName = '';
         this.createKey = '';
+        this.createCategory = '';
         this.createdAssetId = null;
         this.isUploading = false;
         this.keyEdited = false;
@@ -247,6 +312,10 @@ export default class DocGenAssets extends LightningElement {
         this.keyEdited = true;
         this.createKey = event.target.value;
         this.scheduleKeyCheck();
+    }
+
+    handleCreateCategoryChange(event) {
+        this.createCategory = event.target.value;
     }
 
     // Debounced server check so the user sees the final slug + availability live.
@@ -294,6 +363,11 @@ export default class DocGenAssets extends LightningElement {
             const asset = await createAsset({ name: this.createName.trim(), assetKey: this.createKey });
             // createAsset returns a map { id, name, assetKey, mergeTag }.
             this.createdAssetId = asset && asset.id ? asset.id : asset;
+            if (this.createCategory && this.createCategory.trim()) {
+                // Separate call — createAsset's signature is fixed (@AuraEnabled
+                // methods can't be overloaded).
+                await setAssetCategory({ assetId: this.createdAssetId, category: this.createCategory.trim() });
+            }
             this.showToast('Asset created', 'Now upload an image for "' + this.createName.trim() + '".', 'success');
             await refreshApex(this.wiredAssetsResult);
         } catch (error) {
@@ -373,17 +447,23 @@ export default class DocGenAssets extends LightningElement {
         this.renameValue = event.target.value;
     }
 
+    handleRenameCategoryChange(event) {
+        this.renameCategory = event.target.value;
+    }
+
     async handleRenameSave() {
         if (this.isRenameDisabled) {
             return;
         }
         try {
             await renameAsset({ assetId: this.renameAssetId, newName: this.renameValue.trim() });
-            this.showToast('Renamed', 'Asset renamed to "' + this.renameValue.trim() + '".', 'success');
+            // Always sent — blank intentionally clears the category.
+            await setAssetCategory({ assetId: this.renameAssetId, category: this.renameCategory.trim() });
+            this.showToast('Saved', '"' + this.renameValue.trim() + '" updated.', 'success');
             this.isRenameModalOpen = false;
             await refreshApex(this.wiredAssetsResult);
         } catch (error) {
-            this.showToast('Error renaming asset', this.errMsg(error), 'error');
+            this.showToast('Error saving asset', this.errMsg(error), 'error');
         }
     }
 

--- a/force-app/main/default/lwc/docGenImageDatatable/docGenImageDatatable.js
+++ b/force-app/main/default/lwc/docGenImageDatatable/docGenImageDatatable.js
@@ -1,0 +1,22 @@
+import LightningDatatable from 'lightning/datatable';
+import imageCell from './imageCell.html';
+
+/**
+ * lightning-datatable has no built-in 'image' column type — a column declared
+ * with an unknown type silently renders its value as plain text (which is how
+ * the Assets tab ended up showing raw /sfc/ URLs instead of thumbnails). This
+ * subclass registers a real 'image' type backed by imageCell.html.
+ *
+ * Column usage:
+ *   { type: 'image', fieldName: 'thumbnailUrl',
+ *     typeAttributes: { alt: { fieldName: 'name' }, height: 48 } }
+ */
+export default class DocGenImageDatatable extends LightningDatatable {
+    static customTypes = {
+        image: {
+            template: imageCell,
+            standardCellLayout: true,
+            typeAttributes: ['alt', 'height']
+        }
+    };
+}

--- a/force-app/main/default/lwc/docGenImageDatatable/docGenImageDatatable.js-meta.xml
+++ b/force-app/main/default/lwc/docGenImageDatatable/docGenImageDatatable.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/docGenImageDatatable/imageCell.html
+++ b/force-app/main/default/lwc/docGenImageDatatable/imageCell.html
@@ -1,0 +1,24 @@
+<template>
+    <template if:true={value}>
+        <!-- Inline styles: the bundle stylesheet can't reach into the datatable's
+             nested primitive-cell shadow roots, so the sizing must live here.
+             Checkerboard backdrop keeps white/transparent logos visible. -->
+        <img
+            src={value}
+            alt={typeAttributes.alt}
+            loading="lazy"
+            style="
+                height: 48px;
+                width: auto;
+                max-width: 104px;
+                object-fit: contain;
+                display: block;
+                border-radius: 4px;
+                background: repeating-conic-gradient(#f3f3f3 0% 25%, #ffffff 0% 50%) 0 0 / 12px 12px;
+            "
+        />
+    </template>
+    <template if:false={value}>
+        <lightning-icon icon-name="utility:image" size="x-small" alternative-text="No image"></lightning-icon>
+    </template>
+</template>

--- a/force-app/main/default/objects/DocGen_Asset__c/fields/Category__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Asset__c/fields/Category__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Category__c</fullName>
+    <description
+    >Free-text grouping label for the Assets tab (e.g. "Logos", "Footers", "Backgrounds"). Filterable in the admin UI; no effect on merge-tag resolution. Free text rather than a picklist so subscribers can invent their own taxonomy and the managed package never has to ship picklist-value changes.</description>
+    <label>Category</label>
+    <length>80</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+    <externalId>false</externalId>
+</CustomField>

--- a/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
@@ -207,6 +207,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>DocGen_Asset__c.Category__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>DocGen_Asset__c.Is_Active__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
@@ -196,6 +196,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>DocGen_Asset__c.Category__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>DocGen_Asset__c.Is_Active__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
Fixes #219, fixes #220.

## 1. Image Files stranded on records (#219 — follow-up to #202)

\`ensureTemplateAssetImageAccessForPdf\` links the current body's template images to the target record so \`Blob.toPdf\` can fetch the \`/sfc/\` URLs as the running user — and the prune-with-keep pass protects exactly that set, so a first generation on a fresh record always stranded the full image set as Files (single-runner report in #support), and bulk-via-Flow stamped it onto every record (Heralds of Hope email report).

**Fix:** the links only matter while \`Blob.toPdf\` fetches inside the same transaction — the PDF embeds the bytes. New \`DocGenService.removeTemplateImageLinksAfterRender(templateId, recordId)\` (a wrapper over the existing prune with null active version + empty keep-set) runs after \`Blob.toPdf\` returns:

- \`renderPdf\` HTML branch and DOCX→HTML branch
- \`DocGenGiantQueryAssembler.renderFinalPdf\` (success path)

Covers single runner (Save to Record **and** Download-only, which also leaked), Flow invocable, \`DocGenBatch\` per-record, and giant-query. The empty keep-set also sweeps sets stranded on records by earlier package versions, fulfilling the "next generation clears previously stranded links" promise from the v3.28 announcement. User-attached files are untouched — the prune is title-scoped to both docgen image naming schemes and to this template.

Not touched (intentionally): signature finalize / merge-job / stitch-job \`Blob.toPdf\` sites — they never created record links and never relied on them (confirmed by the reporter: the signature path doesn't leave files).

## 2. Template API Name saved-then-wiped (#220)

The v3.29 create wizard persisted \`API_Name__c\` via \`createRecord\`, but the optimistic \`newRow\` omitted \`[F.ApiName]\` and \`resetForm()\` cleared the wizard value — so the edit modal opened blank and the mandatory follow-up save posted \`API_Name__c: ''\`, wiping the stored key.

**Fix:** \`newRow\` carries \`[F.ApiName]\`; \`saveTemplate\` treats blank \`API_Name__c\` as "leave unchanged" (it's a stable developer key referenced by Flows — same philosophy as the \`Is_Active__c\` guard).

## Validation

- \`DocGenMiscTests.testRemoveTemplateImageLinksAfterRenderClearsCurrentSet\` — both naming schemes linked for the fetch, swept post-render, user file untouched
- \`DocGenControllerTests.testSaveTemplateBlankApiNameDoesNotWipeValue\` — blank leaves the key, non-blank still updates
- Full \`DocGenMiscTests\` + \`DocGenControllerTests\` + \`DocGenGiantQueryTest\` on Portwood Dev: 665 ran, 4 failures on first run — 3 were \`UNABLE_TO_LOCK_ROW\` parallel-run flakes (pass on rerun), 1 was a payload bug in the new test (fixed); targeted rerun 5/5 pass
- Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)