### PR TITLE
Excel child-record loops expand vertically (row cloning + renumbering)

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -2942,7 +2942,19 @@ The signing page runs as a guest user, which the platform restricts pretty heavi
 
 ### 14.9 Excel templates — alpha limitations
 
-Excel (`.xlsx`) templates handle plain field tags, parent lookups, basic loops, and format suffixes. Not yet supported in Excel output: **images** (`{%…}` tags are removed cleanly), **charts** (`{Chart:…}` renders a text placeholder), **shared assets** (tag removed), and **rich-text fields** (may carry Word-style formatting artifacts). Use Word or HTML templates when you need those.
+Excel (`.xlsx`) templates handle plain field tags, parent lookups, child-record loops, and format suffixes.
+
+**Child-record tables.** A loop that spans cells in a single worksheet row expands **down** — the row is cloned once per child record, and rows below the table shift down automatically. Put the opening tag (with the first column's field) in the leftmost cell and close the loop in the last column's cell:
+
+| Cell | Contents                 |
+| ---- | ------------------------ |
+| `A2` | `{#Contacts}{FirstName}` |
+| `B2` | `{LastName}`             |
+| `C2` | `{Email}{/Contacts}`     |
+
+With 3 contacts, rows 2–4 each carry one contact's `FirstName` / `LastName` / `Email` across columns A–C. Keep the loop as the only tagged region in its row — a second loop in the same row falls back to in-cell repetition. If the relationship returns no records, the row is removed.
+
+Not yet supported in Excel output: **images** (`{%…}` tags are removed cleanly), **charts** (`{Chart:…}` renders a text placeholder), **shared assets** (tag removed), and **rich-text fields** (may carry Word-style formatting artifacts). Use Word or HTML templates when you need those.
 
 ---
 

--- a/force-app/main/default/classes/DocGenMiscTests.cls
+++ b/force-app/main/default/classes/DocGenMiscTests.cls
@@ -10089,4 +10089,105 @@ private class DocGenMiscTests {
             'Date field must render the same calendar day, not shift back one (timezone off-by-one bug)'
         );
     }
