### PR TITLE
Friendly errors for oversized signature-settings values

### DIFF
--- a/force-app/main/default/classes/DocGenEmailTemplateController.cls
+++ b/force-app/main/default/classes/DocGenEmailTemplateController.cls
@@ -177,8 +177,12 @@ public with sharing class DocGenEmailTemplateController {
         } else {
             DocGenFlsGuard.assertUpdateable(rec, fields);
         }
-        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-        Database.upsert(rec, AccessLevel.SYSTEM_MODE);
+        try {
+            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+            Database.upsert(rec, AccessLevel.SYSTEM_MODE);
+        } catch (DmlException e) {
+            throw DocGenService.dmlAhe(e, DocGen_Email_Template__c.sObjectType);
+        }
         return rec.Id;
     }
 

--- a/force-app/main/default/classes/DocGenEmailTemplateTest.cls
+++ b/force-app/main/default/classes/DocGenEmailTemplateTest.cls
@@ -168,6 +168,33 @@ private class DocGenEmailTemplateTest {
         System.assertEquals('Updated subject', rec.Subject__c);
     }
 
+    // Oversized Logo URL Override must surface a friendly "too long" message,
+    // not the raw DmlException (which renders as "[object Object]" in the LWC).
+    @IsTest
+    static void controller_save_oversized_logo_url_friendly_error() {
+        Map<String, Object> data = new Map<String, Object>{
+            'type' => DocGenEmailTemplateService.TYPE_REQUEST,
+            'subject' => 'Hi',
+            'bodyHtml' => '<p>x</p>',
+            'logoUrl' => 'https://example.com/' + 'a'.repeat(300)
+        };
+        Boolean caught = false;
+        String message;
+        Test.startTest();
+        try {
+            DocGenEmailTemplateController.saveTemplate(data);
+        } catch (AuraHandledException e) {
+            caught = true;
+            message = e.getMessage();
+        }
+        Test.stopTest();
+        System.assert(caught, 'Oversized logo URL must throw AuraHandledException');
+        System.assert(
+            message.contains('255') && message.containsIgnoreCase('too long'),
+            'Message must name the max length; got: ' + message
+        );
+    }
+
     // ---- Controller: getDefault + renderPreview ----
     @IsTest
     static void controller_default_and_preview() {

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -378,6 +378,47 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
     }
 
     /**
+     * Converts a DmlException from a settings/config save into a user-friendly
+     * AuraHandledException. STRING_TOO_LONG gets a field-specific "too long, max N
+     * characters" message (the raw DmlException surfaces as "[object Object]" in LWC).
+     */
+    public static AuraHandledException dmlAhe(DmlException e, Schema.SObjectType sObjType) {
+        if (e.getNumDml() > 0 && e.getDmlType(0) == StatusCode.STRING_TOO_LONG) {
+            List<String> fieldNames = e.getDmlFieldNames(0);
+            Schema.DescribeFieldResult dfr = describeDmlField(sObjType, fieldNames);
+            if (dfr != null) {
+                return ahe(
+                    dfr.getLabel() + ' is too long (max ' + dfr.getLength() + ' characters) — use a shorter value.'
+                );
+            }
+            return ahe('A value is too long: ' + e.getDmlMessage(0));
+        }
+        return ahe('Could not save: ' + (e.getNumDml() > 0 ? e.getDmlMessage(0) : e.getMessage()));
+    }
+
+    /**
+     * Resolves a field name from DmlException.getDmlFieldNames against the object's
+     * field map. Falls back to an endsWith match because DML field names may or may
+     * not carry the namespace prefix depending on context.
+     */
+    private static Schema.DescribeFieldResult describeDmlField(Schema.SObjectType sObjType, List<String> fieldNames) {
+        if (fieldNames == null || fieldNames.isEmpty() || sObjType == null) {
+            return null;
+        }
+        Map<String, Schema.SObjectField> fieldMap = sObjType.getDescribe().fields.getMap();
+        String wanted = fieldNames[0].toLowerCase();
+        if (fieldMap.containsKey(wanted)) {
+            return fieldMap.get(wanted).getDescribe();
+        }
+        for (String key : fieldMap.keySet()) {
+            if (key.endsWith(wanted)) {
+                return fieldMap.get(key).getDescribe();
+            }
+        }
+        return null;
+    }
+
+    /**
      * Public wrapper for processXml — used by e2e tests to validate tag processing.
      * @param xml The XML string containing merge tags
      * @param data The record data map to resolve tags against

--- a/force-app/main/default/classes/DocGenSetupController.cls
+++ b/force-app/main/default/classes/DocGenSetupController.cls
@@ -73,8 +73,12 @@ public with sharing class DocGenSetupController {
         // custom settings record already exists.
         DocGenFlsGuard.assertCreateable(settings, new Set<String>{ 'Experience_Site_Url__c' });
         DocGenFlsGuard.assertUpdateable(settings, new Set<String>{ 'Experience_Site_Url__c' });
-        /* code-analyzer-suppress ApexFlsViolation */
-        Database.upsert(settings, AccessLevel.SYSTEM_MODE);
+        try {
+            /* code-analyzer-suppress ApexFlsViolation */
+            Database.upsert(settings, AccessLevel.SYSTEM_MODE);
+        } catch (DmlException e) {
+            throw DocGenService.dmlAhe(e, DocGen_Settings__c.sObjectType);
+        }
     }
 
     /**
@@ -318,8 +322,12 @@ public with sharing class DocGenSetupController {
         };
         DocGenFlsGuard.assertCreateable(settings, sigSettingsFields);
         DocGenFlsGuard.assertUpdateable(settings, sigSettingsFields);
-        /* code-analyzer-suppress ApexFlsViolation */
-        Database.upsert(settings, AccessLevel.SYSTEM_MODE);
+        try {
+            /* code-analyzer-suppress ApexFlsViolation */
+            Database.upsert(settings, AccessLevel.SYSTEM_MODE);
+        } catch (DmlException e) {
+            throw DocGenService.dmlAhe(e, DocGen_Settings__c.sObjectType);
+        }
     }
 
     /**
@@ -342,8 +350,12 @@ public with sharing class DocGenSetupController {
         Set<String> reminderFields = new Set<String>{ 'Signature_Reminder_Enabled__c', 'Signature_Reminder_Hours__c' };
         DocGenFlsGuard.assertCreateable(settings, reminderFields);
         DocGenFlsGuard.assertUpdateable(settings, reminderFields);
-        /* code-analyzer-suppress ApexFlsViolation */
-        Database.upsert(settings, AccessLevel.SYSTEM_MODE);
+        try {
+            /* code-analyzer-suppress ApexFlsViolation */
+            Database.upsert(settings, AccessLevel.SYSTEM_MODE);
+        } catch (DmlException e) {
+            throw DocGenService.dmlAhe(e, DocGen_Settings__c.sObjectType);
+        }
 
         // Auto-schedule or abort the reminder job
         String jobName = 'DocGen Signature Reminders';

