### PR TITLE
Attach the finalized PDF to completion emails (signers + sender)

### DIFF
--- a/force-app/main/default/classes/DocGenSignatureController.cls
+++ b/force-app/main/default/classes/DocGenSignatureController.cls
@@ -2769,7 +2769,10 @@ public without sharing class DocGenSignatureController {
             : null;
 
         ContentVersion cv = new ContentVersion();
-        cv.VersionData = EncodingUtil.base64Decode(base64Pdf);
+        // Held in a local so the completion emails below can attach the final PDF
+        // without a second base64 decode (Blob is by-reference — no heap copy).
+        Blob compositedPdf = EncodingUtil.base64Decode(base64Pdf);
+        cv.VersionData = compositedPdf;
         if (result.isComplete) {
             // Final signed document — attach to the related record. Honor the template's
             // document-naming pattern (Document_Title_Format__c, e.g. "Waiver - {Name}
@@ -2891,7 +2894,11 @@ public without sharing class DocGenSignatureController {
             // single-signer Flow path). Mirror the trigger here. Same OWA-required, log-and-swallow
             // contract so a missing Org-Wide Email Address can never block the signer's success.
             try {
-                DocGenSignatureEmailService.sendAllSignedNotification(signer.Signature_Request__c);
+                DocGenSignatureEmailService.sendAllSignedNotification(
+                    signer.Signature_Request__c,
+                    compositedPdf,
+                    cv.Title
+                );
             } catch (Exception notifEx) {
                 System.debug(
                     LoggingLevel.WARN,
@@ -2899,7 +2906,11 @@ public without sharing class DocGenSignatureController {
                 );
             }
             try {
-                DocGenSignatureEmailService.sendSignerCompletionEmails(signer.Signature_Request__c);
+                DocGenSignatureEmailService.sendSignerCompletionEmails(
+                    signer.Signature_Request__c,
+                    compositedPdf,
+                    cv.Title
+                );
             } catch (Exception signerNotifEx) {
                 System.debug(
                     LoggingLevel.WARN,

--- a/force-app/main/default/classes/DocGenSignatureEmailService.cls
+++ b/force-app/main/default/classes/DocGenSignatureEmailService.cls
@@ -259,12 +259,21 @@ public with sharing class DocGenSignatureEmailService {
         );
     }
 
-    /** Notifies the sender that all signers have completed — signed PDF is attached. */
+    /** Notifies the sender that all signers have completed. */
     public static void sendAllSignedNotification(Id requestId) {
+        sendAllSignedNotification(requestId, null, null);
+    }
+
+    /**
+     * All-signed sender notification with the finalized PDF attached. signedPdf
+     * null (or over the attachment cap) sends the plain notification.
+     */
+    public static void sendAllSignedNotification(Id requestId, Blob signedPdf, String fileName) {
         sendSenderNotification(
             requestId,
             DocGenEmailTemplateService.TYPE_ALL_SIGNED,
-            new Map<String, String>{ 'RequestId' => String.valueOf(requestId) }
+            new Map<String, String>{ 'RequestId' => String.valueOf(requestId) },
+            buildPdfAttachment(signedPdf, fileName)
         );
     }
 
@@ -287,6 +296,15 @@ public with sharing class DocGenSignatureEmailService {
      * rendered from the template for the given type.
      */
     private static void sendSenderNotification(Id requestId, String templateType, Map<String, String> tokens) {
+        sendSenderNotification(requestId, templateType, tokens, null);
+    }
+
+    private static void sendSenderNotification(
+        Id requestId,
+        String templateType,
+        Map<String, String> tokens,
+        Messaging.EmailFileAttachment attachment
+    ) {
         try {
             DocGenFlsGuard.assertAccessible(DocGen_Signature_Request__c.sObjectType, new Set<String>{ 'CreatedById' });
             /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
@@ -315,6 +333,9 @@ public with sharing class DocGenSignatureEmailService {
                 email.setPlainTextBody(rendered.plainBody);
             }
             email.setSaveAsActivity(false);
+            if (attachment != null) {
+                email.setFileAttachments(new List<Messaging.EmailFileAttachment>{ attachment });
+            }
 
             DocGen_Settings__c settings = DocGen_Settings__c.getOrgDefaults();
             String owaId = settings == null ? null : settings.Signature_OWA_Id__c;
@@ -340,6 +361,17 @@ public with sharing class DocGenSignatureEmailService {
      * can't block the finalize that calls it.
      */
     public static void sendSignerCompletionEmails(Id requestId) {
+        sendSignerCompletionEmails(requestId, null, null);
+    }
+
+    /**
+     * Completion confirmation with the finalized PDF attached. One attachment
+     * instance is reused across every signer's message (the Blob rides along by
+     * reference — no per-recipient heap copies). signedPdf null (or over the
+     * attachment cap) sends the plain confirmation.
+     */
+    public static void sendSignerCompletionEmails(Id requestId, Blob signedPdf, String fileName) {
+        Messaging.EmailFileAttachment attachment = buildPdfAttachment(signedPdf, fileName);
         try {
             DocGenFlsGuard.assertAccessible(DocGen_Signature_Request__c.sObjectType, new Set<String>{ 'Template__c' });
             /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
@@ -406,6 +438,9 @@ public with sharing class DocGenSignatureEmailService {
                 }
                 email.setSaveAsActivity(false);
                 email.setOrgWideEmailAddressId(owaId);
+                if (attachment != null) {
+                    email.setFileAttachments(new List<Messaging.EmailFileAttachment>{ attachment });
+                }
                 emails.add(email);
             }
             if (!emails.isEmpty()) {
@@ -415,6 +450,32 @@ public with sharing class DocGenSignatureEmailService {
             System.debug(LoggingLevel.WARN, 'DocGen: Signer completion emails failed: ' + e.getMessage());
             logSignatureEmailFailure('sendSignerCompletionEmails', requestId, e);
         }
+    }
+
+    /**
+     * Shared PDF attachment for completion emails. Returns null when there is no
+     * PDF or it exceeds the email attachment cap (the notification still goes out
+     * plain — the signed document is always on the related record regardless).
+     */
+    private static final Integer MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024;
+
+    private static Messaging.EmailFileAttachment buildPdfAttachment(Blob pdf, String fileName) {
+        if (pdf == null) {
+            return null;
+        }
+        if (pdf.size() > MAX_ATTACHMENT_BYTES) {
+            System.debug(
+                LoggingLevel.WARN,
+                'DocGen: signed PDF (' + pdf.size() + ' bytes) exceeds the email attachment cap — sending without it.'
+            );
+            return null;
+        }
+        Messaging.EmailFileAttachment att = new Messaging.EmailFileAttachment();
+        String name = String.isNotBlank(fileName) ? fileName : 'Signed Document';
+        att.setFileName(name.endsWith('.pdf') ? name : name + '.pdf');
+        att.setContentType('application/pdf');
+        att.setBody(pdf);
+        return att;
     }
 
     // =========================================================================

--- a/force-app/main/default/classes/DocGenSignatureService.cls
+++ b/force-app/main/default/classes/DocGenSignatureService.cls
@@ -1366,6 +1366,21 @@ public without sharing class DocGenSignatureService {
                 /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
                 Database.update(req, false, AccessLevel.SYSTEM_MODE);
 
+                // Completion emails (moved here from DocGenSignaturePdfTrigger so the
+                // finalized PDF can be attached — it doesn't exist yet in the trigger).
+                // Each send is individually guarded: an email failure must never reach
+                // the outer catch, which would reset a signed request back to Viewed.
+                try {
+                    DocGenSignatureEmailService.sendAllSignedNotification(requestId, pdfBlob, fileName);
+                } catch (Exception notifEx) {
+                    System.debug(LoggingLevel.WARN, 'DocGen: All-signed notification failed: ' + notifEx.getMessage());
+                }
+                try {
+                    DocGenSignatureEmailService.sendSignerCompletionEmails(requestId, pdfBlob, fileName);
+                } catch (Exception notifEx) {
+                    System.debug(LoggingLevel.WARN, 'DocGen: Signer completion email failed: ' + notifEx.getMessage());
+                }
+
                 // Clean up temp images
                 cleanupTempImages(requestId);
             } catch (Exception e) {
@@ -1644,6 +1659,21 @@ public without sharing class DocGenSignatureService {
                 /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
                 Database.update(req, false, AccessLevel.SYSTEM_MODE);
                 purgeFrozenSnapshotCv(frozenCvToPurge);
+
+                // Completion emails (moved here from DocGenSignaturePdfTrigger so the
+                // finalized PDF can be attached — it doesn't exist yet in the trigger).
+                // Each send is individually guarded: an email failure must never reach
+                // the outer catch, which would reset a signed request back to Viewed.
+                try {
+                    DocGenSignatureEmailService.sendAllSignedNotification(requestId, pdfBlob, fileName);
+                } catch (Exception notifEx) {
+                    System.debug(LoggingLevel.WARN, 'DocGen: All-signed notification failed: ' + notifEx.getMessage());
+                }
+                try {
+                    DocGenSignatureEmailService.sendSignerCompletionEmails(requestId, pdfBlob, fileName);
+                } catch (Exception notifEx) {
+                    System.debug(LoggingLevel.WARN, 'DocGen: Signer completion email failed: ' + notifEx.getMessage());
+                }
             } catch (Exception e) {
                 String errMsg = e.getTypeName() + ': ' + e.getMessage() + '\n' + e.getStackTraceString();
                 System.debug(LoggingLevel.ERROR, 'DocGen: Template signature PDF failed for ' + req.Id + ': ' + errMsg);

--- a/force-app/main/default/classes/DocGenSignatureTests.cls
+++ b/force-app/main/default/classes/DocGenSignatureTests.cls
@@ -3022,6 +3022,27 @@ private class DocGenSignatureTests {
     // =========================================================================
 
     @isTest
+    static void testCompletionEmails_attachmentOverloads_neverThrow() {
+        // The attachment overloads are best-effort like their 1-arg forms: a missing
+        // OWA, a null blob, or a send failure logs and returns — an email problem
+        // must never break the finalize that calls these from the queueables.
+        DocGen_Signer__c signer = getTestSigner();
+        signer.Status__c = 'Signed';
+        Database.update(signer, AccessLevel.SYSTEM_MODE);
+        Blob pdf = Blob.valueOf('%PDF-1.4 fake signed document');
+
+        Test.startTest();
+        DocGenSignatureEmailService.sendAllSignedNotification(signer.Signature_Request__c, pdf, 'Waiver - Signed');
+        DocGenSignatureEmailService.sendSignerCompletionEmails(signer.Signature_Request__c, pdf, 'Waiver - Signed');
+        // Null blob = plain notification, same contract.
+        DocGenSignatureEmailService.sendAllSignedNotification(signer.Signature_Request__c, null, null);
+        DocGenSignatureEmailService.sendSignerCompletionEmails(signer.Signature_Request__c, null, null);
+        Test.stopTest();
+
+        System.assert(true, 'attachment overloads completed without throwing');
+    }
+
+    @isTest
     static void testSignatureExpiry_isExpiredMatrix() {
         System.assert(
             !DocGenSignatureExpiry.isExpired(System.now().addDays(1), System.now().addDays(-30)),

--- a/force-app/main/default/triggers/DocGenSignaturePdfTrigger.trigger
+++ b/force-app/main/default/triggers/DocGenSignaturePdfTrigger.trigger
@@ -110,29 +110,14 @@ trigger DocGenSignaturePdfTrigger on DocGen_Signature_PDF__e(after insert) {
             }
 
             if (remaining == 0 && req.Status__c != 'Signed') {
-                // All signers complete — generate PDF
+                // All signers complete — generate PDF. The all-signed (sender) and
+                // completion (signer) emails are sent by the queueables AFTER the
+                // final CV insert, so the finalized PDF can ride along as an email
+                // attachment — at this point in the trigger it doesn't exist yet.
                 if (req.Template__c != null) {
                     System.enqueueJob(new DocGenSignatureService.TemplateSignaturePdfQueueable(requestId));
                 } else {
                     System.enqueueJob(new DocGenSignatureService.SignaturePdfQueueable(requestId));
-                }
-
-                // Send "all signed" notification to sender
-                try {
-                    DocGenSignatureEmailService.sendAllSignedNotification(requestId);
-                } catch (Exception notifEx) {
-                    System.debug(LoggingLevel.WARN, 'DocGen: All-signed notification failed: ' + notifEx.getMessage());
-                }
-
-                // Send a completion confirmation to the SIGNERS themselves (Sarah's #3 —
-                // previously only the sender was notified, so signers never got a "done").
-                try {
-                    DocGenSignatureEmailService.sendSignerCompletionEmails(requestId);
-                } catch (Exception signerNotifEx) {
-                    System.debug(
-                        LoggingLevel.WARN,
-                        'DocGen: Signer completion email failed: ' + signerNotifEx.getMessage()
-                    );
                 }
             } else if (remaining > 0) {
                 // Not all done — send "signer completed" notification


### PR DESCRIPTION
## What
When all parties finish signing, everyone involved now receives the finalized, stamped PDF **attached** to their completion email — signers on the Completion Confirmation, the sender on the All Signed notification.

## Why it wasn't possible before
The trigger (`DocGenSignaturePdfTrigger`) sent both completion emails synchronously **before** the final PDF existed — it's created later in the async PDF queueables. Nothing could ever be attached from there.

## How
- The two sends moved from the trigger into **both** PDF queueables (`SignaturePdfQueueable` + `TemplateSignaturePdfQueueable`), after the signed-CV insert and status flip, carrying the PDF blob + resolved file name
- The guided drawn-signature path (`saveCompositedSignedPdf`) — which has no queueable and already sent these inline — now passes its composited blob too
- New best-effort overloads on `DocGenSignatureEmailService`: `sendAllSignedNotification(Id, Blob, String)` / `sendSignerCompletionEmails(Id, Blob, String)`; 1-arg forms delegate
- **One** `EmailFileAttachment` instance is shared across all recipients (Blob rides by reference — no per-signer heap copies); PDFs over 20MB fall back to the plain notification with a debug log
- Every send is individually try/caught inside the queueables — their outer catch resets `Status__c` to Viewed, and an email failure must never un-sign a completed request
- Side effect (deliberate): the legacy `handleSignatureSubmission` enqueue path now gains completion emails too

## Validation
- Namespaced pkgval scratch (combined with #224): **RunLocalTests 1694/1694, 100% pass**
- New unit test: attachment overloads never throw (with blob / null blob / no OWA)
- `sf code-analyzer`: 0 violations; prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)