+
+    /**
+     * Builds the child-loop data map shape the retriever produces:
+     * relationship name → {records: [...], totalSize: n}.
+     */
+    private static Map<String, Object> excelLoopData(List<Map<String, Object>> contacts) {
+        return new Map<String, Object>{
+            'Name' => 'Acme Corp',
+            'Contacts' => new Map<String, Object>{ 'records' => contacts, 'totalSize' => contacts.size() }
+        };
+    }
+
+    @IsTest
+    static void testExcelRowLoopExpandsVertically() {
+        // A child loop spanning cells in one worksheet row ({#Contacts}{FirstName}
+        // in A2, {LastName}{/Contacts} in B2) must clone the whole <row> per record
+        // and renumber rows/cell refs so Excel doesn't flag duplicates as corruption.
+        String xml =
+            '<worksheet><dimension ref="A1:B2"/><sheetData>' +
+            '<row r="1"><c r="A1" t="inlineStr"><is><t>{Name}</t></is></c></row>' +
+            '<row r="2"><c r="A2" t="inlineStr"><is><t>{#Contacts}{FirstName}</t></is></c>' +
+            '<c r="B2" t="inlineStr"><is><t>{LastName}{/Contacts}</t></is></c></row>' +
+            '</sheetData></worksheet>';
+        Map<String, Object> data = excelLoopData(
+            new List<Map<String, Object>>{
+                new Map<String, Object>{ 'FirstName' => 'Alice', 'LastName' => 'Adams' },
+                new Map<String, Object>{ 'FirstName' => 'Bob', 'LastName' => 'Brown' },
+                new Map<String, Object>{ 'FirstName' => 'Cara', 'LastName' => 'Clark' }
+            }
+        );
+
+        String result = DocGenService.renumberExcelRows(DocGenService.processXmlForTest(xml, data, 'Excel'));
+
+        System.assertEquals(4, result.countMatches('<row '), 'Header row + one row per contact');
+        System.assert(
+            result.contains(
+                '<row r="2"><c r="A2" t="inlineStr"><is><t>Alice</t></is></c>' +
+                '<c r="B2" t="inlineStr"><is><t>Adams</t></is></c></row>'
+            ),
+            'First clone keeps the authored row position: ' + result
+        );
+        System.assert(
+            result.contains('<row r="3"><c r="A3"') && result.contains('<is><t>Bob</t>'),
+            'Second clone renumbered to row 3: ' + result
+        );
+        System.assert(
+            result.contains('<row r="4"><c r="A4"') && result.contains('<is><t>Cara</t>'),
+            'Third clone renumbered to row 4: ' + result
+        );
+        System.assert(result.contains('<dimension ref="A1:B4"/>'), 'Dimension extended to last row: ' + result);
+        System.assert(!result.contains('{#') && !result.contains('{/'), 'No leaked loop tags: ' + result);
+    }
+
+    @IsTest
+    static void testExcelRowLoopRenumberPreservesAuthoredGaps() {
+        // Rows after the loop shift down by the inserted count, but authored blank
+        // gaps between rows must survive (a footer at row 5 with rows 3-4 blank
+        // stays 2 blank rows below the table).
+        String xml =
+            '<worksheet><sheetData>' +
+            '<row r="1"><c r="A1" t="inlineStr"><is><t>Hdr</t></is></c></row>' +
+            '<row r="2"><c r="A2" t="inlineStr"><is><t>{#Contacts}{FirstName}{/Contacts}</t></is></c></row>' +
+            '<row r="5"><c r="A5" t="inlineStr"><is><t>Footer</t></is></c></row>' +
+            '</sheetData></worksheet>';
+        Map<String, Object> data = excelLoopData(
+            new List<Map<String, Object>>{
+                new Map<String, Object>{ 'FirstName' => 'Alice' },
+                new Map<String, Object>{ 'FirstName' => 'Bob' }
+            }
+        );
+
+        String result = DocGenService.renumberExcelRows(DocGenService.processXmlForTest(xml, data, 'Excel'));
+
+        System.assert(result.contains('<row r="2"><c r="A2"') && result.contains('<is><t>Alice</t>'), result);
+        System.assert(result.contains('<row r="3"><c r="A3"') && result.contains('<is><t>Bob</t>'), result);
+        System.assert(
+            result.contains('<row r="6"><c r="A6" t="inlineStr"><is><t>Footer</t></is></c></row>'),
+            'Footer shifted down by 1 inserted row, keeping its 2-row authored gap: ' + result
+        );
+    }
+
+    @IsTest
+    static void testExcelRowLoopEmptyListDropsRow() {
+        // Zero child records: the loop row disappears entirely and later rows
+        // keep their authored positions (no upward shift).
+        String xml =
+            '<worksheet><sheetData>' +
+            '<row r="1"><c r="A1" t="inlineStr"><is><t>Hdr</t></is></c></row>' +
+            '<row r="2"><c r="A2" t="inlineStr"><is><t>{#Contacts}{FirstName}{/Contacts}</t></is></c></row>' +
+            '<row r="3"><c r="A3" t="inlineStr"><is><t>Footer</t></is></c></row>' +
+            '</sheetData></worksheet>';
+        Map<String, Object> data = excelLoopData(new List<Map<String, Object>>());
+
+        String result = DocGenService.renumberExcelRows(DocGenService.processXmlForTest(xml, data, 'Excel'));
+
+        System.assertEquals(2, result.countMatches('<row '), 'Loop row dropped: ' + result);
+        System.assert(
+            result.contains('<row r="3"><c r="A3" t="inlineStr"><is><t>Footer</t></is></c></row>'),
+            'Footer keeps its authored position: ' + result
+        );
+    }
 }

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -761,10 +761,22 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
                 xml = inlineSharedStrings(xml, sharedStrings);
                 currentEntryName = sheetName;
                 xml = processXml(xml, recordDataMap);
+                // Loop expansion clones <row> elements with duplicate indices/refs;
+                // reassign them so Excel doesn't flag the sheet as corrupt.
+                xml = renumberExcelRows(xml);
                 mr.processedXmlEntries.put(sheetName, xml);
             }