--- a/force-app/main/default/classes/DocGenSetupControllerTest.cls
+++ b/force-app/main/default/classes/DocGenSetupControllerTest.cls
@@ -128,4 +128,60 @@ private class DocGenSetupControllerTest {
         System.assert(fresh.containsKey('Experience_Site_Url__c'), 'Fresh map must expose unqualified field names');
         System.assertNotEquals(null, orgUrl, 'getOrgUrl must return a non-null URL');
     }
+
+    // =========================================================================
+    // Oversized values — DmlException must surface as a friendly
+    // AuraHandledException naming the field and the max length, not the raw
+    // DML error (which renders as "[object Object]" in the LWC).
+    // =========================================================================
+
+    @IsTest
+    static void testSaveSignatureSettingsOversizedLogoUrlFriendlyError() {
+        String longUrl = 'https://example.com/' + 'a'.repeat(300);
+        Boolean caught = false;
+        String message;
+        Test.startTest();
+        try {
+            DocGenSetupController.saveSignatureSettings(
+                '#0176D3',
+                longUrl,
+                'Subject',
+                'Message',
+                'Footer',
+                'Company',
+                null
+            );
+        } catch (AuraHandledException e) {
+            caught = true;
+            message = e.getMessage();
+        }
+        Test.stopTest();
+
+        System.assert(caught, 'Oversized logo URL must throw AuraHandledException, not raw DmlException');
+        System.assert(
+            message.contains('255') && message.containsIgnoreCase('too long'),
+            'Message must say the field is too long with the 255 max; got: ' + message
+        );
+    }
+
+    @IsTest
+    static void testSaveSettingsOversizedSiteUrlFriendlyError() {
+        String longUrl = 'https://example.com/' + 'a'.repeat(300);
+        Boolean caught = false;
+        String message;
+        Test.startTest();
+        try {
+            DocGenSetupController.saveSettings(longUrl);
+        } catch (AuraHandledException e) {
+            caught = true;
+            message = e.getMessage();
+        }
+        Test.stopTest();
+
+        System.assert(caught, 'Oversized site URL must throw AuraHandledException, not raw DmlException');
+        System.assert(
+            message.contains('255') && message.containsIgnoreCase('too long'),
+            'Message must say the field is too long with the 255 max; got: ' + message
+        );
+    }
 }

--- a/force-app/main/default/lwc/docGenEmailTemplates/docGenEmailTemplates.html
+++ b/force-app/main/default/lwc/docGenEmailTemplates/docGenEmailTemplates.html
@@ -108,6 +108,7 @@
                                     type="text"
                                     label="Logo URL Override"
                                     value={logoUrl}
