### PR TITLE
Fix completion emails silently failing in guest signing context

### DIFF
--- a/force-app/main/default/classes/DocGenSignatureEmailService.cls
+++ b/force-app/main/default/classes/DocGenSignatureEmailService.cls
@@ -5,7 +5,15 @@
  * recipient/OWA/reply-to wiring, sequential-signing logic, delivery-status
  * write-back, and best-effort error logging.
  */
-public with sharing class DocGenSignatureEmailService {
+// "without sharing" + guest FLS-guard variants are load-bearing: the guided
+// drawn-signature path finishes inside the GUEST signer's transaction
+// (saveCompositedSignedPdf), and every read here is an internal, requestId-scoped
+// config lookup — the guest has no sharing on DocGen_Signature_Request__c, so a
+// "with sharing" SYSTEM_MODE query returns no rows and the completion emails
+// silently fail (logged as "List has no rows" / "Insufficient FLS ...Template__c").
+// Same security model as DocGenSignatureController (also without sharing): the
+// capability is the validated signing token upstream, not record sharing.
+public without sharing class DocGenSignatureEmailService {
     /**
      * Data wrapper for each signer email to send.
      */
@@ -87,8 +95,11 @@ public with sharing class DocGenSignatureEmailService {
         if (requestId == null) {
             return null;
         }
-        DocGenFlsGuard.assertAccessible(DocGen_Signature_Request__c.sObjectType, new Set<String>{ 'Template__c' });
-        DocGenFlsGuard.assertAccessible(DocGen_Template__c.sObjectType, new Set<String>{ 'Default_Email_Message__c' });
+        DocGenFlsGuard.guestAssertAccessible(DocGen_Signature_Request__c.sObjectType, new Set<String>{ 'Template__c' });
+        DocGenFlsGuard.guestAssertAccessible(
+            DocGen_Template__c.sObjectType,
+            new Set<String>{ 'Default_Email_Message__c' }
+        );
         /* code-analyzer-suppress ApexFlsViolation */
         List<DocGen_Signature_Request__c> reqs = [
             SELECT Template__c, Template__r.Default_Email_Message__c
@@ -112,7 +123,10 @@ public with sharing class DocGenSignatureEmailService {
         if (requestId == null) {
             return null;
         }
-        DocGenFlsGuard.assertAccessible(DocGen_Signature_Request__c.sObjectType, new Set<String>{ 'Expires_At__c' });
+        DocGenFlsGuard.guestAssertAccessible(
+            DocGen_Signature_Request__c.sObjectType,
+            new Set<String>{ 'Expires_At__c' }
+        );
         /* code-analyzer-suppress ApexFlsViolation */
         List<DocGen_Signature_Request__c> reqs = [
             SELECT Expires_At__c
@@ -306,7 +320,10 @@ public with sharing class DocGenSignatureEmailService {
         Messaging.EmailFileAttachment attachment
     ) {
         try {
-            DocGenFlsGuard.assertAccessible(DocGen_Signature_Request__c.sObjectType, new Set<String>{ 'CreatedById' });
+            DocGenFlsGuard.guestAssertAccessible(
+                DocGen_Signature_Request__c.sObjectType,
+                new Set<String>{ 'CreatedById' }
+            );
             /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
             DocGen_Signature_Request__c req = [
                 SELECT CreatedById
@@ -316,7 +333,7 @@ public with sharing class DocGenSignatureEmailService {
                 LIMIT 1
             ]; // NOPMD
 
-            DocGenFlsGuard.assertAccessible(User.sObjectType, new Set<String>{ 'Email' });
+            DocGenFlsGuard.guestAssertAccessible(User.sObjectType, new Set<String>{ 'Email' });
             /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
             User sender = [SELECT Email FROM User WHERE Id = :req.CreatedById WITH SYSTEM_MODE LIMIT 1]; // NOPMD
             if (String.isBlank(sender.Email)) {
@@ -373,7 +390,10 @@ public with sharing class DocGenSignatureEmailService {
     public static void sendSignerCompletionEmails(Id requestId, Blob signedPdf, String fileName) {
         Messaging.EmailFileAttachment attachment = buildPdfAttachment(signedPdf, fileName);
         try {
-            DocGenFlsGuard.assertAccessible(DocGen_Signature_Request__c.sObjectType, new Set<String>{ 'Template__c' });
+            DocGenFlsGuard.guestAssertAccessible(
+                DocGen_Signature_Request__c.sObjectType,
+                new Set<String>{ 'Template__c' }
+            );
             /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
             DocGen_Signature_Request__c req = [
                 SELECT
@@ -406,7 +426,7 @@ public with sharing class DocGenSignatureEmailService {
             // Resolve a friendly document name (best-effort, guarded).
             String docTitle = 'your document';
             if (req.Template__c != null) {
-                DocGenFlsGuard.assertAccessible(DocGen_Template__c.sObjectType, new Set<String>{ 'Name' });
+                DocGenFlsGuard.guestAssertAccessible(DocGen_Template__c.sObjectType, new Set<String>{ 'Name' });
                 /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
                 List<DocGen_Template__c> tpls = [
                     SELECT Name
@@ -508,7 +528,7 @@ public with sharing class DocGenSignatureEmailService {
             DocGen_Signature_Request__c req = new DocGen_Signature_Request__c(Id = requestId);
             req.Email_Status__c = status.left(1000);
             // v2.0.1 — per-field FLS enforcement (Checkmarx "FLS Update").
-            DocGenFlsGuard.assertUpdateable(req, new Set<String>{ 'Email_Status__c' });
+            DocGenFlsGuard.guestAssertUpdateable(req, new Set<String>{ 'Email_Status__c' });
             /* code-analyzer-suppress ApexFlsViolation */
             Database.update(req, false, AccessLevel.SYSTEM_MODE);
         } catch (Exception e) {

--- a/force-app/main/default/classes/DocGenSignaturePdfTests.cls
+++ b/force-app/main/default/classes/DocGenSignaturePdfTests.cls
@@ -120,6 +120,53 @@ private class DocGenSignaturePdfTests {
     }
 
     // =========================================================================
+    // Guest-context regression — completion emails.
+    // The guided drawn-signature path sends the all-signed + signer-completion
+    // emails inside the GUEST transaction (saveCompositedSignedPdf). With the
+    // service "with sharing" + admin FLS guards, the guest could not see the
+    // request row ("List has no rows") / read Template__c ("Insufficient FLS"),
+    // and both emails silently failed into DocGen_Error_Log__c. Assert no such
+    // failure rows are written. Strongest where a real guest user exists.
+    // =========================================================================
+    @isTest
+    static void testGuestContext_completionEmails_noSilentFailures() {
+        User guest = getGuestUser();
+        Id reqId = [SELECT Id FROM DocGen_Signature_Request__c LIMIT 1].Id;
+        Blob pdf = Blob.valueOf('%PDF-1.4 guest test');
+
+        Test.startTest();
+        if (guest != null) {
+            System.runAs(guest) {
+                DocGenSignatureEmailService.sendAllSignedNotification(reqId, pdf, 'Guest Completion Test');
+                DocGenSignatureEmailService.sendSignerCompletionEmails(reqId, pdf, 'Guest Completion Test');
+            }
+        } else {
+            DocGenSignatureEmailService.sendAllSignedNotification(reqId, pdf, 'Guest Completion Test');
+            DocGenSignatureEmailService.sendSignerCompletionEmails(reqId, pdf, 'Guest Completion Test');
+        }
+        Test.stopTest();
+
+        // Message__c is a long text area (not filterable in SOQL) — filter in Apex.
+        List<String> regressions = new List<String>();
+        for (DocGen_Error_Log__c log : [
+            SELECT Message__c
+            FROM DocGen_Error_Log__c
+            WHERE Operation__c IN ('sendSenderNotification', 'sendSignerCompletionEmails')
+        ]) {
+            String msg = log.Message__c == null ? '' : log.Message__c;
+            if (msg.contains('Insufficient FLS') || msg.contains('no rows')) {
+                regressions.add(msg);
+            }
+        }
+        System.assertEquals(
+            0,
+            regressions.size(),
+            'Completion emails must not silently fail in guest context; got: ' +
+            (regressions.isEmpty() ? '' : regressions[0])
+        );
+    }
+
+    // =========================================================================
     // A1 — getSourcePdfBase64
     // =========================================================================
 


### PR DESCRIPTION
## Symptom (Dave's live test)
Guided drawn signing completed, request went Signed, but no completion emails (and no attached PDF) reached the parties. `DocGen_Error_Log__c` had the evidence at the exact signing timestamps:
- `sendSignerCompletionEmails: Insufficient FLS to read DocGen_Signature_Request__c.Template__c`
- `sendSenderNotification: List has no rows for assignment to SObject`

## Root cause
The composited (drawn-signature) path sends completion emails **inside the guest signer's transaction**. `DocGenSignatureEmailService` was `with sharing` + admin FLS guards: guests have no sharing on the request (so the SYSTEM_MODE query returns no rows) and fail the per-field FLS verdict. Failures are best-effort logged and swallowed — so the drawn path has silently never delivered completion emails for real guest signers. The typed-name path only worked because its emails ran in the trigger's system context.

## Fix
- Class → `without sharing` — every read here is an internal, requestId-scoped config lookup; same security model as `DocGenSignatureController` (the capability is the validated signing token upstream)
- All 8 guard sites → `guestAssert*` variants (the v2.2 guest-FLS pattern)
- New `runAs(guest)` regression test asserting no silent-failure rows are written

## Validation
- **Live end-to-end:** real guest drawn signing in the browser on Portwood Dev → request Signed, zero new error-log rows, completion emails delivered with the signed PDF attached
- `DocGenSignaturePdfTests` / `DocGenSignatureTests` / `DocGenSarahFixesTest` all green
- prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)