-            // Remove sharedStrings.xml from passthrough — cells are now inline
-            mr.passthroughEntries.remove('xl/sharedStrings.xml');
+            // Cells are now inline, but workbook.xml.rels and [Content_Types].xml
+            // still reference the sharedStrings part — removing it outright leaves a
+            // dangling reference that strict readers (openpyxl, POI) reject and Excel
+            // silently repairs. Ship an empty table instead so every reference stays valid.
+            mr.passthroughEntries.put(
+                'xl/sharedStrings.xml',
+                Blob.valueOf(
+                    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="0" uniqueCount="0"/>'
+                )
+            );
         }
 
         // PowerPoint post-process: convert {%}-emitted DGPIC markers into real
@@ -3857,6 +3869,41 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
                             }
                         }
 
+                        // Excel worksheet <row> container: mirror the DOCX <w:tr> auto-expand
+                        // for spreadsheet rows so a loop spanning cells in one row
+                        // ({#Contacts}{FirstName} in A1, {LastName}{/Contacts} in B1) clones
+                        // the whole row per record. Gated on Excel — <row> only exists in
+                        // spreadsheetml. Cloned rows carry duplicate r indices and cell refs
+                        // (Excel treats duplicates as corruption); renumberExcelRows() rewrites
+                        // them after the merge pass.
+                        if (currentTemplateType == 'Excel' && !isIfConditional) {
+                            Integer xlRowStart = lastIndexOfTagStart(xml, 'row', cursor);
+                            if (xlRowStart != -1) {
+                                Integer xlRowEnd = xml.indexOf('</row>', xlRowStart);
+                                Boolean xlRowClosedBeforeCursor = xml.substring(xlRowStart, cursor).contains('</row>');
+                                if (!xlRowClosedBeforeCursor && xlRowEnd != -1 && xlRowEnd > closeTagEnd) {
+                                    Integer xlRowFullEnd = xlRowEnd + 6; // </row>
+                                    // Same sibling guard as <w:tr>: only expand when this section
+                                    // is the row's sole tagged region.
+                                    String xlBefore = xml.substring(xlRowStart, cursor);
+                                    String xlAfter = xml.substring(closeTagEnd + 1, xlRowFullEnd);
+                                    Boolean xlHasSibling =
+                                        xlBefore.contains('{#') ||
+                                        xlBefore.contains('{^') ||
+                                        xlBefore.contains('{/') ||
+                                        xlAfter.contains('{#') ||
+                                        xlAfter.contains('{^') ||
+                                        xlAfter.contains('{/');
+                                    if (!xlHasSibling) {
+                                        if (chosenContainerStart == -1 || xlRowStart > chosenContainerStart) {
+                                            chosenContainerStart = xlRowStart;
+                                            chosenContainerEnd = xlRowFullEnd;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
                         if (chosenContainerStart != -1 && chosenContainerEnd != -1) {
                             contentStart = chosenContainerStart;
                             contentEnd = chosenContainerEnd;
@@ -5048,6 +5095,103 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
             // Not a shared string cell — pass through
             result += cellXml;
             cursor = cEnd + 4;
+        }
+
+        return result;
+    }
+
+    /**
+     * Post-merge row renumbering for Excel worksheets. Loop expansion clones
+     * <row> elements verbatim, so an expanded sheet carries duplicate row
+     * indices (three rows all declaring r="2") and duplicate cell refs
+     * (r="A2" in each clone) — Excel flags duplicate refs as corruption.
+     * Walks sheetData in document order reassigning row numbers: original
+     * rows keep their position (authored gaps preserved), clones push every
+     * subsequent row down. Cell refs inside each row are rewritten to
+     * <column letters><new row number>, and the <dimension> end row is
+     * extended to the last assigned row.
+     */
+    @TestVisible
+    private static String renumberExcelRows(String xml) {
+        Integer sheetDataStart = xml.indexOf('<sheetData');
+        if (sheetDataStart == -1) {
+            return xml;
+        }
+        String result = xml.substring(0, sheetDataStart);
+        Integer cursor = sheetDataStart;
+        Integer lastAssigned = 0;
+        Integer delta = 0;
+        Pattern rowRefPattern = Pattern.compile('(<row[^>]*\\br=")(\\d+)(")');
+        Pattern cellRefPattern = Pattern.compile('(<c[^>]*\\br=")([A-Z]+)(\\d+)(")');
+
+        while (cursor < xml.length()) {
+            Integer rowStart = xml.indexOf('<row', cursor);
+            if (rowStart == -1) {
+                result += xml.substring(cursor);
+                break;
+            }
+            Integer rowEnd = xml.indexOf('</row>', rowStart);
+            Integer rowSelfClose = xml.indexOf('/>', rowStart);
+            Integer rowOpenEnd = xml.indexOf('>', rowStart);
+            Boolean isSelfClosing = rowSelfClose != -1 && rowSelfClose + 1 == rowOpenEnd;
+            Integer rowFullEnd = isSelfClosing ? rowOpenEnd + 1 : (rowEnd == -1 ? -1 : rowEnd + 6);
+            if (rowFullEnd == -1) {
+                result += xml.substring(cursor);
+                break;
+            }
+            result += xml.substring(cursor, rowStart);
+            String rowXml = xml.substring(rowStart, rowFullEnd);
+
+            // Declared row index (r attribute is optional per OOXML spec)
+            Matcher rowMatcher = rowRefPattern.matcher(rowXml);
+            Integer newRow;
+            if (rowMatcher.find()) {
+                Integer declaredRow = Integer.valueOf(rowMatcher.group(2));
+                newRow = declaredRow + delta;
+                if (newRow <= lastAssigned) {
+                    // Duplicate/overlap from loop expansion — shift down
+                    newRow = lastAssigned + 1;
+                    delta = newRow - declaredRow;
+                }
+                rowXml =
+                    rowXml.substring(0, rowMatcher.start()) +
+                    rowMatcher.group(1) +
+                    newRow +
+                    rowMatcher.group(3) +
+                    rowXml.substring(rowMatcher.end());
+            } else {
+                newRow = lastAssigned + 1;
+            }
+            lastAssigned = newRow;
+
+            // Rewrite cell refs to the assigned row, preserving column letters
+            Matcher cellMatcher = cellRefPattern.matcher(rowXml);
+            String rebuilt = '';
+            Integer rowCursor = 0;
+            while (cellMatcher.find()) {
+                rebuilt += rowXml.substring(rowCursor, cellMatcher.start());
+                rebuilt += cellMatcher.group(1) + cellMatcher.group(2) + newRow + cellMatcher.group(4);
+                rowCursor = cellMatcher.end();
+            }
+            rebuilt += rowXml.substring(rowCursor);
+
+            result += rebuilt;
+            cursor = rowFullEnd;
+        }
+
+        // Extend the <dimension> end row to the last assigned row so readers
+        // that trust the hint see the expanded extent.
+        if (lastAssigned > 0) {
+            Pattern dimPattern = Pattern.compile('(<dimension ref="[A-Z]+\\d+:[A-Z]+)(\\d+)(")');
+            Matcher dimMatcher = dimPattern.matcher(result);
+            if (dimMatcher.find() && Integer.valueOf(dimMatcher.group(2)) < lastAssigned) {
+                result =
+                    result.substring(0, dimMatcher.start()) +
+                    dimMatcher.group(1) +
+                    lastAssigned +
+                    dimMatcher.group(3) +
+                    result.substring(dimMatcher.end());
+            }
         }
 
         return result;


### PR DESCRIPTION
Brings in the Excel row-loop work from Dave's parallel session for the v3.31.0 release.

- A child loop spanning cells in a single worksheet row (`{#Contacts}{FirstName}` in A2, `{LastName}{/Contacts}` in B2) now clones the whole `<row>` per record and shifts subsequent rows down — mirroring the DOCX `<w:tr>` auto-expand, gated to Excel with the same sole-tagged-region sibling guard
- New `renumberExcelRows` post-pass: reassigns duplicate row indices/cell refs from the cloning (Excel treats duplicates as corruption), keeps authored row gaps, extends `<dimension>`
- `sharedStrings.xml` is replaced with an empty valid table instead of removed — removing it left dangling references in `workbook.xml.rels`/`[Content_Types].xml` that strict readers (openpyxl, POI) reject
- 3 unit tests + UserGuide §14.9 documentation

No schema changes, no SOQL, no namespace-sensitive constructs; `@TestVisible` member referenced only from `@IsTest` code (not e2e scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)