### PR TITLE
Email logo: long URLs + "Override with Asset File"

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -2431,6 +2431,9 @@ For each template you can edit the **subject** and **body**, preview it live wit
 **Two layout modes** (per template):
 
 - **DocGen layout** (default) — edit just the body in a rich-text editor; DocGen wraps the branded header (logo + brand color) and footer around it. You can override **brand color / logo / footer** per template here. Best when you want consistent branding with minimal effort.
+
+    **Logo options (v3.32+):** the **Logo URL Override** accepts URLs of any length (long CDN or Salesforce Files delivery links included). Or skip URLs entirely with **"…or override with an Asset file"** — pick a Shared Asset image (Command Hub → Assets) and DocGen creates a permanent public file link for it and fills the URL for you. The link always serves the asset's **latest** image, so replacing the asset's file updates your email logo everywhere with no re-save. (Requires Content Deliveries enabled — Setup → Content Deliveries and Public Links.)
+
 - **Full custom HTML** — paste your **entire** HTML email document (your own table layout, inline styles, and `<img src="https://…">` images). DocGen sends it exactly as authored, resolving only merge tokens and widgets — no added header/footer. Use this for pixel-perfect, fully on-brand emails. **Images must use absolute, publicly reachable URLs** (your website/CDN); Salesforce file links won't load in a recipient's inbox. You can still reference org values with `{CompanyName}` and `{BrandColor}`, and drop in `{ActionButton}`/`{VerificationCode}` so the signing button/code keep working.
 
 **Merge tokens** resolve at send time and are HTML-escaped: `{SignerName}`, `{SenderName}`, `{CompanyName}`, `{DocumentTitle}`, `{RoleName}`, `{ExpirationHours}`, `{RequestId}`, and `{Message}`. Four **widget tokens** render branded blocks — place them anywhere in the body:

