### PR TITLE
Restore site header/footer as inert packaging stubs (unblocks v3.31.0 build)

### DIFF
--- a/force-app/main/default/components/DocGenSiteFooter.component
+++ b/force-app/main/default/components/DocGenSiteFooter.component
@@ -1,0 +1,11 @@
+<apex:component>
+    <!--
+      INERT PACKAGING STUB — renders nothing.
+      This component shipped in early package versions and 2GP cannot remove
+      packaged metadata without the Partner Community "Remove Metadata
+      Components" feature (see project notes / v1.98 precedent). The live site
+      chrome is owned by the Portwood Website repo — do NOT put markup here,
+      and never deploy this repo's source to the website org expecting it to
+      preserve the live footer.
+    -->
+</apex:component>

--- a/force-app/main/default/components/DocGenSiteFooter.component-meta.xml
+++ b/force-app/main/default/components/DocGenSiteFooter.component-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexComponent xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <description
+    >Inert packaging stub — site chrome lives in the Portwood Website repo. Kept only because 2GP cannot remove packaged metadata.</description>
+    <label>DocGen Site Footer</label>
+</ApexComponent>

--- a/force-app/main/default/components/DocGenSiteHeader.component
+++ b/force-app/main/default/components/DocGenSiteHeader.component
@@ -1,0 +1,11 @@
+<apex:component>
+    <!--
+      INERT PACKAGING STUB — renders nothing.
+      This component shipped in early package versions and 2GP cannot remove
+      packaged metadata without the Partner Community "Remove Metadata
+      Components" feature (see project notes / v1.98 precedent). The live site
+      chrome is owned by the Portwood Website repo — do NOT put markup here,
+      and never deploy this repo's source to the website org expecting it to
+      preserve the live header.
+    -->
+</apex:component>

--- a/force-app/main/default/components/DocGenSiteHeader.component-meta.xml
+++ b/force-app/main/default/components/DocGenSiteHeader.component-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexComponent xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <description
+    >Inert packaging stub — site chrome lives in the Portwood Website repo. Kept only because 2GP cannot remove packaged metadata.</description>
+    <label>DocGen Site Header</label>
+</ApexComponent>


### PR DESCRIPTION
`sf package version create` for v3.31.0 failed: `DocGenSiteHeader`/`DocGenSiteFooter` (ApexComponents) are in the released package, and removing packaged metadata needs the Partner Community 'Remove Metadata Components' feature we don't have (same wall as v1.98). de6ee01 deleted them because deploying this repo to the website org clobbered live site chrome with April-era snapshots.

This restores the two components as **empty, loudly-commented stubs**: the package builds again, nothing renders, and an accidental website-org deploy can no longer overwrite the live header/footer with stale markup (worst case it blanks the packaged copies, which the website repo owns anyway).

Long-term fix stays the same: file the Partner Community case (tracked in project notes) and then truly remove them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)