### PR TITLE
Configurable signing-link expiration + multi-reminder schedule

### DIFF
--- a/force-app/main/default/classes/DocGenEmailTemplateController.cls
+++ b/force-app/main/default/classes/DocGenEmailTemplateController.cls
@@ -264,7 +264,7 @@ public with sharing class DocGenEmailTemplateController {
             'DocumentTitle' => 'Master Services Agreement',
             'SenderName' => UserInfo.getName(),
             'SignatureUrl' => 'https://example.com/sign?token=SAMPLE-TOKEN',
-            'ExpirationHours' => '48',
+            'ExpirationHours' => String.valueOf(DocGenSignatureExpiry.defaultHours()),
             'ExpirationMinutes' => '15',
             'Pin' => '481627',
             'RequestId' => 'a0X000000000SAMPLE',

--- a/force-app/main/default/classes/DocGenGuidedSigningTest.cls
+++ b/force-app/main/default/classes/DocGenGuidedSigningTest.cls
@@ -85,6 +85,29 @@ private class DocGenGuidedSigningTest {
     }
 
     @IsTest
+    static void guidedRequest_stampsDefaultExpiry() {
+        Id tplId = createTaggedTemplate();
+        Account a = [SELECT Id FROM Account LIMIT 1];
+
+        Test.startTest();
+        DocGenSignatureSenderController.createGuidedPdfSignatureRequest(tplId, a.Id, signersJson(), 'Parallel', null);
+        Test.stopTest();
+
+        DocGen_Signature_Request__c req = [
+            SELECT Expires_At__c
+            FROM DocGen_Signature_Request__c
+            WHERE Template__c = :tplId
+            LIMIT 1
+        ];
+        System.assertNotEquals(null, req.Expires_At__c, 'Every new request stamps its signing window');
+        Long deltaMs = req.Expires_At__c.getTime() - System.now().addDays(2).getTime();
+        System.assert(
+            Math.abs(deltaMs) < 5 * 60 * 1000,
+            'Org default (unset setting) = 2 days, matching the historical 48h; delta ms=' + deltaMs
+        );
+    }
+
+    @IsTest
     static void synthesizesPlacementsForTaglessTemplate() {
         // #170 option (b): a tag-less legacy template is no longer rejected — the guided
         // path auto-appends a "Signatures" block (Full + Date per signer) so it signs

--- a/force-app/main/default/classes/DocGenSetupController.cls
+++ b/force-app/main/default/classes/DocGenSetupController.cls
@@ -41,6 +41,8 @@ public with sharing class DocGenSetupController {
         result.put('Signature_OWA_Id__c', s.Signature_OWA_Id__c);
         result.put('Signature_Reminder_Enabled__c', s.Signature_Reminder_Enabled__c);
         result.put('Signature_Reminder_Hours__c', s.Signature_Reminder_Hours__c);
+        result.put('Signature_Reminder_Schedule__c', s.Signature_Reminder_Schedule__c);
+        result.put('Signature_Expiration_Days__c', s.Signature_Expiration_Days__c);
         // #verification — stored as inverted "skip" so the safe default (required) survives
         // upgrades. Report require = NOT skip; key kept stable for the LWC.
         result.put(
@@ -335,19 +337,41 @@ public with sharing class DocGenSetupController {
      * When enabled, schedules DocGenSignatureReminderSchedulable to run hourly.
      * When disabled, aborts the scheduled job.
      */
-    @AuraEnabled
     public static void saveReminderSettings(Boolean enabled, Integer hours) {
+        saveReminderSettings(enabled, hours, null, null);
+    }
+
+    /**
+     * 4-arg canonical. schedule = CSV of reminder hour offsets ("24,72,168");
+     * blank keeps the legacy single reminder from hours. expirationDays = org-wide
+     * default signing-window (1-365); null leaves the stored value untouched.
+     */
+    @AuraEnabled
+    public static void saveReminderSettings(Boolean enabled, Integer hours, String schedule, Integer expirationDays) {
         if (
             !FeatureManagement.checkPermission('DocGen_Admin_Access') &&
             !Schema.sObjectType.DocGen_Settings__c.isUpdateable()
         ) {
             throw DocGenService.ahe('Insufficient privileges to modify DocGen settings.');
         }
+        String normalizedSchedule = normalizeReminderSchedule(schedule);
+        if (expirationDays != null && (expirationDays < 1 || expirationDays > 365)) {
+            throw DocGenService.ahe('Link expiration must be between 1 and 365 days.');
+        }
         DocGen_Settings__c settings = DocGen_Settings__c.getOrgDefaults();
         settings.Signature_Reminder_Enabled__c = enabled;
         settings.Signature_Reminder_Hours__c = hours != null && hours > 0 ? hours : 24;
+        settings.Signature_Reminder_Schedule__c = normalizedSchedule;
+        if (expirationDays != null) {
+            settings.Signature_Expiration_Days__c = expirationDays;
+        }
         // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Create"/"FLS Update").
-        Set<String> reminderFields = new Set<String>{ 'Signature_Reminder_Enabled__c', 'Signature_Reminder_Hours__c' };
+        Set<String> reminderFields = new Set<String>{
+            'Signature_Reminder_Enabled__c',
+            'Signature_Reminder_Hours__c',
+            'Signature_Reminder_Schedule__c',
+            'Signature_Expiration_Days__c'
+        };
         DocGenFlsGuard.assertCreateable(settings, reminderFields);
         DocGenFlsGuard.assertUpdateable(settings, reminderFields);
         try {
@@ -380,6 +404,36 @@ public with sharing class DocGenSetupController {
         } catch (Exception e) {
             System.debug(LoggingLevel.WARN, 'DocGen: Failed to schedule/abort reminder job: ' + e.getMessage());
         }
+    }
+
+    /**
+     * Validates + normalizes the reminder-schedule CSV: digits separated by
+     * commas, each entry 1-8760 hours, max 10 entries, returned sorted and
+     * whitespace-free. Blank in → null out (legacy single-reminder mode).
+     */
+    private static String normalizeReminderSchedule(String schedule) {
+        if (String.isBlank(schedule)) {
+            return null;
+        }
+        List<Integer> offsets = new List<Integer>();
+        for (String part : schedule.split(',')) {
+            String trimmed = part.trim();
+            if (!trimmed.isNumeric()) {
+                throw DocGenService.ahe(
+                    'Reminder schedule must be hour offsets separated by commas, e.g. 24, 72, 168.'
+                );
+            }
+            Integer hours = Integer.valueOf(trimmed);
+            if (hours < 1 || hours > 8760) {
+                throw DocGenService.ahe('Each reminder offset must be between 1 and 8760 hours (1 year).');
+            }
+            offsets.add(hours);
+        }
+        if (offsets.size() > 10) {
+            throw DocGenService.ahe('At most 10 reminders are allowed per schedule.');
+        }
+        offsets.sort();
+        return String.join(offsets, ',');
     }
 
     /**

--- a/force-app/main/default/classes/DocGenSetupControllerTest.cls
+++ b/force-app/main/default/classes/DocGenSetupControllerTest.cls
@@ -130,6 +130,52 @@ private class DocGenSetupControllerTest {
     }
 
     // =========================================================================
+    // saveReminderSettings — schedule + expiration (4-arg canonical)
+    // =========================================================================
+
+    @IsTest
+    static void testSaveReminderSettings_scheduleAndExpiration() {
+        Test.startTest();
+        DocGenSetupController.saveReminderSettings(true, 24, ' 168, 24 , 72 ', 14);
+        Test.stopTest();
+
+        DocGen_Settings__c s = DocGen_Settings__c.getOrgDefaults();
+        System.assertEquals('24,72,168', s.Signature_Reminder_Schedule__c, 'Schedule normalized and sorted');
+        System.assertEquals(14, s.Signature_Expiration_Days__c);
+        System.assertEquals(true, s.Signature_Reminder_Enabled__c);
+    }
+
+    @IsTest
+    static void testSaveReminderSettings_invalidScheduleRejected() {
+        Boolean caught = false;
+        String message;
+        Test.startTest();
+        try {
+            DocGenSetupController.saveReminderSettings(true, 24, '24,banana,72', 2);
+        } catch (AuraHandledException e) {
+            caught = true;
+            message = e.getMessage();
+        }
+        Test.stopTest();
+        System.assert(caught, 'Non-numeric schedule entry must be rejected');
+        System.assert(message.contains('hour offsets'), 'Friendly guidance expected; got: ' + message);
+    }
+
+    @IsTest
+    static void testSaveReminderSettings_expirationOutOfRangeRejected() {
+        Boolean caught = false;
+        Test.startTest();
+        try {
+            DocGenSetupController.saveReminderSettings(false, 24, null, 9999);
+        } catch (AuraHandledException e) {
+            caught = true;
+            System.assert(e.getMessage().contains('365'), 'Range named in message; got: ' + e.getMessage());
+        }
+        Test.stopTest();
+        System.assert(caught, 'Out-of-range expiration must be rejected');
+    }
+
+    // =========================================================================
     // Oversized values — DmlException must surface as a friendly
     // AuraHandledException naming the field and the max length, not the raw
     // DML error (which renders as "[object Object]" in the LWC).

--- a/force-app/main/default/classes/DocGenSignatureController.cls
+++ b/force-app/main/default/classes/DocGenSignatureController.cls
@@ -1,5 +1,6 @@
 public without sharing class DocGenSignatureController {
-    // Signature links expire after this many hours from creation
+    // Legacy signing-window: requests created before Expires_At__c existed live this
+    // long from creation. New requests stamp Expires_At__c (DocGenSignatureExpiry).
     private static final Integer TOKEN_EXPIRATION_HOURS = 48;
     // PIN verification settings
     private static final Integer PIN_EXPIRATION_MINUTES = 10;
@@ -311,6 +312,7 @@ public without sharing class DocGenSignatureController {
                 Signature_Request__r.Prefill_Signer_Email__c,
                 Signature_Request__r.Source_Document_Id__c,
                 Signature_Request__r.Related_Record_Id__c,
+                Signature_Request__r.Expires_At__c,
                 Signature_Request__r.Template__c,
                 Signature_Request__r.Template__r.Name,
                 Signature_Request__r.Template__r.Form_Fields_Config__c
@@ -321,8 +323,9 @@ public without sharing class DocGenSignatureController {
         ];
 
         if (!signers.isEmpty()) {
-            // Token expiration: 30 days from creation
-            if (signers[0].CreatedDate.addHours(TOKEN_EXPIRATION_HOURS) < System.now()) {
+            if (
+                DocGenSignatureExpiry.isExpired(signers[0].Signature_Request__r.Expires_At__c, signers[0].CreatedDate)
+            ) {
                 res.errorMessage = 'This signature link has expired. Please request a new one.';
                 return res;
             }
@@ -338,12 +341,20 @@ public without sharing class DocGenSignatureController {
                 'Source_Document_Id__c',
                 'Related_Record_Id__c',
                 'CreatedDate',
-                'Secure_Token__c'
+                'Secure_Token__c',
+                'Expires_At__c'
             }
         );
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
         List<DocGen_Signature_Request__c> requests = [
-            SELECT Id, Status__c, Signer_Name__c, Source_Document_Id__c, Related_Record_Id__c, CreatedDate
+            SELECT
+                Id,
+                Status__c,
+                Signer_Name__c,
+                Source_Document_Id__c,
+                Related_Record_Id__c,
+                CreatedDate,
+                Expires_At__c
             FROM DocGen_Signature_Request__c
             WHERE Secure_Token__c = :token
             WITH SYSTEM_MODE
@@ -355,8 +366,7 @@ public without sharing class DocGenSignatureController {
             return res;
         }
 
-        // Token expiration: 30 days from creation
-        if (requests[0].CreatedDate.addHours(TOKEN_EXPIRATION_HOURS) < System.now()) {
+        if (DocGenSignatureExpiry.isExpired(requests[0].Expires_At__c, requests[0].CreatedDate)) {
             res.errorMessage = 'This signature link has expired. Please request a new one.';
             return res;
         }
@@ -390,7 +400,7 @@ public without sharing class DocGenSignatureController {
         );
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
         List<DocGen_Signer__c> signers = [
-            SELECT Id, Signer_Email__c, PIN_Attempts__c, Status__c, CreatedDate
+            SELECT Id, Signer_Email__c, PIN_Attempts__c, Status__c, CreatedDate, Signature_Request__r.Expires_At__c
             FROM DocGen_Signer__c
             WHERE Secure_Token__c = :token
             WITH SYSTEM_MODE
@@ -413,7 +423,7 @@ public without sharing class DocGenSignatureController {
         }
 
         // Check if token is expired
-        if (signer.CreatedDate.addHours(TOKEN_EXPIRATION_HOURS) < System.now()) {
+        if (DocGenSignatureExpiry.isExpired(signer.Signature_Request__r.Expires_At__c, signer.CreatedDate)) {
             result.put('success', false);
             result.put('message', 'This signature link has expired.');
             return result;
@@ -711,7 +721,7 @@ public without sharing class DocGenSignatureController {
                 // public preview link is optional. ContentDistribution creation is not permitted
                 // in guest context, so never let it break token validation.
                 try {
-                    res.documentUrl = getOrCreatePublicLink(cvs[0]);
+                    res.documentUrl = getOrCreatePublicLink(cvs[0], parentReq.Expires_At__c);
                 } catch (Exception e) {
                     System.debug(LoggingLevel.WARN, 'DocGen: public preview link unavailable — ' + e.getMessage());
                 }
@@ -770,7 +780,7 @@ public without sharing class DocGenSignatureController {
         ];
         if (!cvs.isEmpty()) {
             res.documentTitle = cvs[0].Title;
-            res.documentUrl = getOrCreatePublicLink(cvs[0]);
+            res.documentUrl = getOrCreatePublicLink(cvs[0], req.Expires_At__c);
         } else {
             res.documentTitle = 'Confidential Document';
         }
@@ -779,7 +789,7 @@ public without sharing class DocGenSignatureController {
     }
 
     // CxSAST: Apex_CRUD_ContentDistribution — SYSTEM_MODE required for guest user context; ContentDistribution created for signature document preview
-    private static String getOrCreatePublicLink(ContentVersion cv) {
+    private static String getOrCreatePublicLink(ContentVersion cv, Datetime requestExpiresAt) {
         DocGenFlsGuard.guestAssertAccessible(
             ContentDistribution.sObjectType,
             new Set<String>{ 'DistributionPublicUrl', 'ContentVersionId' }
@@ -800,10 +810,11 @@ public without sharing class DocGenSignatureController {
         cd.ContentVersionId = cv.Id;
         cd.PreferencesAllowViewInBrowser = true;
         cd.PreferencesLinkLatestVersion = true;
-        // Expire the public link in line with the signing token lifetime so a signed
-        // (or cancelled) request can't be re-fetched anonymously after the signing window.
+        // Expire the public link in line with the signing window so a signed
+        // (or cancelled) request can't be re-fetched anonymously afterwards.
+        // Legacy requests (no stamped expiry) keep the historical 48 hours.
         cd.PreferencesExpires = true;
-        cd.ExpiryDate = System.now().addHours(TOKEN_EXPIRATION_HOURS);
+        cd.ExpiryDate = requestExpiresAt != null ? requestExpiresAt : System.now().addHours(TOKEN_EXPIRATION_HOURS);
         cd.PreferencesNotifyOnVisit = false;
         cd.PreferencesAllowOriginalDownload = false;
         cd.PreferencesAllowPDFDownload = false;
@@ -1142,6 +1153,7 @@ public without sharing class DocGenSignatureController {
                 Signer_Name__c,
                 Signer_Email__c,
                 Signature_Request__c,
+                Signature_Request__r.Expires_At__c,
                 Role_Name__c,
                 Contact__c,
                 CreatedDate,
@@ -1158,7 +1170,7 @@ public without sharing class DocGenSignatureController {
         }
 
         DocGen_Signer__c signer = signers[0];
-        if (signer.CreatedDate.addHours(TOKEN_EXPIRATION_HOURS) < System.now()) {
+        if (DocGenSignatureExpiry.isExpired(signer.Signature_Request__r.Expires_At__c, signer.CreatedDate)) {
             throw new AuraHandledException('This signature link has expired.');
         }
         if (signer.Status__c == 'Signed') {
@@ -1795,6 +1807,7 @@ public without sharing class DocGenSignatureController {
                 Signer_Name__c,
                 Signer_Email__c,
                 Signature_Request__c,
+                Signature_Request__r.Expires_At__c,
                 Role_Name__c,
                 Contact__c,
                 CreatedDate
@@ -1811,7 +1824,7 @@ public without sharing class DocGenSignatureController {
         }
 
         DocGen_Signer__c signer = signers[0];
-        if (signer.CreatedDate.addHours(TOKEN_EXPIRATION_HOURS) < System.now()) {
+        if (DocGenSignatureExpiry.isExpired(signer.Signature_Request__r.Expires_At__c, signer.CreatedDate)) {
             result.put('success', false);
             result.put('message', 'This signature link has expired.');
             return result;
@@ -1945,7 +1958,7 @@ public without sharing class DocGenSignatureController {
         );
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
         List<DocGen_Signer__c> signers = [
-            SELECT Id, Signature_Request__c, CreatedDate, PIN_Verified_At__c
+            SELECT Id, Signature_Request__c, CreatedDate, PIN_Verified_At__c, Signature_Request__r.Expires_At__c
             FROM DocGen_Signer__c
             WHERE Secure_Token__c = :token
             WITH SYSTEM_MODE
@@ -1957,7 +1970,7 @@ public without sharing class DocGenSignatureController {
         }
 
         DocGen_Signer__c signer = signers[0];
-        if (signer.CreatedDate.addHours(TOKEN_EXPIRATION_HOURS) < System.now()) {
+        if (DocGenSignatureExpiry.isExpired(signer.Signature_Request__r.Expires_At__c, signer.CreatedDate)) {
             throw new AuraHandledException('This signature link has expired.');
         }
 
@@ -2034,7 +2047,13 @@ public without sharing class DocGenSignatureController {
         );
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
         List<DocGen_Signer__c> signers = [
-            SELECT Id, CreatedDate, PIN_Verified_At__c, Status__c, Signature_Request__c
+            SELECT
+                Id,
+                CreatedDate,
+                PIN_Verified_At__c,
+                Status__c,
+                Signature_Request__c,
+                Signature_Request__r.Expires_At__c
             FROM DocGen_Signer__c
             WHERE Secure_Token__c = :token
             WITH SYSTEM_MODE
@@ -2046,7 +2065,7 @@ public without sharing class DocGenSignatureController {
         }
 
         DocGen_Signer__c signer = signers[0];
-        if (signer.CreatedDate.addHours(TOKEN_EXPIRATION_HOURS) < System.now()) {
+        if (DocGenSignatureExpiry.isExpired(signer.Signature_Request__r.Expires_At__c, signer.CreatedDate)) {
             throw new AuraHandledException('This signature link has expired.');
         }
         if (requestRequiresVerification(signer.Signature_Request__c) && signer.PIN_Verified_At__c == null) {
@@ -2136,14 +2155,18 @@ public without sharing class DocGenSignatureController {
                 CreatedDate,
                 Signature_Request__c,
                 Signature_Request__r.Source_Document_Id__c,
-                Signature_Request__r.Template__c
+                Signature_Request__r.Template__c,
+                Signature_Request__r.Expires_At__c
             FROM DocGen_Signer__c
             WHERE Secure_Token__c = :token
             WITH SYSTEM_MODE
             LIMIT 1
         ];
 
-        if (signers.isEmpty() || signers[0].CreatedDate.addHours(TOKEN_EXPIRATION_HOURS) < System.now()) {
+        if (
+            signers.isEmpty() ||
+            DocGenSignatureExpiry.isExpired(signers[0].Signature_Request__r.Expires_At__c, signers[0].CreatedDate)
+        ) {
             result.put('error', 'Invalid or expired token');
             return result;
         }
@@ -2312,14 +2335,17 @@ public without sharing class DocGenSignatureController {
         );
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
         List<DocGen_Signer__c> signers = [
-            SELECT Id, CreatedDate, Signature_Request__r.Source_Document_Id__c
+            SELECT Id, CreatedDate, Signature_Request__r.Source_Document_Id__c, Signature_Request__r.Expires_At__c
             FROM DocGen_Signer__c
             WHERE Secure_Token__c = :token
             WITH SYSTEM_MODE
             LIMIT 1
         ];
 
-        if (signers.isEmpty() || signers[0].CreatedDate.addHours(TOKEN_EXPIRATION_HOURS) < System.now()) {
+        if (
+            signers.isEmpty() ||
+            DocGenSignatureExpiry.isExpired(signers[0].Signature_Request__r.Expires_At__c, signers[0].CreatedDate)
+        ) {
             result.put('error', 'Invalid or expired token');
             return result;
         }
@@ -2420,6 +2446,7 @@ public without sharing class DocGenSignatureController {
                 Signer_Name__c,
                 Signer_Email__c,
                 Signature_Request__c,
+                Signature_Request__r.Expires_At__c,
                 Role_Name__c,
                 Contact__c,
                 CreatedDate,
@@ -2436,7 +2463,7 @@ public without sharing class DocGenSignatureController {
         }
 
         DocGen_Signer__c signer = signers[0];
-        if (signer.CreatedDate.addHours(TOKEN_EXPIRATION_HOURS) < System.now()) {
+        if (DocGenSignatureExpiry.isExpired(signer.Signature_Request__r.Expires_At__c, signer.CreatedDate)) {
             throw new AuraHandledException('This signature link has expired.');
         }
         if (signer.Status__c == 'Signed') {
@@ -2631,6 +2658,7 @@ public without sharing class DocGenSignatureController {
                 Signature_Request__r.Related_Record_Id__c,
                 Signature_Request__r.Template__r.Name,
                 Signature_Request__r.Document_Title_Format__c,
+                Signature_Request__r.Expires_At__c,
                 Role_Name__c,
                 Contact__c,
                 CreatedDate,
@@ -2646,7 +2674,7 @@ public without sharing class DocGenSignatureController {
         }
 
         DocGen_Signer__c signer = signers[0];
-        if (signer.CreatedDate.addHours(TOKEN_EXPIRATION_HOURS) < System.now()) {
+        if (DocGenSignatureExpiry.isExpired(signer.Signature_Request__r.Expires_At__c, signer.CreatedDate)) {
             throw new AuraHandledException('This signature link has expired.');
         }
         if (signer.Status__c == 'Signed') {

--- a/force-app/main/default/classes/DocGenSignatureEmailService.cls
+++ b/force-app/main/default/classes/DocGenSignatureEmailService.cls
@@ -103,6 +103,27 @@ public with sharing class DocGenSignatureEmailService {
         return reqs[0].Template__r.Default_Email_Message__c;
     }
 
+    /**
+     * The request's stamped Expires_At__c, or null (legacy request / no requestId).
+     * FLS-guard + SYSTEM_MODE (internal config read; USER_MODE on a new packaged
+     * field breaks the namespaced build and guest senders lack request read).
+     */
+    private static Datetime requestExpiresAt(Id requestId) {
+        if (requestId == null) {
+            return null;
+        }
+        DocGenFlsGuard.assertAccessible(DocGen_Signature_Request__c.sObjectType, new Set<String>{ 'Expires_At__c' });
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<DocGen_Signature_Request__c> reqs = [
+            SELECT Expires_At__c
+            FROM DocGen_Signature_Request__c
+            WHERE Id = :requestId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        return reqs.isEmpty() ? null : reqs[0].Expires_At__c;
+    }
+
     private static void sendRequestLikeEmails(
         List<SignerEmail> signers,
         String documentTitle,
@@ -129,6 +150,10 @@ public with sharing class DocGenSignatureEmailService {
             return;
         }
 
+        // {ExpirationHours} reflects the request's actual signing window (stamped
+        // Expires_At__c, or the legacy 48h when no requestId / no stamp).
+        String expirationHours = String.valueOf(DocGenSignatureExpiry.effectiveHours(requestExpiresAt(requestId)));
+
         String defaultMessage = DocGenEmailTemplateService.defaultMessage(templateType);
         // #208 — when the sender supplied no message, a Default_Email_Message__c on
         // the request's document template beats the generic type default. A send-time
@@ -149,7 +174,7 @@ public with sharing class DocGenSignatureEmailService {
                 'DocumentTitle' => documentTitle,
                 'SenderName' => senderName,
                 'SignatureUrl' => signer.signatureUrl,
-                'ExpirationHours' => '48',
+                'ExpirationHours' => expirationHours,
                 'Message' => defaultMessage
             };
             DocGenEmailTemplateService.RenderedEmail rendered = DocGenEmailTemplateService.render(

--- a/force-app/main/default/classes/DocGenSignatureExpiry.cls
+++ b/force-app/main/default/classes/DocGenSignatureExpiry.cls
@@ -1,0 +1,71 @@
+/**
+ * Single source of truth for signature-link expiration.
+ *
+ * Requests stamp Expires_At__c at send/resend time (org default from
+ * DocGen_Settings__c.Signature_Expiration_Days__c, or a per-send override).
+ * Enforcement everywhere goes through isExpired(). Requests created before the
+ * field existed have a null Expires_At__c and keep the legacy 48-hour lifetime
+ * from CreatedDate — deliberately NOT the new setting, so upgrading the package
+ * never silently shortens or lengthens in-flight links.
+ */
+public with sharing class DocGenSignatureExpiry {
+    /** Pre-Expires_At__c requests live this long from CreatedDate. Do not change. */
+    @TestVisible
+    private static final Integer LEGACY_EXPIRATION_HOURS = 48;
+
+    private static final Integer DEFAULT_DAYS = 2;
+    private static final Integer MAX_DAYS = 365;
+
+    /** Org default from settings, clamped to 1–365; 2 days when unset. */
+    public static Integer defaultDays() {
+        DocGen_Settings__c s = DocGen_Settings__c.getOrgDefaults();
+        Decimal configured = s != null ? s.Signature_Expiration_Days__c : null;
+        if (configured == null || configured < 1 || configured > MAX_DAYS) {
+            return DEFAULT_DAYS;
+        }
+        return configured.intValue();
+    }
+
+    public static Integer defaultHours() {
+        return defaultDays() * 24;
+    }
+
+    /**
+     * Expiry timestamp for a request being sent now. overrideDays (per-send /
+     * Flow input) wins when valid; otherwise the org default applies.
+     */
+    public static Datetime computeExpiry(Integer overrideDays) {
+        Integer days = (overrideDays != null &&
+            overrideDays >= 1 &&
+            overrideDays <= MAX_DAYS)
+            ? overrideDays
+            : defaultDays();
+        return System.now().addHours(days * 24);
+    }
+
+    /**
+     * The one expiration check. Pass the request's stamped Expires_At__c and the
+     * record's CreatedDate (request or signer — signers are created with their
+     * request, so either works for the legacy fallback).
+     */
+    public static Boolean isExpired(Datetime expiresAt, Datetime createdDate) {
+        if (expiresAt != null) {
+            return expiresAt < System.now();
+        }
+        return createdDate != null && createdDate.addHours(LEGACY_EXPIRATION_HOURS) < System.now();
+    }
+
+    /**
+     * Whole-hours lifetime for the {ExpirationHours} email token: hours from now
+     * until expiresAt (minimum 1 so a nearly-expired link never says "0 hours"),
+     * or the legacy 48 when no stamp exists.
+     */
+    public static Integer effectiveHours(Datetime expiresAt) {
+        if (expiresAt == null) {
+            return LEGACY_EXPIRATION_HOURS;
+        }
+        Long msLeft = expiresAt.getTime() - System.now().getTime();
+        Integer hours = (Integer) (msLeft / (1000 * 60 * 60));
+        return hours < 1 ? 1 : hours;
+    }
+}

--- a/force-app/main/default/classes/DocGenSignatureExpiry.cls-meta.xml
+++ b/force-app/main/default/classes/DocGenSignatureExpiry.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DocGenSignatureFlowAction.cls
+++ b/force-app/main/default/classes/DocGenSignatureFlowAction.cls
@@ -163,6 +163,12 @@ global with sharing class DocGenSignatureFlowAction { // NOPMD AvoidGlobalModifi
             description='Optional. TRUE auto-sends the verification code to the known signer email (skips the type-your-email step); FALSE makes the signer type it. Leave blank to inherit the template/org default.'
         )
         global Boolean prefillSignerEmail;
+
+        @InvocableVariable(
+            label='Link Expiration (Days)'
+            description='Optional. Signing links for this request expire this many days after send (1-365). Leave blank to use the org default from DocGen Settings.'
+        )
+        global Integer expirationDays;
     }
 
     global class Result {
@@ -174,7 +180,7 @@ global with sharing class DocGenSignatureFlowAction { // NOPMD AvoidGlobalModifi
 
         @InvocableVariable(
             label='Signer URLs'
-            description='A collection of unique signing URLs — one per signer, in the same order as the Signers input. Each URL is valid for 48 hours. Use these in Send Email actions, Slack posts, or custom notifications.'
+            description='A collection of unique signing URLs — one per signer, in the same order as the Signers input. Each URL is valid until the request expires (org default or the Link Expiration input). Use these in Send Email actions, Slack posts, or custom notifications.'
         )
         global List<String> signerUrls;
 
@@ -287,7 +293,8 @@ global with sharing class DocGenSignatureFlowAction { // NOPMD AvoidGlobalModifi
                 req.emailSubject, // #193 — optional send-time custom subject
                 req.requireEmailVerification, // #verification — null = inherit template/org
                 req.prefillSignerEmail,
-                req.sendEmails // #195 — false suppresses DocGen's invites (Flow sends its own)
+                req.sendEmails, // #195 — false suppresses DocGen's invites (Flow sends its own)
+                req.expirationDays // null = org-default signing window
             );
 
             // Find the request ID

--- a/force-app/main/default/classes/DocGenSignatureFlowActionTest.cls
+++ b/force-app/main/default/classes/DocGenSignatureFlowActionTest.cls
@@ -477,4 +477,29 @@ private class DocGenSignatureFlowActionTest {
         Test.stopTest();
         System.assert(caught, 'Blank email in signerRecords must throw');
     }
+
+    @isTest
+    static void testGenerate_expirationDaysStampsWindow() {
+        DocGenSignatureFlowAction.Request req = buildRequest();
+        req.expirationDays = 7;
+
+        Test.startTest();
+        List<DocGenSignatureFlowAction.Result> results = DocGenSignatureFlowAction.generate(
+            new List<DocGenSignatureFlowAction.Request>{ req }
+        );
+        Test.stopTest();
+
+        System.assertEquals(true, results[0].success, 'Send should succeed: ' + results[0].errorMessage);
+        DocGen_Signature_Request__c created = [
+            SELECT Expires_At__c
+            FROM DocGen_Signature_Request__c
+            WHERE Id = :results[0].signatureRequestId
+        ];
+        System.assertNotEquals(null, created.Expires_At__c, 'Expiration must be stamped at send');
+        Long deltaMs = created.Expires_At__c.getTime() - System.now().addDays(7).getTime();
+        System.assert(
+            Math.abs(deltaMs) < 5 * 60 * 1000,
+            'Link Expiration input must set a ~7-day window; delta ms=' + deltaMs
+        );
+    }
 }

--- a/force-app/main/default/classes/DocGenSignatureReminderSchedulable.cls
+++ b/force-app/main/default/classes/DocGenSignatureReminderSchedulable.cls
@@ -1,7 +1,14 @@
 /**
  * Schedulable class that sends reminder emails to pending signers.
- * Runs on a schedule (e.g., hourly) and checks for signers who haven't
- * responded within the configured reminder threshold.
+ * Runs on a schedule (e.g., hourly) and checks each pending signer against the
+ * org-wide reminder schedule (DocGen_Settings__c.Signature_Reminder_Schedule__c,
+ * CSV of hour offsets after send, e.g. "24,72,168"). A blank schedule falls back
+ * to the legacy single reminder driven by Signature_Reminder_Hours__c.
+ *
+ * Per-signer progress is tracked in Reminders_Sent__c (count of schedule entries
+ * consumed). Missed offsets — e.g. the job was paused for a week — collapse into
+ * ONE catch-up reminder rather than a burst: reminders are nags, not an audit
+ * trail, and bursting risks the org's daily email limit.
  *
  * Schedule via: System.schedule('DocGen Signature Reminders', '0 0 * * * ?', new DocGenSignatureReminderSchedulable());
  */
@@ -17,17 +24,15 @@ public with sharing class DocGenSignatureReminderSchedulable implements Schedula
         if (settings.Signature_Reminder_Enabled__c != true)
             return;
 
-        Integer reminderHours = settings.Signature_Reminder_Hours__c != null
-            ? Integer.valueOf(settings.Signature_Reminder_Hours__c)
-            : 24;
-        if (reminderHours <= 0)
+        List<Integer> offsets = parseSchedule(settings);
+        if (offsets.isEmpty())
             return;
 
-        DateTime threshold = testThresholdOverride != null
-            ? testThresholdOverride
-            : System.now().addHours(-reminderHours);
+        DateTime threshold = testThresholdOverride != null ? testThresholdOverride : System.now().addHours(-offsets[0]);
 
-        // Find pending signers created before the threshold who haven't been reminded yet
+        // Pending signers old enough for the first offset who haven't consumed the
+        // whole schedule yet. Legacy signers reminded before Reminders_Sent__c
+        // existed have it null — they're seeded from Reminder_Sent_At__c below.
         // v2.0.1 — per-field FLS enforcement on SOQL reads (the "Apex SOQL
         // USER_MODE Missing" finding category). DocGenFlsGuard.assertAccessible
         // calls Schema.SObjectField.getDescribe().isAccessible() on every field
@@ -44,11 +49,17 @@ public with sharing class DocGenSignatureReminderSchedulable implements Schedula
                 'Secure_Token__c',
                 'Contact__c',
                 'Reminder_Sent_At__c',
+                'Reminders_Sent__c',
                 'CreatedDate',
                 'Signature_Request__c',
                 'Status__c'
             }
         );
+        DocGenFlsGuard.assertAccessible(
+            DocGen_Signature_Request__c.sObjectType,
+            new Set<String>{ 'Status__c', 'Expires_At__c', 'Render_Data_Snapshot__c', 'Source_Document_Id__c' }
+        );
+        Integer scheduleSize = offsets.size();
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
         List<DocGen_Signer__c> pendingSigners = [
             SELECT
@@ -59,16 +70,21 @@ public with sharing class DocGenSignatureReminderSchedulable implements Schedula
                 Secure_Token__c,
                 Contact__c,
                 Reminder_Sent_At__c,
+                Reminders_Sent__c,
                 CreatedDate,
                 Signature_Request__c,
                 Signature_Request__r.Status__c,
+                Signature_Request__r.Expires_At__c,
+                Signature_Request__r.Render_Data_Snapshot__c,
+                Signature_Request__r.Source_Document_Id__c,
                 Signature_Request__r.Template__c,
                 Signature_Request__r.Template__r.Name
             FROM DocGen_Signer__c
             WHERE
                 Status__c IN ('Pending', 'Viewed')
                 AND CreatedDate < :threshold
-                AND Reminder_Sent_At__c = NULL
+                AND (Reminders_Sent__c = NULL
+                OR Reminders_Sent__c < :scheduleSize)
                 AND Signature_Request__r.Status__c NOT IN ('Signed', 'Cancelled', 'Declined')
             WITH SYSTEM_MODE
             LIMIT 200
@@ -78,18 +94,29 @@ public with sharing class DocGenSignatureReminderSchedulable implements Schedula
             return;
 
         String siteUrl = DocGenSignatureSenderController.getSiteBaseUrl();
-        String sigPagePath = DocGenSignatureSenderController.getSigningPagePath();
 
         List<DocGenSignatureEmailService.SignerEmail> emailList = new List<DocGenSignatureEmailService.SignerEmail>();
+        List<DocGen_Signer__c> signersToUpdate = new List<DocGen_Signer__c>();
         for (DocGen_Signer__c s : pendingSigners) {
-            // Skip if token is expired (48 hours)
-            if (s.CreatedDate.addHours(48) < System.now())
+            // Skip expired signing windows (stamped Expires_At__c, or legacy 48h)
+            if (DocGenSignatureExpiry.isExpired(s.Signature_Request__r.Expires_At__c, s.CreatedDate))
                 continue;
 
+            Integer dueCount = countDueOffsets(offsets, s.CreatedDate);
+            // Tests inject testThresholdOverride to make just-created signers due.
+            if (testThresholdOverride != null && dueCount == 0)
+                dueCount = 1;
+            // Legacy seed: reminded once before Reminders_Sent__c existed.
+            Integer sentCount = s.Reminders_Sent__c != null
+                ? Integer.valueOf(s.Reminders_Sent__c)
+                : (s.Reminder_Sent_At__c != null ? 1 : 0);
+            if (dueCount <= sentCount)
+                continue;
+
+            // Guided-PDF requests must be reminded with the PDF signing page, the
+            // classic typed-name flow with the legacy page (same routing as resend).
+            String sigPagePath = DocGenSignatureSenderController.resolveSigningPath(s.Signature_Request__r);
             String sigUrl = siteUrl + sigPagePath + '?token=' + s.Secure_Token__c;
-            String docTitle = s.Signature_Request__r.Template__r != null
-                ? s.Signature_Request__r.Template__r.Name
-                : 'Document';
 
             emailList.add(
                 new DocGenSignatureEmailService.SignerEmail(
@@ -102,6 +129,8 @@ public with sharing class DocGenSignatureReminderSchedulable implements Schedula
             );
 
             s.Reminder_Sent_At__c = System.now();
+            s.Reminders_Sent__c = dueCount;
+            signersToUpdate.add(s);
         }
 
         if (!emailList.isEmpty()) {
@@ -112,9 +141,60 @@ public with sharing class DocGenSignatureReminderSchedulable implements Schedula
             );
 
             // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Update").
-            DocGenFlsGuard.assertUpdateable(pendingSigners, new Set<String>{ 'Reminder_Sent_At__c' });
+            DocGenFlsGuard.assertUpdateable(
+                signersToUpdate,
+                new Set<String>{ 'Reminder_Sent_At__c', 'Reminders_Sent__c' }
+            );
             /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
-            Database.update(pendingSigners, false, AccessLevel.SYSTEM_MODE);
+            Database.update(signersToUpdate, false, AccessLevel.SYSTEM_MODE);
         }
+    }
+
+    /**
+     * Sorted hour offsets from Signature_Reminder_Schedule__c ("24,72,168").
+     * Blank or unparseable → single-entry legacy schedule from
+     * Signature_Reminder_Hours__c (exactly the pre-schedule behavior: at most
+     * one reminder ever). Entries clamp to 1–8760 (a year); max 10.
+     */
+    @TestVisible
+    private static List<Integer> parseSchedule(DocGen_Settings__c settings) {
+        List<Integer> offsets = new List<Integer>();
+        String csv = settings.Signature_Reminder_Schedule__c;
+        if (String.isNotBlank(csv)) {
+            for (String part : csv.split(',')) {
+                String trimmed = part.trim();
+                if (trimmed.isNumeric()) {
+                    Integer hours = Integer.valueOf(trimmed);
+                    if (hours >= 1 && hours <= 8760) {
+                        offsets.add(hours);
+                    }
+                }
+            }
+        }
+        if (offsets.isEmpty()) {
+            Integer legacyHours = settings.Signature_Reminder_Hours__c != null
+                ? Integer.valueOf(settings.Signature_Reminder_Hours__c)
+                : 24;
+            if (legacyHours > 0) {
+                offsets.add(legacyHours);
+            }
+        }
+        offsets.sort();
+        while (offsets.size() > 10) {
+            offsets.remove(offsets.size() - 1);
+        }
+        return offsets;
+    }
+
+    /** How many schedule offsets have elapsed since the signer was created. */
+    private static Integer countDueOffsets(List<Integer> offsets, Datetime createdDate) {
+        Long elapsedHours = (System.now().getTime() - createdDate.getTime()) / (1000 * 60 * 60);
+        Integer due = 0;
+        for (Integer offsetHours : offsets) {
+            if (elapsedHours >= offsetHours) {
+                due++;
+            }
+        }
+        return due;
     }
 }

--- a/force-app/main/default/classes/DocGenSignatureSenderController.cls
+++ b/force-app/main/default/classes/DocGenSignatureSenderController.cls
@@ -627,6 +627,7 @@ public with sharing class DocGenSignatureSenderController {
         // post-signing verification link (?token=) printed on the certificate.
         // Distinct from signer signing tokens — this only gates audit-roster reads.
         req.Secure_Token__c = generateRequestVerificationToken();
+        req.Expires_At__c = DocGenSignatureExpiry.computeExpiry(null);
         // Package-internal object — CRUD controlled by DocGen permission sets
         // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Create").
         DocGenFlsGuard.assertCreateable(
@@ -637,7 +638,8 @@ public with sharing class DocGenSignatureSenderController {
                 'Status__c',
                 'Signing_Order__c',
                 'Document_Title_Format__c',
-                'Secure_Token__c'
+                'Secure_Token__c',
+                'Expires_At__c'
             }
         );
         /* code-analyzer-suppress ApexFlsViolation */
@@ -840,11 +842,12 @@ public with sharing class DocGenSignatureSenderController {
         req.Source_Document_Id__c = contentVersionId;
         req.Related_Record_Id__c = relatedRecordId;
         req.Status__c = 'Sent';
+        req.Expires_At__c = DocGenSignatureExpiry.computeExpiry(null);
         // Package-internal object — CRUD controlled by DocGen permission sets
         // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Create").
         DocGenFlsGuard.assertCreateable(
             req,
-            new Set<String>{ 'Source_Document_Id__c', 'Related_Record_Id__c', 'Status__c' }
+            new Set<String>{ 'Source_Document_Id__c', 'Related_Record_Id__c', 'Status__c', 'Expires_At__c' }
         );
         /* code-analyzer-suppress ApexFlsViolation */
         Database.insert(req, AccessLevel.SYSTEM_MODE);
@@ -1003,7 +1006,7 @@ public with sharing class DocGenSignatureSenderController {
         );
     }
 
-    /** 10-arg canonical — #195: see createGuidedPdfSignatureRequest. */
+    /** 10-arg overload — pre-expirationDays callers. */
     public static List<SignerResult> createTemplateSnapshotRequest(
         Id templateId,
         String relatedRecordId,
@@ -1015,6 +1018,35 @@ public with sharing class DocGenSignatureSenderController {
         Boolean requireVerification,
         Boolean prefillSignerEmail,
         Boolean sendEmails
+    ) {
+        return createTemplateSnapshotRequest(
+            templateId,
+            relatedRecordId,
+            signersJson,
+            signingOrder,
+            documentTitleFormat,
+            emailMessage,
+            emailSubject,
+            requireVerification,
+            prefillSignerEmail,
+            sendEmails,
+            null
+        );
+    }
+
+    /** 11-arg canonical — #195/expirationDays: see createGuidedPdfSignatureRequest. */
+    public static List<SignerResult> createTemplateSnapshotRequest(
+        Id templateId,
+        String relatedRecordId,
+        String signersJson,
+        String signingOrder,
+        String documentTitleFormat,
+        String emailMessage,
+        String emailSubject,
+        Boolean requireVerification,
+        Boolean prefillSignerEmail,
+        Boolean sendEmails,
+        Integer expirationDays
     ) {
         if (templateId == null) {
             throw new AuraHandledException('A template Id is required.');
@@ -1103,6 +1135,7 @@ public with sharing class DocGenSignatureSenderController {
         if (String.isNotBlank(documentTitleFormat)) {
             req.Document_Title_Format__c = documentTitleFormat;
         }
+        req.Expires_At__c = DocGenSignatureExpiry.computeExpiry(expirationDays);
         DocGenFlsGuard.assertCreateable(
             req,
             new Set<String>{
@@ -1112,7 +1145,8 @@ public with sharing class DocGenSignatureSenderController {
                 'Related_Record_Id__c',
                 'Status__c',
                 'Signing_Order__c',
-                'Document_Title_Format__c'
+                'Document_Title_Format__c',
+                'Expires_At__c'
             }
         );
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
@@ -1351,7 +1385,6 @@ public with sharing class DocGenSignatureSenderController {
         );
     }
 
-    @AuraEnabled
     public static List<SignerResult> createGuidedPdfSignatureRequest(
         Id templateId,
         String relatedRecordId,
@@ -1377,11 +1410,7 @@ public with sharing class DocGenSignatureSenderController {
         );
     }
 
-    /**
-     * 10-arg canonical — #195: sendEmails=false suppresses the branded invitation
-     * emails so a Flow can send its own using the returned signer URLs. null/true
-     * sends (the long-standing behavior; every pre-existing caller delegates null).
-     */
+    /** 10-arg overload — #195: pre-expirationDays callers. */
     public static List<SignerResult> createGuidedPdfSignatureRequest(
         Id templateId,
         String relatedRecordId,
@@ -1393,6 +1422,42 @@ public with sharing class DocGenSignatureSenderController {
         Boolean requireVerification,
         Boolean prefillSignerEmail,
         Boolean sendEmails
+    ) {
+        return createGuidedPdfSignatureRequest(
+            templateId,
+            relatedRecordId,
+            signersJson,
+            signingOrder,
+            documentTitleFormat,
+            emailMessage,
+            emailSubject,
+            requireVerification,
+            prefillSignerEmail,
+            sendEmails,
+            null
+        );
+    }
+
+    /**
+     * 11-arg canonical. sendEmails=false (#195) suppresses the branded invitation
+     * emails so a Flow can send its own using the returned signer URLs; null/true
+     * sends (the long-standing behavior; every pre-existing caller delegates null).
+     * expirationDays overrides the org-default signing window for this request
+     * (null → DocGen_Settings__c.Signature_Expiration_Days__c, fallback 2 days).
+     */
+    @AuraEnabled
+    public static List<SignerResult> createGuidedPdfSignatureRequest(
+        Id templateId,
+        String relatedRecordId,
+        String signersJson,
+        String signingOrder,
+        String documentTitleFormat,
+        String emailMessage,
+        String emailSubject,
+        Boolean requireVerification,
+        Boolean prefillSignerEmail,
+        Boolean sendEmails,
+        Integer expirationDays
     ) {
         List<DocGen_Template__c> tpls = [
             SELECT Id, Name, Document_Title_Format__c
@@ -1462,7 +1527,8 @@ public with sharing class DocGenSignatureSenderController {
                     emailSubject,
                     requireVerification,
                     prefillSignerEmail,
-                    sendEmails
+                    sendEmails,
+                    expirationDays
                 );
             }
         }
@@ -1557,6 +1623,7 @@ public with sharing class DocGenSignatureSenderController {
             req.Document_Title_Format__c = documentTitleFormat;
         }
         req.Secure_Token__c = generateRequestVerificationToken();
+        req.Expires_At__c = DocGenSignatureExpiry.computeExpiry(expirationDays);
         Set<String> reqFields = new Set<String>{
             'Template__c',
             'Related_Record_Id__c',
@@ -1564,7 +1631,8 @@ public with sharing class DocGenSignatureSenderController {
             'Status__c',
             'Signing_Order__c',
             'Document_Title_Format__c',
-            'Secure_Token__c'
+            'Secure_Token__c',
+            'Expires_At__c'
         };
         if (String.isNotBlank(frozenJson)) {
             // #156: snapshot persisted to a ContentVersion (no 131072-char cap) and referenced
@@ -1824,6 +1892,7 @@ public with sharing class DocGenSignatureSenderController {
             req.Document_Title_Format__c = documentTitleFormat;
         }
         req.Secure_Token__c = generateRequestVerificationToken();
+        req.Expires_At__c = DocGenSignatureExpiry.computeExpiry(null);
         Set<String> reqFields = new Set<String>{
             'Template__c',
             'Template_Ids__c',
@@ -1832,7 +1901,8 @@ public with sharing class DocGenSignatureSenderController {
             'Status__c',
             'Signing_Order__c',
             'Document_Title_Format__c',
-            'Secure_Token__c'
+            'Secure_Token__c',
+            'Expires_At__c'
         };
         if (String.isNotBlank(frozenJson)) {
             // #156: multi-document packet snapshot persisted to a ContentVersion (no size cap).
@@ -1956,6 +2026,7 @@ public with sharing class DocGenSignatureSenderController {
         req.Related_Record_Id__c = relatedRecordId;
         req.Secure_Token__c = token;
         req.Status__c = 'Sent';
+        req.Expires_At__c = DocGenSignatureExpiry.computeExpiry(null);
         // Package-internal object — CRUD controlled by DocGen permission sets
         // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Create").
         DocGenFlsGuard.assertCreateable(
@@ -1966,7 +2037,8 @@ public with sharing class DocGenSignatureSenderController {
                 'Source_Document_Id__c',
                 'Related_Record_Id__c',
                 'Secure_Token__c',
-                'Status__c'
+                'Status__c',
+                'Expires_At__c'
             }
         );
         /* code-analyzer-suppress ApexFlsViolation */
@@ -2847,23 +2919,25 @@ public with sharing class DocGenSignatureSenderController {
         /* code-analyzer-suppress ApexFlsViolation */
         Database.update(signers, false, AccessLevel.SYSTEM_MODE);
         req.Status__c = 'Sent';
+        // Resend opens a fresh signing window (org default) alongside the new tokens.
+        req.Expires_At__c = DocGenSignatureExpiry.computeExpiry(null);
         // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Update").
-        DocGenFlsGuard.assertUpdateable(req, new Set<String>{ 'Status__c' });
+        DocGenFlsGuard.assertUpdateable(req, new Set<String>{ 'Status__c', 'Expires_At__c' });
         /* code-analyzer-suppress ApexFlsViolation */
         Database.update(req, false, AccessLevel.SYSTEM_MODE);
 
-        DocGenSignatureEmailService.sendSignatureRequestEmails(emailList, documentTitle);
+        // requestId so {ExpirationHours} reflects the fresh signing window.
+        DocGenSignatureEmailService.sendSignatureRequestEmails(emailList, documentTitle, req.Id);
     }
 
     /**
      * PDF-viewer requests (snapshot re-render or send-existing-CV) set
      * Render_Data_Snapshot__c or Source_Document_Id__c; the classic typed-name
      * flow sets neither. Same predicate as the sequential-signer routing in
-     * DocGenSignaturePdfTrigger — resending with the legacy page path would
-     * email guided-PDF signers a broken link.
+     * DocGenSignaturePdfTrigger — resend and reminders with the legacy page path
+     * would email guided-PDF signers a broken link.
      */
-    @TestVisible
-    private static String resolveSigningPath(DocGen_Signature_Request__c req) {
+    public static String resolveSigningPath(DocGen_Signature_Request__c req) {
         Boolean isPdfViewer = req.Render_Data_Snapshot__c != null || req.Source_Document_Id__c != null;
         return isPdfViewer ? getSigningPdfPagePath() : getSigningPagePath();
     }

--- a/force-app/main/default/classes/DocGenSignatureService.cls
+++ b/force-app/main/default/classes/DocGenSignatureService.cls
@@ -1107,7 +1107,8 @@ public without sharing class DocGenSignatureService {
                 'Source_Document_Id__c',
                 'Related_Record_Id__c',
                 'CreatedDate',
-                'Secure_Token__c'
+                'Secure_Token__c',
+                'Expires_At__c'
             }
         );
         /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
@@ -1119,7 +1120,8 @@ public without sharing class DocGenSignatureService {
                 Signer_Email__c,
                 Source_Document_Id__c,
                 Related_Record_Id__c,
-                CreatedDate
+                CreatedDate,
+                Expires_At__c
             FROM DocGen_Signature_Request__c
             WHERE Secure_Token__c = :token
             WITH SYSTEM_MODE
@@ -1130,7 +1132,7 @@ public without sharing class DocGenSignatureService {
             return;
         }
 
-        if (requests[0].CreatedDate.addHours(48) < System.now()) {
+        if (DocGenSignatureExpiry.isExpired(requests[0].Expires_At__c, requests[0].CreatedDate)) {
             throw new SignatureException('This signature link has expired.');
         }
 

--- a/force-app/main/default/classes/DocGenSignatureTests.cls
+++ b/force-app/main/default/classes/DocGenSignatureTests.cls
@@ -3016,6 +3016,221 @@ private class DocGenSignatureTests {
         System.assertEquals('Pending', signer.Status__c);
     }
 
+    // =========================================================================
+    // DocGenSignatureExpiry — configurable signing window (stamped Expires_At__c,
+    // legacy 48h fallback for pre-upgrade requests)
+    // =========================================================================
+
+    @isTest
+    static void testSignatureExpiry_isExpiredMatrix() {
+        System.assert(
+            !DocGenSignatureExpiry.isExpired(System.now().addDays(1), System.now().addDays(-30)),
+            'Future stamp is not expired even when created long ago'
+        );
+        System.assert(
+            DocGenSignatureExpiry.isExpired(System.now().addMinutes(-1), System.now()),
+            'Past stamp is expired even when freshly created'
+        );
+        System.assert(
+            !DocGenSignatureExpiry.isExpired(null, System.now().addHours(-47)),
+            'Legacy request 47h old is still valid'
+        );
+        System.assert(
+            DocGenSignatureExpiry.isExpired(null, System.now().addHours(-49)),
+            'Legacy request 49h old is expired (48h window must NOT follow the new setting)'
+        );
+        System.assertEquals(48, DocGenSignatureExpiry.effectiveHours(null), 'Legacy email token stays 48');
+        System.assertEquals(
+            1,
+            DocGenSignatureExpiry.effectiveHours(System.now().addMinutes(30)),
+            'Nearly-expired link floors at 1 hour'
+        );
+    }
+
+    @isTest
+    static void testSignatureExpiry_defaultsAndOverride() {
+        System.assertEquals(2, DocGenSignatureExpiry.defaultDays(), 'Unset setting falls back to 2 days');
+
+        DocGen_Settings__c s = DocGen_Settings__c.getOrgDefaults();
+        s.Signature_Expiration_Days__c = 30;
+        upsert s;
+        System.assertEquals(30, DocGenSignatureExpiry.defaultDays());
+        System.assertEquals(720, DocGenSignatureExpiry.defaultHours());
+
+        Datetime fromOverride = DocGenSignatureExpiry.computeExpiry(7);
+        Long deltaMs = fromOverride.getTime() - System.now().addDays(7).getTime();
+        System.assert(Math.abs(deltaMs) < 60000, 'Override wins over the 30-day org default; delta=' + deltaMs);
+
+        Datetime fromDefault = DocGenSignatureExpiry.computeExpiry(null);
+        deltaMs = fromDefault.getTime() - System.now().addDays(30).getTime();
+        System.assert(Math.abs(deltaMs) < 60000, 'Null override uses the org default; delta=' + deltaMs);
+    }
+
+    @isTest
+    static void testValidateToken_expiredStampRejectsFreshRequest() {
+        // Past Expires_At__c on a freshly-created request must reject the link —
+        // proves the stamped field is authoritative over CreatedDate+48h.
+        DocGen_Signer__c signer = getTestSigner();
+        DocGen_Signature_Request__c req = new DocGen_Signature_Request__c(
+            Id = signer.Signature_Request__c,
+            Expires_At__c = System.now().addMinutes(-5)
+        );
+        Database.update(req, AccessLevel.SYSTEM_MODE);
+
+        Test.startTest();
+        DocGenSignatureController.SignatureInitResponse res = DocGenSignatureController.validateToken(
+            signer.Secure_Token__c
+        );
+        Test.stopTest();
+
+        System.assertEquals(false, res.isValid, 'Expired stamp must invalidate the link');
+        System.assert(
+            res.errorMessage != null && res.errorMessage.containsIgnoreCase('expired'),
+            'Error should say expired; got: ' + res.errorMessage
+        );
+    }
+
+    @isTest
+    static void testReminderSchedulable_multiSchedule_sendsOncePerDueOffset() {
+        DocGen_Settings__c s = DocGen_Settings__c.getOrgDefaults();
+        s.Signature_Reminder_Enabled__c = true;
+        s.Signature_Reminder_Hours__c = 24;
+        s.Signature_Reminder_Schedule__c = '24,72';
+        s.Experience_Site_Url__c = 'https://test.salesforce-sites.com';
+        upsert s;
+
+        DocGen_Signer__c signer = getTestSigner();
+        DocGen_Signature_Request__c req = new DocGen_Signature_Request__c(
+            Id = signer.Signature_Request__c,
+            Status__c = 'Sent'
+        );
+        Database.update(req, AccessLevel.SYSTEM_MODE);
+        DocGenSignatureReminderSchedulable.testThresholdOverride = System.now().addDays(1);
+
+        Test.startTest();
+        new DocGenSignatureReminderSchedulable().execute(null);
+        Test.stopTest();
+
+        DocGen_Signer__c updated = [
+            SELECT Reminders_Sent__c, Reminder_Sent_At__c
+            FROM DocGen_Signer__c
+            WHERE Id = :signer.Id
+        ];
+        System.assertEquals(1, updated.Reminders_Sent__c, 'First due offset consumed');
+        System.assertNotEquals(null, updated.Reminder_Sent_At__c);
+
+        // Immediate second run: no additional offset has elapsed → no re-send.
+        new DocGenSignatureReminderSchedulable().execute(null);
+        updated = [SELECT Reminders_Sent__c FROM DocGen_Signer__c WHERE Id = :signer.Id];
+        System.assertEquals(1, updated.Reminders_Sent__c, 'No repeat send until the next offset elapses');
+    }
+
+    @isTest
+    static void testReminderSchedulable_legacySeedPreventsDoubleReminder() {
+        // A signer reminded before Reminders_Sent__c existed (Reminder_Sent_At__c set,
+        // count null) must NOT be re-reminded under the legacy single-entry schedule.
+        DocGen_Settings__c s = DocGen_Settings__c.getOrgDefaults();
+        s.Signature_Reminder_Enabled__c = true;
+        s.Signature_Reminder_Hours__c = 24;
+        s.Signature_Reminder_Schedule__c = null;
+        s.Experience_Site_Url__c = 'https://test.salesforce-sites.com';
+        upsert s;
+
+        DocGen_Signer__c signer = getTestSigner();
+        signer.Reminder_Sent_At__c = System.now().addHours(-1);
+        signer.Reminders_Sent__c = null;
+        Database.update(signer, AccessLevel.SYSTEM_MODE);
+        DocGen_Signature_Request__c req = new DocGen_Signature_Request__c(
+            Id = signer.Signature_Request__c,
+            Status__c = 'Sent'
+        );
+        Database.update(req, AccessLevel.SYSTEM_MODE);
+        DocGenSignatureReminderSchedulable.testThresholdOverride = System.now().addDays(1);
+
+        Test.startTest();
+        new DocGenSignatureReminderSchedulable().execute(null);
+        Test.stopTest();
+
+        DocGen_Signer__c updated = [
+            SELECT Reminders_Sent__c
+            FROM DocGen_Signer__c
+            WHERE Id = :signer.Id
+        ];
+        System.assertEquals(null, updated.Reminders_Sent__c, 'Seeded legacy signer is not re-reminded');
+    }
+
+    @isTest
+    static void testReminderSchedulable_skipsExpiredRequests() {
+        DocGen_Settings__c s = DocGen_Settings__c.getOrgDefaults();
+        s.Signature_Reminder_Enabled__c = true;
+        s.Signature_Reminder_Hours__c = 24;
+        s.Experience_Site_Url__c = 'https://test.salesforce-sites.com';
+        upsert s;
+
+        DocGen_Signer__c signer = getTestSigner();
+        DocGen_Signature_Request__c req = new DocGen_Signature_Request__c(
+            Id = signer.Signature_Request__c,
+            Status__c = 'Sent',
+            Expires_At__c = System.now().addMinutes(-5)
+        );
+        Database.update(req, AccessLevel.SYSTEM_MODE);
+        DocGenSignatureReminderSchedulable.testThresholdOverride = System.now().addDays(1);
+
+        Test.startTest();
+        new DocGenSignatureReminderSchedulable().execute(null);
+        Test.stopTest();
+
+        DocGen_Signer__c updated = [SELECT Reminder_Sent_At__c FROM DocGen_Signer__c WHERE Id = :signer.Id];
+        System.assertEquals(null, updated.Reminder_Sent_At__c, 'No reminders past the signing window');
+    }
+
+    @isTest
+    static void testReminderSchedule_parsing() {
+        DocGen_Settings__c s = new DocGen_Settings__c(
+            Signature_Reminder_Schedule__c = ' 72, 24, 9999999,junk ',
+            Signature_Reminder_Hours__c = 12
+        );
+        List<Integer> offsets = DocGenSignatureReminderSchedulable.parseSchedule(s);
+        System.assertEquals(new List<Integer>{ 24, 72 }, offsets, 'Sorted; out-of-range and junk dropped');
+
+        s.Signature_Reminder_Schedule__c = null;
+        System.assertEquals(
+            new List<Integer>{ 12 },
+            DocGenSignatureReminderSchedulable.parseSchedule(s),
+            'Blank schedule falls back to the legacy single reminder'
+        );
+    }
+
+    @isTest
+    static void testResendSignatureRequest_restampsExpiry() {
+        Account acc = [SELECT Id FROM Account LIMIT 1];
+        DocGen_Signature_Request__c req = new DocGen_Signature_Request__c(
+            Related_Record_Id__c = acc.Id,
+            Status__c = 'Sent',
+            Expires_At__c = System.now().addMinutes(-10)
+        );
+        Database.insert(req, AccessLevel.SYSTEM_MODE);
+        DocGen_Signer__c signer = new DocGen_Signer__c(
+            Signature_Request__c = req.Id,
+            Signer_Name__c = 'Restamp Signer',
+            Signer_Email__c = 'restamp@test.com',
+            Secure_Token__c = 'ddaa333333333333333333333333333333333333333333333333333333333333',
+            Status__c = 'Pending',
+            Sort_Order__c = 1
+        );
+        Database.insert(signer, AccessLevel.SYSTEM_MODE);
+
+        Test.startTest();
+        DocGenSignatureSenderController.resendSignatureRequest(req.Id);
+        Test.stopTest();
+
+        req = [SELECT Expires_At__c FROM DocGen_Signature_Request__c WHERE Id = :req.Id];
+        System.assert(
+            req.Expires_At__c != null && req.Expires_At__c > System.now(),
+            'Resend must open a fresh signing window; got ' + req.Expires_At__c
+        );
+    }
+
     @isTest
     static void testResolveSigningPath_routesGuidedRequestsToPdfPage() {
         // Guided-PDF requests (snapshot or source-doc) must resend links to the

--- a/force-app/main/default/lwc/docGenSignatureSender/docGenSignatureSender.html
+++ b/force-app/main/default/lwc/docGenSignatureSender/docGenSignatureSender.html
@@ -140,6 +140,19 @@
             <template if:true={isSingleTemplate}>
                 <div class="slds-var-m-bottom_medium">
                     <lightning-input
+                        type="number"
+                        name="expirationDays"
+                        label="Link Expiration in Days (optional)"
+                        field-level-help="How many days the signing links stay valid for this request. Leave blank to use the org default from DocGen Signature Settings."
+                        placeholder="Org default"
+                        value={expirationDays}
+                        min="1"
+                        max="365"
+                        onchange={handleExpirationDaysChange}
+                    ></lightning-input>
+                </div>
+                <div class="slds-var-m-bottom_medium">
+                    <lightning-input
                         type="text"
                         name="emailSubject"
                         label="Custom Email Subject (optional)"

--- a/force-app/main/default/lwc/docGenSignatureSender/docGenSignatureSender.js
+++ b/force-app/main/default/lwc/docGenSignatureSender/docGenSignatureSender.js
@@ -42,6 +42,7 @@ export default class DocGenSignatureSender extends NavigationMixin(LightningElem
     // #verification — per-send overrides ('Inherit' falls back to template/org default)
     @track verificationOverride = 'Inherit';
     @track prefillOverride = 'Inherit';
+    @track expirationDays = null; // per-send signing-window override (blank = org default)
 
     // Signers
     @track signers = [];
@@ -258,6 +259,10 @@ export default class DocGenSignatureSender extends NavigationMixin(LightningElem
 
     handleEmailSubjectChange(event) {
         this.emailSubject = event.detail.value || '';
+    }
+
+    handleExpirationDaysChange(event) {
+        this.expirationDays = event.detail.value;
     }
 
     // --- Template Selection ---
@@ -642,7 +647,8 @@ export default class DocGenSignatureSender extends NavigationMixin(LightningElem
                     emailMessage: (this.emailMessage || '').trim() || null,
                     emailSubject: (this.emailSubject || '').trim() || null,
                     requireVerification: this.requireVerificationValue,
-                    prefillSignerEmail: this.prefillValue
+                    prefillSignerEmail: this.prefillValue,
+                    expirationDays: parseInt(this.expirationDays, 10) || null
                 });
             } else {
                 const templateIds = this.selectedTemplates.map((t) => t.templateId);

--- a/force-app/main/default/lwc/docGenSignatureSettings/docGenSignatureSettings.html
+++ b/force-app/main/default/lwc/docGenSignatureSettings/docGenSignatureSettings.html
@@ -150,6 +150,25 @@
                      subject/body/branding + live preview). Org-wide fallback values are
                      preserved on save below but no longer edited here. -->
 
+                <!-- ===== SIGNING LINKS ===== -->
+                <div class="slds-section slds-is-open slds-m-top_medium">
+                    <h3 class="slds-section__title slds-theme_shade slds-p-around_x-small">
+                        <span class="slds-text-title_caps">Signing Links</span>
+                    </h3>
+                    <div class="slds-section__content slds-p-top_small">
+                        <lightning-input
+                            type="number"
+                            label="Link expiration (days)"
+                            value={expirationDays}
+                            min="1"
+                            max="365"
+                            onchange={handleExpirationDaysChange}
+                            field-level-help="Signing links expire this many days after send. Individual sends and the Flow action can override this per request."
+                        >
+                        </lightning-input>
+                    </div>
+                </div>
+
                 <!-- ===== REMINDERS ===== -->
                 <div class="slds-section slds-is-open slds-m-top_medium">
                     <h3 class="slds-section__title slds-theme_shade slds-p-around_x-small">
@@ -167,13 +186,13 @@
                         </lightning-input>
                         <template if:true={reminderEnabled}>
                             <lightning-input
-                                type="number"
-                                label="Send reminder after (hours)"
-                                value={reminderHours}
-                                min="1"
-                                max="168"
-                                onchange={handleReminderHoursChange}
-                                field-level-help="Signers who haven't responded within this many hours will receive a reminder email. Each signer gets at most one reminder."
+                                type="text"
+                                label="Send reminders after (hours, comma-separated)"
+                                value={reminderSchedule}
+                                pattern="^\s*\d+\s*(,\s*\d+\s*)*$"
+                                message-when-pattern-mismatch="Enter hour offsets separated by commas, e.g. 24, 72, 168"
+                                onchange={handleReminderScheduleChange}
+                                field-level-help="Each entry is hours after send: 24, 72, 168 reminds pending signers after 1, 3 and 7 days. A single entry sends at most one reminder. Reminders stop once the link expires."
                                 class="slds-m-top_small"
                             >
                             </lightning-input>

--- a/force-app/main/default/lwc/docGenSignatureSettings/docGenSignatureSettings.js
+++ b/force-app/main/default/lwc/docGenSignatureSettings/docGenSignatureSettings.js
@@ -23,9 +23,11 @@ export default class DocGenSignatureSettings extends LightningElement {
     @track owaId = '';
     @track owaOptions = [];
 
-    // Reminders
+    // Reminders + link expiration
     @track reminderEnabled = false;
     @track reminderHours = 24;
+    @track reminderSchedule = '24';
+    @track expirationDays = 2;
 
     // #verification — org defaults
     @track requireVerification = true;
@@ -53,6 +55,8 @@ export default class DocGenSignatureSettings extends LightningElement {
             this.owaId = data.Signature_OWA_Id__c || '';
             this.reminderEnabled = data.Signature_Reminder_Enabled__c === true;
             this.reminderHours = data.Signature_Reminder_Hours__c || 24;
+            this.reminderSchedule = data.Signature_Reminder_Schedule__c || String(this.reminderHours);
+            this.expirationDays = data.Signature_Expiration_Days__c || 2;
             // null → required (upgrade-safe default)
             this.requireVerification = data.Signature_Require_Email_Verification__c !== false;
             this.prefillEmail = data.Signature_Prefill_Signer_Email__c === true;
@@ -91,6 +95,12 @@ export default class DocGenSignatureSettings extends LightningElement {
     handleReminderHoursChange(e) {
         this.reminderHours = e.target.value;
     }
+    handleReminderScheduleChange(e) {
+        this.reminderSchedule = e.target.value;
+    }
+    handleExpirationDaysChange(e) {
+        this.expirationDays = e.target.value;
+    }
     handleRequireVerificationChange(e) {
         this.requireVerification = e.target.checked;
     }
@@ -118,6 +128,16 @@ export default class DocGenSignatureSettings extends LightningElement {
     }
 
     async handleSave() {
+        // Surface pattern/min/max violations on the inputs before calling Apex.
+        const inputsValid = [...this.template.querySelectorAll('lightning-input')].reduce(
+            (valid, input) => input.reportValidity() && valid,
+            true
+        );
+        if (!inputsValid) {
+            this.saveSuccess = false;
+            this.saveMessage = 'Fix the highlighted fields and try again.';
+            return;
+        }
         this.isSaving = true;
         this.saveMessage = '';
         try {
@@ -134,9 +154,13 @@ export default class DocGenSignatureSettings extends LightningElement {
                 owaId: this.owaId
             });
             // CxSAST: CSRF protection handled by Salesforce Aura/LWC framework
+            const schedule = (this.reminderSchedule || '').trim();
+            const firstOffset = parseInt(schedule.split(',')[0], 10);
             await saveReminderSettings({
                 enabled: this.reminderEnabled,
-                hours: parseInt(this.reminderHours, 10) || 24
+                hours: firstOffset > 0 ? firstOffset : parseInt(this.reminderHours, 10) || 24,
+                schedule,
+                expirationDays: parseInt(this.expirationDays, 10) || null
             });
             // CxSAST: CSRF protection handled by Salesforce Aura/LWC framework
             await saveVerificationSettings({

--- a/force-app/main/default/objects/DocGen_Settings__c/fields/Signature_Expiration_Days__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Settings__c/fields/Signature_Expiration_Days__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Signature_Expiration_Days__c</fullName>
+    <defaultValue>2</defaultValue>
+    <description
+    >Org-wide default: signing links expire this many days after send. Individual sends and the Flow action can override per request. Requests created before this setting existed keep the legacy 48-hour lifetime.</description>
+    <externalId>false</externalId>
+    <label>Signature Link Expiration (Days)</label>
+    <precision>3</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Settings__c/fields/Signature_Reminder_Schedule__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Settings__c/fields/Signature_Reminder_Schedule__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Signature_Reminder_Schedule__c</fullName>
+    <description
+    >Comma-separated hour offsets after send at which pending signers are reminded, e.g. "24,72,168" = after 1, 3 and 7 days. Blank falls back to the single-reminder behavior driven by Signature Reminder After (Hours).</description>
+    <externalId>false</externalId>
+    <label>Signature Reminder Schedule (Hours)</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Signature_Request__c/fields/Expires_At__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Signature_Request__c/fields/Expires_At__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Expires_At__c</fullName>
+    <description
+    >When the signing links for this request stop working. Stamped at send (org default or per-send override) and re-stamped on resend. Null on requests created before v3.31 — those keep the legacy 48-hour lifetime from CreatedDate.</description>
+    <externalId>false</externalId>
+    <label>Link Expires At</label>
+    <required>false</required>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Signer__c/fields/Reminders_Sent__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Signer__c/fields/Reminders_Sent__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Reminders_Sent__c</fullName>
+    <defaultValue>0</defaultValue>
+    <description
+    >How many reminder-schedule entries have been consumed for this signer. Missed offsets (e.g. the reminder job was paused) collapse into a single catch-up reminder rather than a burst.</description>
+    <externalId>false</externalId>
+    <label>Reminders Sent</label>
+    <precision>3</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
@@ -340,6 +340,16 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>DocGen_Settings__c.Signature_Reminder_Schedule__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>DocGen_Settings__c.Signature_Expiration_Days__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>DocGen_Template_Version__c.Base_Object_API__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -553,6 +563,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>DocGen_Signature_Request__c.Expires_At__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>DocGen_Signature_Request__c.Secure_Token__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -676,6 +691,11 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>DocGen_Signer__c.Reminder_Sent_At__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>DocGen_Signer__c.Reminders_Sent__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/main/default/permissionsets/DocGen_Guest_Signature.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Guest_Signature.permissionset-meta.xml
@@ -164,6 +164,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>DocGen_Signature_Request__c.Expires_At__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>DocGen_Signature_Request__c.Signer_Email__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
@@ -328,6 +328,16 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Settings__c.Signature_Reminder_Schedule__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>DocGen_Settings__c.Signature_Expiration_Days__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>DocGen_Template_Version__c.Base_Object_API__c</field>
         <readable>true</readable>
@@ -624,6 +634,11 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>DocGen_Signature_Request__c.Document_Title_Format__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>DocGen_Signature_Request__c.Expires_At__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <!-- Signer fields (User: read-only; PIN_Hash/PIN_Attempts/PIN_Expires_At/Secure_Token intentionally blocked) -->


### PR DESCRIPTION
## What
Customers were stuck with a hardcoded 48-hour signing window and a single one-shot reminder. Both are now configurable.

### Expiration
- New org default **Signature Link Expiration (Days)** in Signature Settings (`DocGen_Settings__c.Signature_Expiration_Days__c`, default 2 = the historical 48h)
- Per-send override on the send screen (**Link Expiration in Days**) and a new `global` **Link Expiration (Days)** input on the `DocGen: Create Signature Request` Flow action
- Requests stamp `Expires_At__c` at send and re-stamp on resend; all 13 hardcoded `CreatedDate.addHours(48)` checks now route through the new `DocGenSignatureExpiry` helper
- **Back-compat:** pre-upgrade requests (null stamp) keep the legacy 48h window — upgrading never moves in-flight links
- The signing document's public-link `ExpiryDate` and the `{ExpirationHours}` email token now reflect the real window

### Reminders
- New **Signature Reminder Schedule** CSV of hour offsets (e.g. `24,72,168` = 1, 3 and 7 days) in Signature Settings; per-signer progress tracked in `DocGen_Signer__c.Reminders_Sent__c`
- Missed offsets collapse into ONE catch-up reminder (no bursts if the job was paused)
- Blank schedule = exact legacy single-reminder behavior; legacy in-flight signers seeded from `Reminder_Sent_At__c` so nobody is double-reminded; no reminders past the signing window
- Bonus fix: reminder emails now route guided-PDF requests to the PDF signing page (same routing bug as resend, fixed via #223's `resolveSigningPath`)

## Schema (4 new fields)
`DocGen_Settings__c.Signature_Expiration_Days__c`, `DocGen_Settings__c.Signature_Reminder_Schedule__c`, `DocGen_Signature_Request__c.Expires_At__c`, `DocGen_Signer__c.Reminders_Sent__c` — all in DocGen_Admin/User permsets; guest gets read on `Expires_At__c`. All new-field reads are SYSTEM_MODE + FLS-guard (namespaced-build safe).

## Validation
- **Namespaced pkgval scratch: full deploy + RunLocalTests 1694/1694, 100% pass**
- 10 new unit tests (expiry matrix, stamping, override, resend re-stamp, schedulable multi-offset/legacy-seed/expired-skip, schedule parsing, Flow input, settings validation)
- Verified live in Portwood Dev: settings save round-trip (`24,72,168` normalized, expiration persisted, cron scheduled), send-form expiration input renders
- `sf code-analyzer`: 0 violations; prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)