--- a/force-app/main/default/classes/DocGenEmailTemplateController.cls
+++ b/force-app/main/default/classes/DocGenEmailTemplateController.cls
@@ -79,6 +79,7 @@ public with sharing class DocGenEmailTemplateController {
                 'Body_Plain__c',
                 'Brand_Color__c',
                 'Logo_Url__c',
+                'Logo_Url_Extended__c',
                 'Footer_Text__c',
                 'Layout_Mode__c',
                 'Is_Active__c'
@@ -95,6 +96,7 @@ public with sharing class DocGenEmailTemplateController {
                 Body_Plain__c,
                 Brand_Color__c,
                 Logo_Url__c,
+                Logo_Url_Extended__c,
                 Footer_Text__c,
                 Layout_Mode__c,
                 Is_Active__c
@@ -121,7 +123,9 @@ public with sharing class DocGenEmailTemplateController {
                     'bodyHtml' => r == null ? def.bodyHtml : r.Body_Html__c,
                     'bodyPlain' => r == null ? '' : r.Body_Plain__c,
                     'brandColor' => r == null ? '' : r.Brand_Color__c,
-                    'logoUrl' => r == null ? '' : r.Logo_Url__c,
+                    'logoUrl' => r == null
+                        ? ''
+                        : (String.isNotBlank(r.Logo_Url_Extended__c) ? r.Logo_Url_Extended__c.trim() : r.Logo_Url__c),
                     'footerText' => r == null ? '' : r.Footer_Text__c,
                     'layoutMode' => (r == null ||
                         r.Layout_Mode__c == null)
@@ -154,7 +158,12 @@ public with sharing class DocGenEmailTemplateController {
         rec.Body_Html__c = (String) data.get('bodyHtml');
         rec.Body_Plain__c = (String) data.get('bodyPlain');
         rec.Brand_Color__c = (String) data.get('brandColor');
-        rec.Logo_Url__c = (String) data.get('logoUrl');
+        // Logo_Url__c (platform Url field) is capped at 255 and type-locked in the
+        // managed package; the long companion field is authoritative. Mirror short
+        // values into the legacy field for anything still reading it.
+        String logoUrl = (String) data.get('logoUrl');
+        rec.Logo_Url_Extended__c = logoUrl;
+        rec.Logo_Url__c = (logoUrl != null && logoUrl.length() <= 255) ? logoUrl : null;
         rec.Footer_Text__c = (String) data.get('footerText');
         rec.Layout_Mode__c = (data.get('layoutMode') == DocGenEmailTemplateService.MODE_FULL_HTML)
             ? DocGenEmailTemplateService.MODE_FULL_HTML
@@ -168,6 +177,7 @@ public with sharing class DocGenEmailTemplateController {
             'Body_Plain__c',
             'Brand_Color__c',
             'Logo_Url__c',
+            'Logo_Url_Extended__c',
             'Footer_Text__c',
             'Layout_Mode__c',
             'Is_Active__c'
@@ -184,6 +194,124 @@ public with sharing class DocGenEmailTemplateController {
             throw DocGenService.dmlAhe(e, DocGen_Email_Template__c.sObjectType);
         }
         return rec.Id;
+    }
+
+    /**
+     * "Override with Asset File": resolves a DocGen Shared Asset (its latest file
+     * version) to a public content-delivery URL that email clients can fetch
+     * anonymously, for use as the branded-header logo. Creates a ContentDistribution
+     * on first use and reuses it afterwards; PreferencesLinkLatestVersion keeps the
+     * URL serving the newest upload when the asset file is replaced. Resolution
+     * happens here — at editor-save time, in an admin session — because guest and
+     * Automated Process contexts (which SEND the emails) cannot create
+     * ContentDistributions.
+     */
+    @AuraEnabled
+    public static String resolveAssetPublicUrl(Id assetId) {
+        if (assetId == null) {
+            throw DocGenService.ahe('An asset Id is required.');
+        }
+        DocGenFlsGuard.assertAccessible(DocGen_Asset__c.sObjectType, new Set<String>{ 'Name' });
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        List<DocGen_Asset__c> assets = [
+            SELECT
+                Id,
+                Name,
+                (
+                    SELECT ContentDocument.LatestPublishedVersionId
+                    FROM ContentDocumentLinks
+                    ORDER BY ContentDocument.CreatedDate DESC, ContentDocument.Id DESC
+                    LIMIT 1
+                )
+            FROM DocGen_Asset__c
+            WHERE Id = :assetId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ]; // NOPMD ApexCRUDViolation - package-internal custom object; CRUD controlled by DocGen permission sets
+        if (assets.isEmpty() || assets[0].ContentDocumentLinks == null || assets[0].ContentDocumentLinks.isEmpty()) {
+            throw DocGenService.ahe('This asset has no file yet — upload an image to it first.');
+        }
+        Id cvId = assets[0].ContentDocumentLinks[0].ContentDocument.LatestPublishedVersionId;
+        if (cvId == null) {
+            throw DocGenService.ahe('This asset has no published file version.');
+        }
+
+        DocGenFlsGuard.assertAccessible(
+            ContentDistribution.sObjectType,
+            new Set<String>{ 'ContentDownloadUrl', 'ContentVersionId', 'PreferencesExpires' }
+        );
+        /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+        List<ContentDistribution> existing = [
+            SELECT Id, ContentDownloadUrl, PreferencesExpires
+            FROM ContentDistribution
+            WHERE ContentVersionId = :cvId
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        try {
+            if (!existing.isEmpty()) {
+                if (existing[0].PreferencesExpires == true) {
+                    // A delivery created elsewhere (e.g. the signing flow) may carry an
+                    // expiry — a logo link must not go dark, so clear it.
+                    ContentDistribution fix = new ContentDistribution(
+                        Id = existing[0].Id,
+                        PreferencesExpires = false,
+                        ExpiryDate = null
+                    );
+                    DocGenFlsGuard.assertUpdateable(fix, new Set<String>{ 'PreferencesExpires', 'ExpiryDate' });
+                    /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+                    Database.update(fix, AccessLevel.SYSTEM_MODE);
+                }
+                return existing[0].ContentDownloadUrl;
+            }
+
+            ContentDistribution cd = new ContentDistribution();
+            cd.Name = 'DocGen Asset - ' + assets[0].Name;
+            cd.ContentVersionId = cvId;
+            cd.PreferencesAllowViewInBrowser = true;
+            cd.PreferencesLinkLatestVersion = true;
+            cd.PreferencesAllowOriginalDownload = true;
+            cd.PreferencesExpires = false;
+            cd.PreferencesNotifyOnVisit = false;
+            cd.PreferencesAllowPDFDownload = false;
+            DocGenFlsGuard.assertCreateable(
+                cd,
+                new Set<String>{
+                    'Name',
+                    'ContentVersionId',
+                    'PreferencesAllowViewInBrowser',
+                    'PreferencesLinkLatestVersion',
+                    'PreferencesAllowOriginalDownload',
+                    'PreferencesExpires',
+                    'PreferencesNotifyOnVisit',
+                    'PreferencesAllowPDFDownload'
+                }
+            );
+            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+            Database.insert(cd, AccessLevel.SYSTEM_MODE);
+            // ContentDownloadUrl is generated server-side — re-query for it.
+            /* code-analyzer-suppress ApexFlsViolation, DatabaseOperationsMustUseWithSharing */
+            ContentDistribution created = [
+                SELECT ContentDownloadUrl
+                FROM ContentDistribution
+                WHERE Id = :cd.Id
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ];
+            if (String.isBlank(created.ContentDownloadUrl)) {
+                throw DocGenService.ahe(
+                    'The public file link was created but has no download URL yet — try again in a moment.'
+                );
+            }
+            return created.ContentDownloadUrl;
+        } catch (AuraHandledException ahe) {
+            throw ahe;
+        } catch (Exception e) {
+            throw DocGenService.ahe(
+                e,
+                'Could not create a public link for this asset. Check that Content Deliveries are enabled (Setup → Content Deliveries and Public Links).'
+            );
+        }
     }
 
     /** The built-in default subject + body for a type (for the editor "Reset" action; not persisted). */

--- a/force-app/main/default/classes/DocGenEmailTemplateService.cls
+++ b/force-app/main/default/classes/DocGenEmailTemplateService.cls
@@ -209,6 +209,7 @@ global with sharing class DocGenEmailTemplateService {
                     'Body_Plain__c',
                     'Brand_Color__c',
                     'Logo_Url__c',
+                    'Logo_Url_Extended__c',
                     'Footer_Text__c',
                     'Layout_Mode__c',
                     'Is_Active__c'
@@ -223,6 +224,7 @@ global with sharing class DocGenEmailTemplateService {
                     Body_Plain__c,
                     Brand_Color__c,
                     Logo_Url__c,
+                    Logo_Url_Extended__c,
                     Footer_Text__c,
                     Layout_Mode__c
                 FROM DocGen_Email_Template__c
@@ -240,7 +242,12 @@ global with sharing class DocGenEmailTemplateService {
                 d.bodyHtml = r.Body_Html__c;
                 d.bodyPlain = r.Body_Plain__c;
                 d.brandColorOverride = r.Brand_Color__c;
-                d.logoUrlOverride = r.Logo_Url__c;
+                // Long field wins — Logo_Url__c is a platform Url field capped at 255
+                // chars and type-locked in the managed package; Files delivery URLs
+                // and other long links live in Logo_Url_Extended__c.
+                d.logoUrlOverride = String.isNotBlank(r.Logo_Url_Extended__c)
+                    ? r.Logo_Url_Extended__c.trim()
+                    : r.Logo_Url__c;
                 d.footerTextOverride = r.Footer_Text__c;
                 d.layoutMode = r.Layout_Mode__c == MODE_FULL_HTML ? MODE_FULL_HTML : MODE_MANAGED;
                 defCache.put(r.Type__c, d);

--- a/force-app/main/default/classes/DocGenEmailTemplateTest.cls
+++ b/force-app/main/default/classes/DocGenEmailTemplateTest.cls
@@ -87,6 +87,122 @@ private class DocGenEmailTemplateTest {
         System.assert(r.htmlBody.contains('#FF0000'), 'brand override applied');
     }
 
+    // ---- Long logo URLs (Logo_Url_Extended__c beats the 255-capped Url field) ----
+    @IsTest
+    static void controller_save_longLogoUrl_roundTripsAndRenders() {
+        String longUrl = 'https://files.example.com/sfc/dist/version/download/' + 'x'.repeat(400) + '/logo.png';
+        Map<String, Object> data = new Map<String, Object>{
+            'type' => DocGenEmailTemplateService.TYPE_REQUEST,
+            'subject' => 'Hi',
+            'bodyHtml' => '<p>x {ActionButton}</p>',
+            'logoUrl' => longUrl,
+            'isActive' => true
+        };
+        Test.startTest();
+        Id recId = DocGenEmailTemplateController.saveTemplate(data);
+        Test.stopTest();
+
+        DocGen_Email_Template__c saved = [
+            SELECT Logo_Url__c, Logo_Url_Extended__c
+            FROM DocGen_Email_Template__c
+            WHERE Id = :recId
+        ];
+        System.assertEquals(longUrl, saved.Logo_Url_Extended__c, 'Long URL stored in the extended field');
+        System.assertEquals(null, saved.Logo_Url__c, 'Over-255 URL must not touch the capped legacy field');
+
+        for (Map<String, Object> row : DocGenEmailTemplateController.getTemplates()) {
+            if (row.get('type') == DocGenEmailTemplateService.TYPE_REQUEST) {
+                System.assertEquals(longUrl, row.get('logoUrl'), 'Editor round-trips the long URL');
+            }
+        }
+
+        DocGenEmailTemplateService.clearCache();
+        DocGenEmailTemplateService.RenderedEmail r = DocGenEmailTemplateService.render(
+            DocGenEmailTemplateService.TYPE_REQUEST,
+            sampleTokens(DocGenEmailTemplateService.TYPE_REQUEST)
+        );
+        System.assert(r.htmlBody.contains('logo.png'), 'Renderer uses the long logo URL: ' + r.htmlBody.left(300));
+    }
+
+    @IsTest
+    static void controller_save_shortLogoUrl_mirrorsLegacyField() {
+        Map<String, Object> data = new Map<String, Object>{
+            'type' => DocGenEmailTemplateService.TYPE_PIN,
+            'subject' => 'Hi',
+            'bodyHtml' => '<p>{VerificationCode}</p>',
+            'logoUrl' => 'https://example.com/logo.png'
+        };
+        Id recId = DocGenEmailTemplateController.saveTemplate(data);
+        DocGen_Email_Template__c saved = [
+            SELECT Logo_Url__c, Logo_Url_Extended__c
+            FROM DocGen_Email_Template__c
+            WHERE Id = :recId
+        ];
+        System.assertEquals('https://example.com/logo.png', saved.Logo_Url_Extended__c);
+        System.assertEquals(
+            'https://example.com/logo.png',
+            saved.Logo_Url__c,
+            'Short URLs mirror into the legacy field for anything still reading it'
+        );
+    }
+
+    // ---- "Override with Asset File": asset → public delivery URL ----
+    @IsTest
+    static void controller_resolveAssetPublicUrl() {
+        DocGen_Asset__c asset = new DocGen_Asset__c(Name = 'Logo Test Asset', Asset_Key__c = 'logo_test');
+        insert asset;
+        ContentVersion cv = new ContentVersion(
+            Title = 'logo',
+            PathOnClient = 'logo.png',
+            VersionData = Blob.valueOf('fake png bytes'),
+            FirstPublishLocationId = asset.Id
+        );
+        insert cv;
+
+        Test.startTest();
+        String url;
+        String failureMsg;
+        try {
+            url = DocGenEmailTemplateController.resolveAssetPublicUrl(asset.Id);
+            // Second call must reuse the same distribution, not mint another.
+            String again = DocGenEmailTemplateController.resolveAssetPublicUrl(asset.Id);
+            System.assertEquals(url, again, 'Repeat resolution reuses the existing public link');
+        } catch (AuraHandledException e) {
+            // Orgs without Content Deliveries enabled can't create distributions —
+            // the contract then is a friendly, actionable message (never raw DML).
+            failureMsg = e.getMessage();
+        }
+        Test.stopTest();
+
+        if (url != null) {
+            System.assert(url.startsWith('http'), 'Public download URL returned: ' + url);
+            System.assertEquals(
+                1,
+                [SELECT COUNT() FROM ContentDistribution WHERE ContentVersionId = :cv.Id],
+                'Exactly one distribution per asset version'
+            );
+        } else {
+            System.assert(
+                failureMsg != null && failureMsg.contains('Content Deliveries'),
+                'Friendly guidance expected when deliveries are unavailable; got: ' + failureMsg
+            );
+        }
+    }
+
+    @IsTest
+    static void controller_resolveAssetPublicUrl_noFileIsFriendly() {
+        DocGen_Asset__c bare = new DocGen_Asset__c(Name = 'Empty Asset', Asset_Key__c = 'empty_asset');
+        insert bare;
+        Boolean caught = false;
+        try {
+            DocGenEmailTemplateController.resolveAssetPublicUrl(bare.Id);
+        } catch (AuraHandledException e) {
+            caught = true;
+            System.assert(e.getMessage().contains('upload an image'), 'Actionable message; got: ' + e.getMessage());
+        }
+        System.assert(caught, 'Asset without a file must be rejected with guidance');
+    }
+
     // ---- Service: invalid brand color falls back to the safe default ----
     @IsTest
     static void invalidBrandColor_fallsBackSafe() {
@@ -172,11 +288,15 @@ private class DocGenEmailTemplateTest {
     // not the raw DmlException (which renders as "[object Object]" in the LWC).
     @IsTest
     static void controller_save_oversized_logo_url_friendly_error() {
+        // URLs past the extended field's 32,768-char cap still get the friendly
+        // "too long" treatment instead of a raw DmlException / [object Object].
+        // (URLs between 256 and 32,768 chars are a supported feature now — see
+        // controller_save_longLogoUrl_roundTripsAndRenders.)
         Map<String, Object> data = new Map<String, Object>{
             'type' => DocGenEmailTemplateService.TYPE_REQUEST,
             'subject' => 'Hi',
             'bodyHtml' => '<p>x</p>',
-            'logoUrl' => 'https://example.com/' + 'a'.repeat(300)
+            'logoUrl' => 'https://example.com/' + 'a'.repeat(33000)
         };
         Boolean caught = false;
         String message;
@@ -190,7 +310,7 @@ private class DocGenEmailTemplateTest {
         Test.stopTest();
         System.assert(caught, 'Oversized logo URL must throw AuraHandledException');
         System.assert(
-            message.contains('255') && message.containsIgnoreCase('too long'),
+            message.contains('32768') && message.containsIgnoreCase('too long'),
             'Message must name the max length; got: ' + message
         );
     }

--- a/force-app/main/default/lwc/docGenEmailTemplates/docGenEmailTemplates.html
+++ b/force-app/main/default/lwc/docGenEmailTemplates/docGenEmailTemplates.html
@@ -108,10 +108,20 @@
                                     type="text"
                                     label="Logo URL Override"
                                     value={logoUrl}
-                                    max-length="255"
                                     onchange={handleLogoChange}
                                     placeholder="https://…/logo.png"
+                                    field-level-help="Any public image URL — no length limit. Or pick a DocGen Asset below to host the logo in Salesforce Files."
                                 ></lightning-input>
+                                <lightning-combobox
+                                    label="…or override with an Asset file"
+                                    value={selectedLogoAssetId}
+                                    options={logoAssetOptions}
+                                    onchange={handleLogoAssetChange}
+                                    placeholder="Pick a Shared Asset image…"
+                                    disabled={logoAssetsUnavailable}
+                                    field-level-help="Uses a Shared Asset (Command Hub → Assets) as the logo: DocGen creates a public file link and fills the URL above. Replacing the asset's image updates the logo everywhere automatically."
+                                    class="slds-p-top_xx-small"
+                                ></lightning-combobox>
                             </div>
                             <div class="slds-col slds-size_1-of-1 slds-p-top_xx-small">
                                 <lightning-input

--- a/force-app/main/default/lwc/docGenEmailTemplates/docGenEmailTemplates.js
+++ b/force-app/main/default/lwc/docGenEmailTemplates/docGenEmailTemplates.js
@@ -5,6 +5,8 @@ import saveTemplate from '@salesforce/apex/DocGenEmailTemplateController.saveTem
 import getDefault from '@salesforce/apex/DocGenEmailTemplateController.getDefault';
 import renderPreview from '@salesforce/apex/DocGenEmailTemplateController.renderPreview';
 import sendTest from '@salesforce/apex/DocGenEmailTemplateController.sendTest';
+import resolveAssetPublicUrl from '@salesforce/apex/DocGenEmailTemplateController.resolveAssetPublicUrl';
+import getAssets from '@salesforce/apex/DocGenController.getAssets';
 
 export default class DocGenEmailTemplates extends LightningElement {
     @track rows = [];
@@ -29,10 +31,55 @@ export default class DocGenEmailTemplates extends LightningElement {
     @track isSaving = false;
     @track isTesting = false;
 
+    // "Override with Asset File" — Shared Asset images selectable as the logo.
+    @track logoAssets = [];
+    @track selectedLogoAssetId = '';
+
     _previewDirty = false;
 
     connectedCallback() {
         this.loadTemplates();
+        this.loadLogoAssets();
+    }
+
+    async loadLogoAssets() {
+        try {
+            const assets = await getAssets();
+            this.logoAssets = (assets || []).filter((a) => a.isActive && a.latestVersionCvId);
+        } catch (_e) {
+            this.logoAssets = []; // Assets tab optional — picker just disables
+        }
+    }
+
+    get logoAssetOptions() {
+        return this.logoAssets.map((a) => ({
+            label: a.name + (a.category ? ' (' + a.category + ')' : ''),
+            value: a.id
+        }));
+    }
+
+    get logoAssetsUnavailable() {
+        return this.logoAssets.length === 0;
+    }
+
+    async handleLogoAssetChange(event) {
+        const assetId = event.detail.value;
+        this.selectedLogoAssetId = assetId;
+        if (!assetId) return;
+        try {
+            const url = await resolveAssetPublicUrl({ assetId });
+            this.logoUrl = url;
+            this._previewDirty = true;
+            this.toast(
+                'Logo set from Asset',
+                'A public file link was created and filled into Logo URL Override. Save to apply.',
+                'success'
+            );
+            this.refreshPreview();
+        } catch (error) {
+            this.selectedLogoAssetId = '';
+            this.toast('Could not use this asset', this.errMsg(error), 'error');
+        }
     }
 
     async loadTemplates() {
@@ -63,6 +110,7 @@ export default class DocGenEmailTemplates extends LightningElement {
         this.layoutMode = row.layoutMode || 'Managed';
         this.isActive = row.isActive !== false;
         this.tokens = (row.tokens || []).map((t) => '{' + t + '}');
+        this.selectedLogoAssetId = ''; // picker is a one-shot fill, not stored state
         this.refreshPreview();
     }
 
@@ -128,6 +176,7 @@ export default class DocGenEmailTemplates extends LightningElement {
     }
     handleLogoChange(event) {
         this.logoUrl = event.target.value;
+        this.selectedLogoAssetId = ''; // manual edit supersedes the asset pick
     }
     handleFooterChange(event) {
         this.footerText = event.target.value;

--- a/force-app/main/default/objects/DocGen_Email_Template__c/fields/Logo_Url_Extended__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Email_Template__c/fields/Logo_Url_Extended__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Logo_Url_Extended__c</fullName>
+    <description
+    >Long-form logo URL override. Supersedes Logo_Url__c (a platform Url field, hard-capped at 255 characters and type-locked in the managed package) so Salesforce Files public-delivery URLs and other long links fit. When set, the renderer prefers this over Logo_Url__c.</description>
+    <externalId>false</externalId>
+    <label>Logo URL Override (Long)</label>
+    <length>32768</length>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
+</CustomField>

--- a/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Admin.permissionset-meta.xml
@@ -183,6 +183,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>DocGen_Email_Template__c.Logo_Url_Extended__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>DocGen_Email_Template__c.Footer_Text__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/DocGen_Guest_Signature.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_Guest_Signature.permissionset-meta.xml
@@ -73,6 +73,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>DocGen_Email_Template__c.Logo_Url_Extended__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>DocGen_Email_Template__c.Footer_Text__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DocGen_User.permissionset-meta.xml
@@ -172,6 +172,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>DocGen_Email_Template__c.Logo_Url_Extended__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>DocGen_Email_Template__c.Footer_Text__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
## What
Two branding upgrades for signature emails (Dave's ask):

1. **Long logo URLs** — `Logo_Url__c` is a platform `Url` field: hard 255-char cap, and its type is locked in the managed package. New `Logo_Url_Extended__c` (Long Text Area, 32,768) is now authoritative — the renderer and editor prefer it, short values mirror into the legacy field for anything still reading it, and the editor input drops its 255 max-length. The friendly too-long error moves to the real 32,768 boundary.
2. **Override with Asset File** — the Email Templates editor gets a picker of Shared Assets (Command Hub → Assets). Selecting one calls new `resolveAssetPublicUrl`: creates (or reuses) a **no-expiry public ContentDistribution** for the asset's latest file version and fills its `ContentDownloadUrl` into the logo field — so the logo is hosted in Salesforce Files and email clients can fetch it anonymously. `PreferencesLinkLatestVersion` means replacing the asset's image updates the logo everywhere with no re-save. A distribution created elsewhere with an expiry (e.g. the signing flow) gets its expiry cleared so the logo never goes dark.

Resolution happens at editor-save time in the admin session — deliberately, since guest and Automated Process contexts (which send the emails) can't create ContentDistributions.

## Validation
- `DocGenEmailTemplateTest` 23/23 on Portwood Dev (4 new: long-URL round-trip + render, short-URL mirror, asset resolution + reuse-not-duplicate, no-file friendly error; tolerant of orgs without Content Deliveries)
- Verified live in the browser: picked an asset → 191-char `file.force.com` delivery URL minted, filled, saved (extended + mirrored), preview renders
- New field in Admin (edit) / User / Guest_Signature (read) permsets; all reads SYSTEM_MODE behind FLS guards (namespaced-build safe)

Targets the next package version (v3.31.0 is already promoted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)