+                                    max-length="255"
                                     onchange={handleLogoChange}
                                     placeholder="https://…/logo.png"
                                 ></lightning-input>

--- a/force-app/main/default/lwc/docGenEmailTemplates/docGenEmailTemplates.js
+++ b/force-app/main/default/lwc/docGenEmailTemplates/docGenEmailTemplates.js
@@ -231,10 +231,20 @@ export default class DocGenEmailTemplates extends LightningElement {
 
     // ===== Helpers =====
     errMsg(error) {
-        if (error && error.body && error.body.message) {
-            return error.body.message;
+        const body = error && error.body;
+        if (Array.isArray(body) && body[0] && typeof body[0].message === 'string') {
+            return body[0].message;
         }
-        return (error && error.message) || String(error);
+        if (body && typeof body.message === 'string' && body.message) {
+            return body.message;
+        }
+        if (body && body.pageErrors && body.pageErrors[0] && body.pageErrors[0].message) {
+            return String(body.pageErrors[0].message);
+        }
+        if (error && typeof error.message === 'string' && error.message) {
+            return error.message;
+        }
+        return 'An unexpected error occurred.';
     }
 
     toast(title, message, variant) {

--- a/force-app/main/default/lwc/docGenSignatureSettings/docGenSignatureSettings.html
+++ b/force-app/main/default/lwc/docGenSignatureSettings/docGenSignatureSettings.html
@@ -128,6 +128,7 @@
                         <lightning-input
                             label="Signature Site URL"
                             value={siteUrl}
+                            max-length="255"
                             placeholder="https://yourorg.my.salesforce-sites.com/DocGenSignatures"
                             onchange={handleSiteUrlChange}
                             field-level-help="The public Salesforce Site URL where signers access the signing page. Copy from Setup > Sites > your site's URL."

--- a/force-app/main/default/lwc/docGenSignatureSettings/docGenSignatureSettings.js
+++ b/force-app/main/default/lwc/docGenSignatureSettings/docGenSignatureSettings.js
@@ -150,9 +150,38 @@ export default class DocGenSignatureSettings extends LightningElement {
             this._loadSetupChecks();
         } catch (err) {
             this.saveSuccess = false;
-            this.saveMessage = err.body ? err.body.message : 'Failed to save settings.';
+            this.saveMessage = this.errMsg(err);
         } finally {
             this.isSaving = false;
         }
+    }
+
+    // Normalizes the LWC error shapes (AuraHandledException, DML page/field errors,
+    // array bodies) into a display string — err.body.message can be a non-string,
+    // which otherwise renders as "[object Object]".
+    errMsg(err) {
+        const body = err && err.body;
+        if (Array.isArray(body) && body[0] && typeof body[0].message === 'string') {
+            return body[0].message;
+        }
+        if (body) {
+            if (typeof body.message === 'string' && body.message) {
+                return body.message;
+            }
+            if (body.pageErrors && body.pageErrors[0] && body.pageErrors[0].message) {
+                return String(body.pageErrors[0].message);
+            }
+            if (body.fieldErrors) {
+                const fieldKey = Object.keys(body.fieldErrors)[0];
+                const fieldErr = fieldKey && body.fieldErrors[fieldKey][0];
+                if (fieldErr && fieldErr.message) {
+                    return String(fieldErr.message);
+                }
+            }
+        }
+        if (err && typeof err.message === 'string' && err.message) {
+            return err.message;
+        }
+        return 'Failed to save settings.';
     }
 }


### PR DESCRIPTION
## Problem
Saving a custom email logo URL (or site URL) longer than 255 characters — the hard platform cap on `Url` custom fields — threw a raw `DmlException` that surfaced in the UI as **`[object Object]`**.

## Fix
- New `DocGenService.dmlAhe(DmlException, SObjectType)`: converts DML failures into friendly `AuraHandledException`s. `STRING_TOO_LONG` gets a field-labeled message, e.g. *"Signature Email Logo URL is too long (max 255 characters) — use a shorter value."* Field lookup is namespace-safe (endsWith fallback).
- Wrapped the four unguarded upserts: `DocGenSetupController.saveSettings / saveSignatureSettings / saveReminderSettings` and `DocGenEmailTemplateController.saveTemplate` (the Logo URL Override editor — the primary repro site).
- `docGenSignatureSettings` + `docGenEmailTemplates` LWCs: hardened `errMsg` normalization (array bodies, non-string `body.message`, pageErrors) so no error shape ever renders as `[object Object]`.
- `max-length="255"` on the Site URL and Logo URL Override inputs — the browser now stops overlong input up front.

## Validation
- 3 new unit tests (oversized logo URL, site URL, template logo override → assert friendly message contains "255"/"too long").
- `DocGenSetupControllerTest` + `DocGenEmailTemplateTest`: 26/26 pass on Portwood Dev.
- prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)