### PR TITLE
Signature requests: View / Resend / Revoke actions + guided resend link fix

### DIFF
--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -2755,11 +2755,11 @@ public with sharing class DocGenSignatureSenderController {
     public static void resendSignatureRequest(Id requestId) {
         DocGenFlsGuard.assertAccessible(
             DocGen_Signature_Request__c.sObjectType,
-            new Set<String>{ 'Status__c', 'Template__c', 'Source_Document_Id__c' }
+            new Set<String>{ 'Status__c', 'Template__c', 'Source_Document_Id__c', 'Render_Data_Snapshot__c' }
         );
         /* code-analyzer-suppress ApexFlsViolation */
         DocGen_Signature_Request__c req = [
-            SELECT Id, Status__c, Template__r.Name, Source_Document_Id__c
+            SELECT Id, Status__c, Template__r.Name, Source_Document_Id__c, Render_Data_Snapshot__c
             FROM DocGen_Signature_Request__c
             WHERE Id = :requestId
             WITH SYSTEM_MODE
@@ -2803,6 +2803,8 @@ public with sharing class DocGenSignatureSenderController {
 
         List<DocGenSignatureEmailService.SignerEmail> emailList = new List<DocGenSignatureEmailService.SignerEmail>();
 
+        String signingPath = resolveSigningPath(req);
+
         for (DocGen_Signer__c s : signers) {
             // Generate new token
             Blob randomBytes = Crypto.generateAesKey(256);
@@ -2818,7 +2820,7 @@ public with sharing class DocGenSignatureSenderController {
             s.PIN_Attempts__c = 0;
             s.PIN_Verified_At__c = null;
 
-            String sigUrl = siteUrl + getSigningPagePath() + '?token=' + newToken;
+            String sigUrl = siteUrl + signingPath + '?token=' + newToken;
             emailList.add(
                 new DocGenSignatureEmailService.SignerEmail(
                     s.Signer_Name__c,
@@ -2851,6 +2853,19 @@ public with sharing class DocGenSignatureSenderController {
         Database.update(req, false, AccessLevel.SYSTEM_MODE);
 
         DocGenSignatureEmailService.sendSignatureRequestEmails(emailList, documentTitle);
+    }
+
+    /**
+     * PDF-viewer requests (snapshot re-render or send-existing-CV) set
+     * Render_Data_Snapshot__c or Source_Document_Id__c; the classic typed-name
+     * flow sets neither. Same predicate as the sequential-signer routing in
+     * DocGenSignaturePdfTrigger — resending with the legacy page path would
+     * email guided-PDF signers a broken link.
+     */
+    @TestVisible
+    private static String resolveSigningPath(DocGen_Signature_Request__c req) {
+        Boolean isPdfViewer = req.Render_Data_Snapshot__c != null || req.Source_Document_Id__c != null;
+        return isPdfViewer ? getSigningPdfPagePath() : getSigningPagePath();
     }
 
     /**

--- a/force-app/main/default/classes/DocGenSignatureTests.cls
+++ b/force-app/main/default/classes/DocGenSignatureTests.cls
@@ -3017,6 +3017,36 @@ private class DocGenSignatureTests {
     }
 
     @isTest
+    static void testResolveSigningPath_routesGuidedRequestsToPdfPage() {
+        // Guided-PDF requests (snapshot or source-doc) must resend links to the
+        // PDF signing page; only the classic typed-name flow uses the legacy page.
+        DocGen_Signature_Request__c classic = new DocGen_Signature_Request__c();
+        System.assertEquals(
+            DocGenSignatureSenderController.getSigningPagePath(),
+            DocGenSignatureSenderController.resolveSigningPath(classic),
+            'Typed-name request (no snapshot, no source doc) resends to the legacy page'
+        );
+
+        DocGen_Signature_Request__c snapshotReq = new DocGen_Signature_Request__c(
+            Render_Data_Snapshot__c = '{"fields":{}}'
+        );
+        System.assertEquals(
+            DocGenSignatureSenderController.getSigningPdfPagePath(),
+            DocGenSignatureSenderController.resolveSigningPath(snapshotReq),
+            'Snapshot-backed request resends to the PDF signing page'
+        );
+
+        DocGen_Signature_Request__c sourceDocReq = new DocGen_Signature_Request__c(
+            Source_Document_Id__c = '068000000000001AAA'
+        );
+        System.assertEquals(
+            DocGenSignatureSenderController.getSigningPdfPagePath(),
+            DocGenSignatureSenderController.resolveSigningPath(sourceDocReq),
+            'Send-existing-document request resends to the PDF signing page'
+        );
+    }
+
+    @isTest
     static void testCreateTemplateSignerRequest_notFound() {
         Test.startTest();
         try {

--- a/force-app/main/default/lwc/docGenSignatureSender/docGenSignatureSender.html
+++ b/force-app/main/default/lwc/docGenSignatureSender/docGenSignatureSender.html
@@ -409,6 +409,33 @@
                                     </p>
                                     <p class="slds-text-body_small slds-text-color_weak">{req.documentTitle}</p>
                                 </div>
+                                <div class="slds-col slds-no-flex">
+                                    <lightning-button-group>
+                                        <lightning-button
+                                            label="View"
+                                            icon-name="utility:open"
+                                            data-request-id={req.id}
+                                            onclick={handleViewRequest}
+                                        >
+                                        </lightning-button>
+                                        <lightning-button
+                                            label="Resend"
+                                            icon-name="utility:send"
+                                            data-request-id={req.id}
+                                            disabled={req.actionsDisabled}
+                                            onclick={handleResendRequest}
+                                        >
+                                        </lightning-button>
+                                        <lightning-button
+                                            label="Revoke"
+                                            variant="destructive-text"
+                                            data-request-id={req.id}
+                                            disabled={req.actionsDisabled}
+                                            onclick={handleRevokeRequest}
+                                        >
+                                        </lightning-button>
+                                    </lightning-button-group>
+                                </div>
                             </div>
                             <template for:each={req.signers} for:item="signer">
                                 <div

--- a/force-app/main/default/lwc/docGenSignatureSender/docGenSignatureSender.js
+++ b/force-app/main/default/lwc/docGenSignatureSender/docGenSignatureSender.js
@@ -1,4 +1,5 @@
 import { LightningElement, api, wire, track } from 'lwc';
+import { NavigationMixin } from 'lightning/navigation';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import getSignerRolePicklistValues from '@salesforce/apex/DocGenSignatureSenderController.getSignerRolePicklistValues';
 import createGuidedPdfSignatureRequest from '@salesforce/apex/DocGenSignatureSenderController.createGuidedPdfSignatureRequest';
@@ -9,11 +10,13 @@ import getPendingSignatureRequests from '@salesforce/apex/DocGenSignatureSenderC
 import getDocGenTemplates from '@salesforce/apex/DocGenSignatureSenderController.getDocGenTemplatesForRecord';
 import getTemplateSignaturePlacements from '@salesforce/apex/DocGenSignatureSenderController.getTemplateSignaturePlacements';
 import getDocumentPreviewPdfBase64 from '@salesforce/apex/DocGenSignatureSenderController.getDocumentPreviewPdfBase64';
+import resendSignatureRequest from '@salesforce/apex/DocGenSignatureSenderController.resendSignatureRequest';
+import cancelSignatureRequest from '@salesforce/apex/DocGenSignatureSenderController.cancelSignatureRequest';
 
 let signerIdCounter = 0;
 let templateIdCounter = 0;
 
-export default class DocGenSignatureSender extends LightningElement {
+export default class DocGenSignatureSender extends NavigationMixin(LightningElement) {
     @api recordId;
 
     @track isLoading = true;
@@ -680,6 +683,7 @@ export default class DocGenSignatureSender extends LightningElement {
             const data = await getPendingSignatureRequests({ relatedRecordId: this.recordId });
             this.previousRequests = data.map((req) => ({
                 ...req,
+                actionsDisabled: req.status === 'Signed' || req.status === 'Cancelled',
                 statusBadgeClass:
                     req.status === 'Signed'
                         ? 'slds-badge slds-theme_success'
@@ -709,6 +713,48 @@ export default class DocGenSignatureSender extends LightningElement {
     handleCopyPreviousUrl(event) {
         this._copyToClipboard(event.currentTarget.dataset.url);
         this.showToast('Copied', 'Link copied to clipboard.', 'success');
+    }
+
+    handleViewRequest(event) {
+        this[NavigationMixin.Navigate]({
+            type: 'standard__recordPage',
+            attributes: {
+                recordId: event.currentTarget.dataset.requestId,
+                actionName: 'view'
+            }
+        });
+    }
+
+    async handleResendRequest(event) {
+        const requestId = event.currentTarget.dataset.requestId;
+        const confirmed = window.confirm(
+            'Resend this signature request to all unsigned signers?\n\n' +
+                'New signing links will be emailed and the previous links will stop working.'
+        );
+        if (!confirmed) return;
+        try {
+            await resendSignatureRequest({ requestId });
+            this.showToast('Resent', 'New signing links were emailed to all unsigned signers.', 'success');
+            await this.loadPreviousRequests();
+        } catch (err) {
+            this.showToast('Unable to resend', err.body && err.body.message ? err.body.message : err.message, 'error');
+        }
+    }
+
+    async handleRevokeRequest(event) {
+        const requestId = event.currentTarget.dataset.requestId;
+        const confirmed = window.confirm(
+            'Revoke this signature request?\n\n' +
+                'All unsigned signing links become invalid and signers can no longer sign. This cannot be undone.'
+        );
+        if (!confirmed) return;
+        try {
+            await cancelSignatureRequest({ requestId });
+            this.showToast('Revoked', 'The signature request was revoked.', 'success');
+            await this.loadPreviousRequests();
+        } catch (err) {
+            this.showToast('Unable to revoke', err.body && err.body.message ? err.body.message : err.message, 'error');
+        }
     }
 
     handleCopyUrl(event) {


### PR DESCRIPTION
## What
The Previous Signature Requests list in `docGenSignatureSender` was display-only (Copy link was the sole action). This wires up the request lifecycle:

- **View** — navigates to the `DocGen_Signature_Request__c` record page (NavigationMixin, no hardcoded object API name so it's namespace-safe)
- **Resend** — confirmation dialog ("old links will stop working"), then the existing `resendSignatureRequest` Apex (rotates tokens, resets signers to Pending, clears PINs, re-emails), then list refresh
- **Revoke** — confirmation dialog, then the existing `cancelSignatureRequest` Apex (Cancelled status, tokens nulled, frozen snapshot CV purged), then list refresh
- Resend/Revoke disabled for Signed/Cancelled requests; Apex guards still enforce server-side

## Latent bug fixed
`resendSignatureRequest` built signer URLs with the legacy `getSigningPagePath()` — every guided-PDF request (which is everything this LWC creates) would have been resent a broken link. It now routes via the same predicate as the sequential-signer path in `DocGenSignaturePdfTrigger` (`Render_Data_Snapshot__c`/`Source_Document_Id__c` ⇒ PDF page). Extracted as `resolveSigningPath` with a 3-case regression test.

## Validation
- `DocGenSignatureTests`: 286/286 pass on Portwood Dev (incl. new `testResolveSigningPath_routesGuidedRequestsToPdfPage`)
- prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)