### PR TITLE
HTML-first template creation + visual designer (Beta)

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -13,7 +13,8 @@
         },
         "securitySettings": {
             "sessionSettings": {
-                "forceRelogin": false
+                "forceRelogin": false,
+                "enableCacheAndAutocomplete": false
             }
         }
     }

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -3939,6 +3939,66 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
         }
     }
 
+    /**
+     * Designer live PDF preview: renders the caller's DRAFT HTML (unsaved
+     * editor contents) through the full merge + Blob.toPdf pipeline against a
+     * real record, without touching the template's saved versions. The result
+     * is returned as base64 for a client-side blob: iframe — nothing is stored.
+     */
+    @AuraEnabled
+    public static Map<String, Object> previewDraftPdf(Id templateId, Id recordId, String draftHtml) {
+        if (String.isBlank(draftHtml)) {
+            throw DocGenService.ahe('Nothing to preview — the editor is empty.');
+        }
+        try {
+            DocGenService.draftHtmlBodyOverride = draftHtml;
+            Map<String, Object> result = DocGenService.generatePdfBlob(templateId, recordId);
+            Blob pdfBlob = (Blob) result.get('blob');
+            // Persist as a ContentVersion so the LWC can open Salesforce's
+            // native file-preview overlay (LWS forbids blob: iframes). One
+            // preview file per template — prior previews are deleted first.
+            String previewTitle = 'dg_pdf_preview_' + templateId;
+            List<ContentVersion> old = [
+                SELECT ContentDocumentId
+                FROM ContentVersion
+                WHERE Title = :previewTitle AND IsLatest = TRUE
+                WITH SYSTEM_MODE
+                LIMIT 10
+            ]; // NOPMD ApexCRUDViolation — internal preview artifacts, owner-scoped cleanup
+            if (!old.isEmpty()) {
+                Set<Id> docIds = new Set<Id>();
+                for (ContentVersion c : old) {
+                    docIds.add(c.ContentDocumentId);
+                }
+                delete [SELECT Id FROM ContentDocument WHERE Id IN :docIds]; // NOPMD ApexCRUDViolation
+            }
+            ContentVersion cv = new ContentVersion(
+                Title = previewTitle,
+                PathOnClient = 'preview.pdf',
+                VersionData = pdfBlob,
+                FirstPublishLocationId = templateId
+            );
+            DocGenFlsGuard.assertCreateable(cv, new Set<String>{ 'Title', 'PathOnClient', 'VersionData' });
+            insert cv; // NOPMD ApexCRUDViolation — guarded above
+            cv = [
+                SELECT Id, ContentDocumentId
+                FROM ContentVersion
+                WHERE Id = :cv.Id
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ]; // NOPMD ApexCRUDViolation — reading back the row just inserted
+            return new Map<String, Object>{
+                'contentVersionId' => cv.Id,
+                'contentDocumentId' => cv.ContentDocumentId,
+                'title' => (String) result.get('title')
+            };
+        } catch (Exception e) {
+            throw DocGenService.ahe(e, 'PDF preview failed. Check the template HTML and sample record.');
+        } finally {
+            DocGenService.draftHtmlBodyOverride = null;
+        }
+    }
+
     /** Heap-pressure signal helper — uniform shape for runner LWC auto-fallback. */
     private static Map<String, Object> heapPressureSignal(String relationshipName) {
         return new Map<String, Object>{ 'heapPressure' => true, 'giantRelationship' => relationshipName };

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -2982,6 +2982,63 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
     }
 
     /**
+     * List the images already attached to an HTML template (uploaded via
+     * saveHtmlTemplateImage — the zip/data-URI extraction path or the
+     * editor's Add Image flow). Feeds the editor's image picker so authors
+     * can re-insert existing images without knowing shepherd URLs.
+     */
+    @AuraEnabled
+    public static List<Map<String, Object>> listHtmlTemplateImages(Id templateId) {
+        if (templateId == null) {
+            throw new DocGenException('Template ID is required.');
+        }
+        try {
+            DocGenFlsGuard.assertAccessible(DocGen_Template__c.sObjectType, new Set<String>{ 'Type__c' });
+            /* code-analyzer-suppress ApexFlsViolation */
+            List<DocGen_Template__c> tpls = [
+                SELECT Id
+                FROM DocGen_Template__c
+                WHERE Id = :templateId
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ];
+            if (tpls.isEmpty()) {
+                throw DocGenService.ahe('Template not found or access denied.');
+            }
+        } catch (QueryException qe) {
+            throw DocGenService.ahe('Template not found or access denied.');
+        } catch (DocGenException fe) {
+            throw DocGenService.ahe('Template not found or access denied.');
+        }
+
+        String titlePrefix = 'docgen_html_img_' + templateId + '%';
+        DocGenFlsGuard.assertAccessible(
+            ContentVersion.sObjectType,
+            new Set<String>{ 'Title', 'PathOnClient', 'IsLatest' }
+        );
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<ContentVersion> cvs = [
+            SELECT Id, PathOnClient
+            FROM ContentVersion
+            WHERE Title LIKE :titlePrefix AND IsLatest = TRUE
+            WITH SYSTEM_MODE
+            ORDER BY CreatedDate DESC
+            LIMIT 50
+        ];
+        List<Map<String, Object>> results = new List<Map<String, Object>>();
+        for (ContentVersion cv : cvs) {
+            results.add(
+                new Map<String, Object>{
+                    'contentVersionId' => cv.Id,
+                    'fileName' => cv.PathOnClient,
+                    'url' => '/sfc/servlet.shepherd/version/download/' + cv.Id
+                }
+            );
+        }
+        return results;
+    }
+
+    /**
      * HTML template upload — body part (v1.61+).
      *
      * Final call in the client-side zip-break-apart flow. The LWC has already

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -3056,6 +3056,60 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
     }
 
     /**
+     * HTML template body read-back for the admin editor (paste-back surface).
+     *
+     * Returns the most recent docgen_html_body_* ContentVersion attached to
+     * the template, or null when no body has been uploaded yet. The CV read
+     * runs WITH SYSTEM_MODE after an explicit FLS/CRUD gate on the template —
+     * template-internal CVs can carry Visibility=InternalUsers ContentDocumentLinks,
+     * which USER_MODE reads silently drop (the #114 quirk).
+     */
+    @AuraEnabled
+    public static String getHtmlTemplateBody(Id templateId) {
+        if (templateId == null) {
+            throw new DocGenException('Template ID is required.');
+        }
+
+        List<DocGen_Template__c> tpls;
+        try {
+            DocGenFlsGuard.assertAccessible(DocGen_Template__c.sObjectType, new Set<String>{ 'Type__c' });
+            /* code-analyzer-suppress ApexFlsViolation */
+            tpls = [
+                SELECT Id, Type__c
+                FROM DocGen_Template__c
+                WHERE Id = :templateId
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ];
+        } catch (QueryException qe) {
+            throw DocGenService.ahe('Template not found or access denied.');
+        } catch (DocGenException fe) {
+            throw DocGenService.ahe('Template not found or access denied.');
+        }
+        if (tpls.isEmpty()) {
+            throw DocGenService.ahe('Template not found or access denied.');
+        }
+        if (tpls[0].Type__c != 'HTML') {
+            throw new DocGenException('getHtmlTemplateBody is for HTML-type templates only.');
+        }
+
+        String titlePrefix = 'docgen_html_body_' + templateId + '%';
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<ContentVersion> cvs = [
+            SELECT VersionData
+            FROM ContentVersion
+            WHERE Title LIKE :titlePrefix AND IsLatest = TRUE
+            WITH SYSTEM_MODE
+            ORDER BY CreatedDate DESC, Id DESC
+            LIMIT 1
+        ];
+        if (cvs.isEmpty()) {
+            return null;
+        }
+        return cvs[0].VersionData.toString();
+    }
+
+    /**
      * PDF AcroForm template upload — prepared browser-normalized body.
      *
      * Encrypted/object-stream-heavy government forms are normalized once in the

--- a/force-app/main/default/classes/DocGenController.cls
+++ b/force-app/main/default/classes/DocGenController.cls
@@ -3110,6 +3110,79 @@ public with sharing class DocGenController { // NOPMD ExcessivePublicCount — c
     }
 
     /**
+     * DOCX→HTML conversion transparency (admin editor).
+     *
+     * Returns the pre-baked docgen_tmpl_html_<versionId> snapshot for the
+     * template's active version — the exact HTML the PDF engine renders from
+     * the author's Word file — plus the decomposition status so the client
+     * can explain a missing snapshot ("Pending" = not yet baked). Read-only
+     * from the engine's perspective: the snapshot regenerates on every new
+     * DOCX upload, so edits are only honored by converting the template to
+     * Type=HTML (client-side flow).
+     *
+     * Uses the same without-sharing internal-CV loaders as the giant-query
+     * assembler — these CVs carry Visibility=InternalUsers links that
+     * USER_MODE reads silently drop (the #114 quirk).
+     */
+    @AuraEnabled
+    public static Map<String, Object> getConvertedHtmlSnapshot(Id templateId) {
+        if (templateId == null) {
+            throw new DocGenException('Template ID is required.');
+        }
+
+        try {
+            DocGenFlsGuard.assertAccessible(DocGen_Template__c.sObjectType, new Set<String>{ 'Type__c' });
+            /* code-analyzer-suppress ApexFlsViolation */
+            List<DocGen_Template__c> tpls = [
+                SELECT Id
+                FROM DocGen_Template__c
+                WHERE Id = :templateId
+                WITH SYSTEM_MODE
+                LIMIT 1
+            ];
+            if (tpls.isEmpty()) {
+                throw DocGenService.ahe('Template not found or access denied.');
+            }
+        } catch (QueryException qe) {
+            throw DocGenService.ahe('Template not found or access denied.');
+        } catch (DocGenException fe) {
+            throw DocGenService.ahe('Template not found or access denied.');
+        }
+
+        DocGenFlsGuard.assertAccessible(
+            DocGen_Template_Version__c.sObjectType,
+            new Set<String>{ 'Is_Active__c', 'Pre_Decomposition_Status__c' }
+        );
+        /* code-analyzer-suppress ApexFlsViolation */
+        List<DocGen_Template_Version__c> vers = [
+            SELECT Id, Name, Pre_Decomposition_Status__c
+            FROM DocGen_Template_Version__c
+            WHERE Template__c = :templateId AND Is_Active__c = TRUE
+            WITH SYSTEM_MODE
+            LIMIT 1
+        ];
+        if (vers.isEmpty()) {
+            return new Map<String, Object>{ 'html' => null, 'status' => 'NoActiveVersion' };
+        }
+
+        String htmlTitle = 'docgen_tmpl_html_' + vers[0].Id;
+        List<ContentVersion> htmlCvs = DocGenService.loadInternalContentVersionsForVersionByTitle(
+            vers[0].Id,
+            htmlTitle
+        );
+        if (htmlCvs.isEmpty()) {
+            htmlCvs = DocGenService.loadInternalContentVersionsByTitle(htmlTitle);
+        }
+
+        return new Map<String, Object>{
+            'html' => htmlCvs.isEmpty() ? null : htmlCvs[0].VersionData.toString(),
+            'versionId' => vers[0].Id,
+            'versionName' => vers[0].Name,
+            'status' => vers[0].Pre_Decomposition_Status__c
+        };
+    }
+
+    /**
      * PDF AcroForm template upload — prepared browser-normalized body.
      *
      * Encrypted/object-stream-heavy government forms are normalized once in the

--- a/force-app/main/default/classes/DocGenHtmlTemplateTest.cls
+++ b/force-app/main/default/classes/DocGenHtmlTemplateTest.cls
@@ -824,4 +824,50 @@ private class DocGenHtmlTemplateTest {
         Test.stopTest();
         System.assertEquals('<p>A &amp; B &lt;C&gt;</p>', result, 'XML-special chars escaped');
     }
+
+    // Designer live PDF preview: draft HTML replaces the saved body for the
+    // merge, renders through the real pipeline, and never touches versions.
+    @IsTest
+    static void previewDraftPdfRendersDraftHtmlNotSavedBody() {
+        Account acct = [SELECT Id FROM Account LIMIT 1];
+        Id tmplId = createHtmlTemplate(null, null, '<html><body><p>SAVED BODY {Name}</p></body></html>');
+
+        Test.startTest();
+        Map<String, Object> result = DocGenController.previewDraftPdf(
+            tmplId,
+            acct.Id,
+            '<html><body><h1>DRAFT ONLY {Name} — {Industry}</h1></body></html>'
+        );
+        Test.stopTest();
+
+        System.assertNotEquals(null, result.get('contentDocumentId'), 'Preview should return a ContentDocument Id');
+        Integer previews = [
+            SELECT COUNT()
+            FROM ContentVersion
+            WHERE Title = :('dg_pdf_preview_' + tmplId) AND IsLatest = TRUE
+        ];
+        System.assertEquals(1, previews, 'Exactly one preview file should exist');
+        String rendered = DocGenService.lastRenderedHtml;
+        System.assert(rendered.contains('DRAFT ONLY'), 'Draft body should be the rendered document: ' + rendered);
+        System.assert(rendered.contains('HTMLTpl Test Co'), 'Merge tags must resolve in the draft: ' + rendered);
+        System.assert(!rendered.contains('SAVED BODY'), 'Saved body must NOT render when a draft is supplied');
+        // The override is one-shot — cleared even on success.
+        System.assertEquals(null, DocGenService.draftHtmlBodyOverride, 'Override must be cleared after preview');
+        Integer versions = [SELECT COUNT() FROM DocGen_Template_Version__c WHERE Template__c = :tmplId];
+        System.assertEquals(1, versions, 'Preview must not create template versions');
+    }
+
+    @IsTest
+    static void previewDraftPdfRejectsEmptyDraft() {
+        Account acct = [SELECT Id FROM Account LIMIT 1];
+        Id tmplId = createHtmlTemplate(null, null, '<html><body><p>{Name}</p></body></html>');
+        Boolean threw = false;
+        try {
+            DocGenController.previewDraftPdf(tmplId, acct.Id, '   ');
+        } catch (AuraHandledException e) {
+            threw = true;
+        }
+        System.assert(threw, 'Blank draft must be rejected');
+        System.assertEquals(null, DocGenService.draftHtmlBodyOverride, 'Override must stay clear');
+    }
 }

--- a/force-app/main/default/classes/DocGenHtmlTemplateTest.cls
+++ b/force-app/main/default/classes/DocGenHtmlTemplateTest.cls
@@ -299,6 +299,51 @@ private class DocGenHtmlTemplateTest {
     }
 
     @IsTest
+    static void getHtmlTemplateBodyReturnsLatestBody() {
+        DocGen_Template__c tmpl = new DocGen_Template__c(
+            Name = 'BodyRead ' + Datetime.now().getTime(),
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF',
+            Base_Object_API__c = 'Account',
+            Query_Config__c = 'Name'
+        );
+        insert tmpl;
+
+        System.assertEquals(null, DocGenController.getHtmlTemplateBody(tmpl.Id), 'No body yet — expect null');
+
+        DocGenController.saveHtmlTemplateBody(tmpl.Id, 'v1.html', '<html><body>first</body></html>');
+        String htmlV2 = '<html><body><h1>{Name}</h1>second</body></html>';
+
+        Test.startTest();
+        DocGenController.saveHtmlTemplateBody(tmpl.Id, 'v2.html', htmlV2);
+        String readBack = DocGenController.getHtmlTemplateBody(tmpl.Id);
+        Test.stopTest();
+
+        System.assertEquals(htmlV2, readBack, 'Read-back should return the most recent body verbatim');
+    }
+
+    @IsTest
+    static void getHtmlTemplateBodyRejectsNonHtmlTemplate() {
+        DocGen_Template__c tmpl = new DocGen_Template__c(
+            Name = 'WordRead ' + Datetime.now().getTime(),
+            Type__c = 'Word',
+            Output_Format__c = 'PDF',
+            Base_Object_API__c = 'Account',
+            Query_Config__c = 'Name'
+        );
+        insert tmpl;
+
+        Boolean threw = false;
+        try {
+            DocGenController.getHtmlTemplateBody(tmpl.Id);
+        } catch (Exception e) {
+            threw = true;
+            System.assert(e.getMessage().contains('HTML-type'), 'Error should mention HTML-type: ' + e.getMessage());
+        }
+        System.assert(threw, 'Should refuse non-HTML templates');
+    }
+
+    @IsTest
     static void saveHtmlTemplateImageRejectsNonHtmlTemplate() {
         DocGen_Template__c tmpl = new DocGen_Template__c(
             Name = 'Word ' + Datetime.now().getTime(),

--- a/force-app/main/default/classes/DocGenHtmlTemplateTest.cls
+++ b/force-app/main/default/classes/DocGenHtmlTemplateTest.cls
@@ -816,6 +816,42 @@ private class DocGenHtmlTemplateTest {
         System.assert(!result.contains('<w:r>'), 'HTML output must not contain DOCX runs: ' + result);
     }
 
+    // Aggregate tags: full format-suffix surface (Dave's spec) — bare COUNT,
+    // :number, :currency, ISO+locale segments, and currency:auto=Field.
+    @IsTest
+    static void aggregateTagsSupportFullFormatSuffixes() {
+        List<Object> lines = new List<Object>{
+            new Map<String, Object>{ 'Amount' => 20000, 'UnitPrice' => 100 },
+            new Map<String, Object>{ 'Amount' => 30000, 'UnitPrice' => 155 }
+        };
+        Map<String, Object> data = new Map<String, Object>{
+            'CustomerCurrency__c' => 'EUR',
+            'Lines' => new Map<String, Object>{ 'records' => lines }
+        };
+        Test.startTest();
+        String outp = DocGenService.processXmlForTest(
+            '<p>C={COUNT:Lines}|CN={COUNT:Lines:number}|S={SUM:Lines.Amount}' +
+                '|SC={SUM:Lines.Amount:currency}|SDE={SUM:Lines.Amount:currency:EUR:de_DE}' +
+                '|AV={AVG:Lines.UnitPrice:currency}|MN={MIN:Lines.Amount:currency}' +
+                '|MX={MAX:Lines.Amount:currency:GBP}|AUTO={SUM:Lines.Amount:currency:auto=CustomerCurrency__c}</p>',
+            data,
+            'HTML'
+        );
+        Test.stopTest();
+        System.assert(outp.contains('C=2|'), 'bare COUNT: ' + outp);
+        System.assert(outp.contains('CN=2|'), 'COUNT:number: ' + outp);
+        System.assert(outp.contains('S=50000|'), 'raw SUM: ' + outp);
+        System.assert(outp.contains('SC=$50,000.00|'), 'SUM currency: ' + outp);
+        System.assert(outp.contains('SDE=50.000,00'), 'ISO+locale de_DE grouping: ' + outp);
+        System.assert(outp.contains('AV=$127.50|'), 'AVG currency: ' + outp);
+        System.assert(outp.contains('MN=$20,000.00|'), 'MIN currency: ' + outp);
+        System.assert(outp.contains('MX=£30,000.00|'), 'MAX currency GBP: ' + outp);
+        System.assert(
+            outp.contains('AUTO=') && outp.substringAfter('AUTO=').contains('€'),
+            'currency:auto=Field should use EUR: ' + outp
+        );
+    }
+
     @IsTest
     static void singleLinePlainTextEscapesXmlForHtmlTemplates() {
         Map<String, Object> data = new Map<String, Object>{ 'Name' => 'A & B <C>' };

--- a/force-app/main/default/classes/DocGenHtmlTemplateTest.cls
+++ b/force-app/main/default/classes/DocGenHtmlTemplateTest.cls
@@ -344,6 +344,53 @@ private class DocGenHtmlTemplateTest {
     }
 
     @IsTest
+    static void getConvertedHtmlSnapshotReturnsBakedHtmlAndStatus() {
+        DocGen_Template__c tmpl = new DocGen_Template__c(
+            Name = 'DocxSnap ' + Datetime.now().getTime(),
+            Type__c = 'Word',
+            Output_Format__c = 'PDF',
+            Base_Object_API__c = 'Account',
+            Query_Config__c = 'Name'
+        );
+        insert tmpl;
+
+        // No active version yet
+        Map<String, Object> r0 = DocGenController.getConvertedHtmlSnapshot(tmpl.Id);
+        System.assertEquals('NoActiveVersion', r0.get('status'), 'Expected NoActiveVersion before any version');
+
+        DocGen_Template_Version__c ver = new DocGen_Template_Version__c(
+            Template__c = tmpl.Id,
+            Is_Active__c = true,
+            Type__c = 'Word',
+            Base_Object_API__c = 'Account',
+            Query_Config__c = 'Name',
+            Pre_Decomposition_Status__c = 'Complete'
+        );
+        Database.insert(ver, AccessLevel.SYSTEM_MODE);
+
+        // Pending snapshot: version exists, no baked CV yet
+        Map<String, Object> r1 = DocGenController.getConvertedHtmlSnapshot(tmpl.Id);
+        System.assertEquals(null, r1.get('html'), 'No snapshot CV yet — html should be null');
+        System.assertEquals('Complete', r1.get('status'), 'Status should surface the version decomp status');
+
+        String snapshotHtml = '<html><body><h1>{Name}</h1>CONVERTED</body></html>';
+        insert new ContentVersion(
+            Title = 'docgen_tmpl_html_' + ver.Id,
+            PathOnClient = 'snapshot.html',
+            VersionData = Blob.valueOf(snapshotHtml),
+            IsMajorVersion = false,
+            FirstPublishLocationId = ver.Id
+        );
+
+        Test.startTest();
+        Map<String, Object> r2 = DocGenController.getConvertedHtmlSnapshot(tmpl.Id);
+        Test.stopTest();
+
+        System.assertEquals(snapshotHtml, r2.get('html'), 'Baked snapshot HTML should be returned verbatim');
+        System.assertEquals(ver.Id, r2.get('versionId'), 'Active version id expected');
+    }
+
+    @IsTest
     static void saveHtmlTemplateImageRejectsNonHtmlTemplate() {
         DocGen_Template__c tmpl = new DocGen_Template__c(
             Name = 'Word ' + Datetime.now().getTime(),

--- a/force-app/main/default/classes/DocGenHtmlTemplateTest.cls
+++ b/force-app/main/default/classes/DocGenHtmlTemplateTest.cls
@@ -344,6 +344,33 @@ private class DocGenHtmlTemplateTest {
     }
 
     @IsTest
+    static void listHtmlTemplateImagesReturnsUploadedImages() {
+        DocGen_Template__c tmpl = new DocGen_Template__c(
+            Name = 'ImgList ' + Datetime.now().getTime(),
+            Type__c = 'HTML',
+            Output_Format__c = 'PDF',
+            Base_Object_API__c = 'Account',
+            Query_Config__c = 'Name'
+        );
+        insert tmpl;
+
+        System.assertEquals(0, DocGenController.listHtmlTemplateImages(tmpl.Id).size(), 'No images yet');
+
+        String pngB64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+        DocGenController.saveHtmlTemplateImage(tmpl.Id, 'logo.png', pngB64);
+        DocGenController.saveHtmlTemplateImage(tmpl.Id, 'hero.png', pngB64);
+
+        Test.startTest();
+        List<Map<String, Object>> imgs = DocGenController.listHtmlTemplateImages(tmpl.Id);
+        Test.stopTest();
+
+        System.assertEquals(2, imgs.size(), 'Both uploaded images should be listed');
+        String url = (String) imgs[0].get('url');
+        System.assert(url.startsWith('/sfc/servlet.shepherd/version/download/'), 'Relative shepherd URL expected');
+        System.assertNotEquals(null, imgs[0].get('fileName'), 'File name expected');
+    }
+
+    @IsTest
     static void getConvertedHtmlSnapshotReturnsBakedHtmlAndStatus() {
         DocGen_Template__c tmpl = new DocGen_Template__c(
             Name = 'DocxSnap ' + Datetime.now().getTime(),

--- a/force-app/main/default/classes/DocGenService.cls
+++ b/force-app/main/default/classes/DocGenService.cls
@@ -10,6 +10,9 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
     private static String currentEntryName;
     @TestVisible
     private static String currentOutputFormat = 'Native'; // Set before processXml — PDF skips blob loading for images
+    // Designer live PDF preview: when set, HTML-template merges render this
+    // draft body instead of the saved one. See mergeTemplate().
+    public static String draftHtmlBodyOverride;
     // Signer form fields ({?key} tags): preserved verbatim during the send-time
     // merge / snapshot freeze (so the placeholder survives into the signed-doc
     // template), then resolved when the signature finalize re-render flips this
@@ -598,6 +601,13 @@ global with sharing class DocGenService { // NOPMD AvoidGlobalModifier — globa
         // Allow callers to force PDF output format
         if (outputFormatOverride != null) {
             outputFormat = outputFormatOverride;
+        }
+
+        // Designer live-preview: render caller-supplied draft HTML in place of
+        // the saved body (HTML templates only). One-shot — cleared by the
+        // controller in a finally block so it never leaks into a later merge.
+        if (draftHtmlBodyOverride != null && templateType == 'HTML') {
+            base64File = EncodingUtil.base64Encode(Blob.valueOf(draftHtmlBodyOverride));
         }
 
         if (base64File == null) {

--- a/force-app/main/default/classes/DocGenTemplateManager.cls
+++ b/force-app/main/default/classes/DocGenTemplateManager.cls
@@ -8,6 +8,12 @@ public with sharing class DocGenTemplateManager {
         if (templateId == null) {
             throw new DocGenException('Template ID is required.');
         }
+        // Designer live-preview override: render the caller-supplied draft in
+        // place of the saved body. Handled here (not just in mergeTemplate) so
+        // a brand-new template with NO saved version can still preview.
+        if (DocGenService.draftHtmlBodyOverride != null) {
+            return EncodingUtil.base64Encode(Blob.valueOf(DocGenService.draftHtmlBodyOverride));
+        }
 
         // Object-level CRUD gate — caller (generateDocumentData) has already
         // enforced Template CRUD; this redundant check documents enforcement

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -567,15 +567,28 @@
 }
 
 /* --- Full-screen Designer tab --- */
+/* Sticky glass chrome: toolbar + statusbar stay at hand while the page scrolls. */
+.dg-designer-chrome {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    background: rgba(255, 255, 255, 0.92);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid #e2e0ef;
+    border-top: 3px solid #7c3aed;
+    border-radius: 0 0 12px 12px;
+    padding: 6px 12px 6px 12px;
+    margin-bottom: 8px;
+    box-shadow: 0 6px 18px rgba(28, 20, 68, 0.08);
+}
+
 .dg-designer-toolbar {
     display: flex;
     align-items: center;
     gap: 12px;
-    margin-bottom: 10px;
-    padding: 10px 14px;
-    background: #fff;
-    border: 1px solid #d8dde6;
-    border-radius: 10px;
+    padding: 4px 0 6px 0;
+    border-bottom: 1px solid #edeaf7;
 }
 
 .dg-designer-toolbar__title {
@@ -616,9 +629,20 @@
 
 .dg-designer-rail {
     flex: 0 0 340px;
-    max-height: calc(100vh - 290px);
+    position: sticky;
+    top: 106px;
+    align-self: flex-start;
+    max-height: calc(100vh - 130px);
     overflow-y: auto;
     padding-right: 2px;
+}
+
+/* Statusbar inside the sticky chrome: tighter, no extra margins. */
+.dg-designer-chrome .dg-html-editor-statusbar {
+    margin-bottom: 0;
+    padding-top: 6px;
+    flex-wrap: wrap;
+    gap: 4px;
 }
 
 .dg-rail-section-label {
@@ -654,33 +678,51 @@
 
 /* --- Visual-mode format bar --- */
 .dg-format-bar {
+    position: sticky;
+    top: 100px;
+    z-index: 30;
     display: flex;
     align-items: center;
     flex-wrap: wrap;
     gap: 4px;
     padding: 6px 10px;
-    background: #fff;
-    border: 1px solid #d8dde6;
-    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.94);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border: 1px solid #e2e0ef;
+    border-radius: 10px;
     margin-bottom: 6px;
+    box-shadow: 0 4px 14px rgba(28, 20, 68, 0.07);
 }
 
 .dg-fmt-btn {
     min-width: 28px;
     height: 26px;
     border: 1px solid #d8dde6;
-    border-radius: 5px;
+    border-radius: 6px;
     background: #fff;
     cursor: pointer;
     font-size: 0.8rem;
     color: #16325c;
     padding: 0 6px;
     font-family: inherit;
+    transition:
+        background 0.12s ease,
+        border-color 0.12s ease,
+        transform 0.12s ease,
+        box-shadow 0.12s ease;
 }
 
 .dg-fmt-btn:hover {
     background: #f4f2ff;
-    border-color: #c9b8f5;
+    border-color: #b49aef;
+    transform: translateY(-1px);
+    box-shadow: 0 2px 6px rgba(124, 58, 237, 0.18);
+}
+
+.dg-fmt-btn:active {
+    transform: translateY(0);
+    box-shadow: none;
 }
 
 .dg-fmt-btn_word {
@@ -889,4 +931,77 @@
     padding: 0 4px;
     margin-left: 4px;
     flex: 0 0 auto;
+}
+
+/* --- AI wizard step: prompt → assets → paste --- */
+.dg-ai-step-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0 0 4px 0;
+    font-size: 0.95rem;
+}
+
+.dg-ai-step-num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: #7c3aed;
+    color: #fff;
+    font-weight: 700;
+    font-size: 0.8rem;
+    flex: 0 0 auto;
+}
+
+.dg-ai-prompt_tall {
+    max-height: 420px;
+    overflow: auto;
+}
+
+.dg-ai-asset-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 4px;
+}
+
+.dg-ai-paste {
+    width: 100%;
+    height: 260px;
+    font-family: 'SF Mono', Consolas, Menlo, monospace;
+    font-size: 0.78rem;
+    line-height: 1.45;
+    border: 1px solid #d8dde6;
+    border-radius: 8px;
+    padding: 10px;
+    resize: vertical;
+    background: #fff;
+    box-sizing: border-box;
+}
+
+.dg-ai-paste:focus {
+    outline: none;
+    border-color: #7c3aed;
+    box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.15);
+}
+
+/* Designer canvas backdrop: soft depth behind the paper sheet. */
+.dg-visual-host.dg-designer-size {
+    background: radial-gradient(ellipse at 50% 0%, #eceef4 0%, #dde1ea 70%, #d4d9e4 100%);
+    border-color: #d3d0e6;
+}
+
+.dg-starter-card-obj {
+    margin-left: auto;
+    font-size: 0.68rem;
+    font-weight: 700;
+    color: #7c3aed;
+    background: #f4f2ff;
+    border: 1px solid #ddd3f7;
+    border-radius: 10px;
+    padding: 1px 8px;
+    white-space: nowrap;
 }

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -744,14 +744,6 @@
 
 .dg-code-split .dg-html-body-editor {
     width: 100%;
-    height: 34vh !important;
-    min-height: 220px !important;
-}
-
-.dg-code-split .dg-code-preview {
-    width: 100%;
-    height: calc(100vh - 420px) !important;
-    min-height: 380px !important;
 }
 
 .dg-fmt-colorpick {

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -735,21 +735,23 @@
     height: 0;
 }
 
-/* Code mode: editor and live preview side by side */
+/* Source mode: code on top, full-width live page preview below */
 .dg-code-split {
     display: flex;
+    flex-direction: column;
     gap: 10px;
-    align-items: stretch;
 }
 
 .dg-code-split .dg-html-body-editor {
-    flex: 1 1 50%;
-    min-width: 0;
+    width: 100%;
+    height: 34vh !important;
+    min-height: 220px !important;
 }
 
 .dg-code-split .dg-code-preview {
-    flex: 1 1 50%;
-    min-width: 0;
+    width: 100%;
+    height: calc(100vh - 420px) !important;
+    min-height: 380px !important;
 }
 
 .dg-fmt-colorpick {
@@ -765,4 +767,52 @@
 .dg-fmt-colorpick:hover {
     outline: 2px solid #7c3aed;
     outline-offset: 1px;
+}
+
+/* Visual | Source segmented switch */
+.dg-mode-seg {
+    display: inline-flex;
+    border: 1px solid #d8dde6;
+    border-radius: 7px;
+    overflow: hidden;
+    margin-right: 8px;
+    flex: 0 0 auto;
+}
+
+.dg-mode-seg .dg-mode-btn {
+    border: none;
+    border-radius: 0;
+    min-width: 62px;
+    height: 28px;
+}
+
+.dg-mode-btn_active {
+    background: #7c3aed !important;
+    color: #fff !important;
+    font-weight: 700;
+}
+
+.dg-context-label {
+    flex: 0 0 auto;
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: #7c3aed;
+    background: #f4f2ff;
+    border: 1px solid #c9b8f5;
+    border-radius: 10px;
+    padding: 2px 10px;
+    margin-right: 8px;
+    white-space: nowrap;
+}
+
+.dg-page-select {
+    height: 26px;
+    border: 1px solid #d8dde6;
+    border-radius: 5px;
+    background: #fff;
+    font-size: 0.72rem;
+    color: #16325c;
+    padding: 0 4px;
+    margin-left: 4px;
+    flex: 0 0 auto;
 }

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -1213,3 +1213,21 @@
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+.dg-slash-foot {
+    border-top: 1px solid #f0eef8;
+    margin-top: 4px;
+    padding: 6px 10px 4px 10px;
+    font-size: 0.68rem;
+    color: #9a93b5;
+}
+
+.dg-slash-foot a {
+    color: #7c3aed;
+    text-decoration: none;
+    font-weight: 700;
+}
+
+.dg-slash-foot a:hover {
+    text-decoration: underline;
+}

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -418,3 +418,27 @@
     background: #fff;
     box-sizing: border-box;
 }
+
+.dg-html-editor-statusbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 4px;
+}
+
+.dg-html-editor-status {
+    font-size: 0.78rem;
+    color: #444;
+    background: #f2f4f7;
+    border: 1px solid #d8dde6;
+    border-radius: 6px;
+    padding: 4px 10px;
+    flex: 1 1 auto;
+}
+
+.dg-html-editor-status_dirty {
+    background: #fef4e5;
+    border-color: #e6a233;
+    color: #7a4a00;
+    font-weight: 600;
+}

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -734,3 +734,35 @@
     flex-basis: 100%;
     height: 0;
 }
+
+/* Code mode: editor and live preview side by side */
+.dg-code-split {
+    display: flex;
+    gap: 10px;
+    align-items: stretch;
+}
+
+.dg-code-split .dg-html-body-editor {
+    flex: 1 1 50%;
+    min-width: 0;
+}
+
+.dg-code-split .dg-code-preview {
+    flex: 1 1 50%;
+    min-width: 0;
+}
+
+.dg-fmt-colorpick {
+    width: 26px;
+    height: 26px;
+    padding: 1px;
+    border: 1px solid #d8dde6;
+    border-radius: 5px;
+    cursor: pointer;
+    background: #fff;
+}
+
+.dg-fmt-colorpick:hover {
+    outline: 2px solid #7c3aed;
+    outline-offset: 1px;
+}

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -816,3 +816,85 @@
     margin-left: 4px;
     flex: 0 0 auto;
 }
+
+/* Pill inspector menu */
+.dg-designer-canvas-col {
+    position: relative;
+}
+
+.dg-pill-menu {
+    position: absolute;
+    z-index: 120;
+    background: #fff;
+    border: 1px solid #c9b8f5;
+    border-radius: 8px;
+    box-shadow: 0 6px 20px rgba(76, 54, 140, 0.25);
+    min-width: 220px;
+    max-width: 280px;
+    padding: 6px;
+}
+
+.dg-pill-menu-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 2px 6px 6px;
+    border-bottom: 1px solid #eee9fb;
+    margin-bottom: 4px;
+}
+
+.dg-pill-menu-head code {
+    font-size: 0.72rem;
+    color: #5a3fc4;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.dg-pill-menu-x {
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: #706e6b;
+    font-size: 0.8rem;
+    padding: 2px 4px;
+}
+
+.dg-pill-menu-item {
+    display: block;
+    width: 100%;
+    text-align: left;
+    border: none;
+    background: none;
+    padding: 5px 8px;
+    font-size: 0.78rem;
+    color: #16325c;
+    border-radius: 5px;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.dg-pill-menu-item:hover {
+    background: #f4f2ff;
+    color: #5a3fc4;
+}
+
+.dg-pill-menu-remove {
+    color: #b91c1c;
+    border-top: 1px solid #eee9fb;
+    border-radius: 0 0 5px 5px;
+    margin-top: 4px;
+}
+
+.dg-page-input {
+    width: 58px;
+    height: 26px;
+    border: 1px solid #d8dde6;
+    border-radius: 5px;
+    font-size: 0.72rem;
+    color: #16325c;
+    padding: 0 4px;
+    margin-left: 4px;
+    flex: 0 0 auto;
+}

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -1236,3 +1236,15 @@
     min-width: 220px;
     max-width: 300px;
 }
+
+.dg-beta-chip {
+    flex: 0 0 auto;
+    font-size: 0.62rem;
+    font-weight: 800;
+    letter-spacing: 1px;
+    color: #fff;
+    background: linear-gradient(135deg, #7c3aed, #9f6bff);
+    border-radius: 8px;
+    padding: 2px 8px;
+    cursor: help;
+}

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -454,3 +454,112 @@
     padding: 20px;
     box-sizing: border-box;
 }
+
+.dg-image-panel {
+    border: 1px solid #d8dde6;
+    border-radius: 8px;
+    padding: 12px 14px;
+    background: #fafbfc;
+}
+
+.dg-image-panel-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.dg-image-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.dg-image-thumb {
+    width: 96px;
+    border: 1.5px solid #d8dde6;
+    border-radius: 6px;
+    padding: 6px;
+    cursor: pointer;
+    background: #fff;
+    text-align: center;
+}
+
+.dg-image-thumb:hover {
+    border-color: #7c3aed;
+    box-shadow: 0 2px 8px rgba(124, 58, 237, 0.15);
+}
+
+.dg-image-thumb img {
+    max-width: 80px;
+    max-height: 56px;
+    object-fit: contain;
+    display: block;
+    margin: 0 auto;
+}
+
+.dg-image-thumb-name {
+    display: block;
+    font-size: 0.65rem;
+    color: #54585d;
+    margin-top: 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.dg-visual-editor-wrap {
+    border: 1px solid #d8dde6;
+    border-radius: 6px;
+    background: #fff;
+}
+
+.dg-tag-panel {
+    border: 1px solid #d8dde6;
+    border-radius: 8px;
+    padding: 12px 14px;
+    background: #fafbfc;
+    max-height: 320px;
+    overflow-y: auto;
+}
+
+.dg-tag-section {
+    margin-bottom: 12px;
+}
+
+.dg-tag-section-label {
+    font-weight: 700;
+    font-size: 0.8rem;
+    color: #1f3a5f;
+    margin-bottom: 2px;
+}
+
+.dg-tag-section-hint {
+    font-size: 0.72rem;
+    color: #706e6b;
+    margin-bottom: 5px;
+}
+
+.dg-tag-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.dg-tag-chip {
+    border: 1px solid #c9c7f5;
+    background: #f4f2ff;
+    color: #4a3aa3;
+    border-radius: 12px;
+    padding: 3px 11px;
+    font-size: 0.75rem;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.dg-tag-chip:hover {
+    background: #7c3aed;
+    border-color: #7c3aed;
+    color: #fff;
+}

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -442,3 +442,15 @@
     color: #7a4a00;
     font-weight: 600;
 }
+
+.dg-html-preview-frame {
+    width: 100%;
+    height: 460px;
+    border: 1px solid #d8dde6;
+    border-radius: 6px;
+    background: #e8eaed;
+    display: block;
+    overflow: auto;
+    padding: 20px;
+    box-sizing: border-box;
+}

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -1005,3 +1005,193 @@
     padding: 1px 8px;
     white-space: nowrap;
 }
+
+/* --- Slash-command menu (type "/" in the page) --- */
+.dg-slash-menu {
+    position: absolute;
+    z-index: 60;
+    min-width: 300px;
+    max-width: 380px;
+    background: #fff;
+    border: 1px solid #e2e0ef;
+    border-radius: 10px;
+    box-shadow: 0 10px 30px rgba(28, 20, 68, 0.18);
+    padding: 4px;
+}
+
+.dg-slash-menu-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 0.7rem;
+    color: #6b6b80;
+    padding: 4px 8px 2px 8px;
+}
+
+.dg-slash-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    width: 100%;
+    border: 0;
+    background: transparent;
+    padding: 7px 10px;
+    border-radius: 7px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85rem;
+    color: #16325c;
+    text-align: left;
+}
+
+.dg-slash-item:hover,
+.dg-slash-item_active {
+    background: #f4f2ff;
+}
+
+.dg-slash-item_active {
+    outline: 1px solid #c9b8f5;
+}
+
+.dg-slash-item-label {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.dg-slash-item-group {
+    font-size: 0.68rem;
+    color: #9a93b5;
+    white-space: nowrap;
+    flex: 0 0 auto;
+}
+
+.dg-slash-empty {
+    padding: 10px;
+    font-size: 0.8rem;
+    color: #6b6b80;
+}
+
+/* --- Floating searchable panel (replaces the fixed right rail) --- */
+.dg-float-panel {
+    position: fixed;
+    right: 22px;
+    top: 165px;
+    bottom: 26px;
+    width: 360px;
+    z-index: 55;
+    overflow-y: auto;
+    background: rgba(255, 255, 255, 0.97);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid #e2e0ef;
+    border-radius: 14px;
+    box-shadow: 0 14px 40px rgba(28, 20, 68, 0.22);
+    padding: 12px 14px;
+}
+
+.dg-float-panel-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+}
+
+.dg-float-panel-title {
+    font-weight: 800;
+    font-size: 0.95rem;
+    color: #1f3a5f;
+}
+
+.dg-float-panel-tip {
+    font-size: 0.75rem;
+    color: #6b6b80;
+    margin: 0 0 8px 0;
+}
+
+.dg-float-panel-tip code {
+    background: #f4f2ff;
+    border: 1px solid #ddd3f7;
+    border-radius: 4px;
+    padding: 0 5px;
+    color: #7c3aed;
+    font-weight: 700;
+}
+
+.dg-panel-search {
+    width: 100%;
+    box-sizing: border-box;
+    border: 1px solid #d8dde6;
+    border-radius: 8px;
+    padding: 8px 10px;
+    font-size: 0.85rem;
+    font-family: inherit;
+    margin-bottom: 10px;
+}
+
+.dg-panel-search:focus {
+    outline: none;
+    border-color: #7c3aed;
+    box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.15);
+}
+
+.dg-panel-btn {
+    font-weight: 700;
+    color: #7c3aed;
+    border-color: #ddd3f7;
+    background: #faf9ff;
+}
+
+/* --- Live PDF preview panel --- */
+.dg-pdf-preview-panel {
+    position: fixed;
+    right: 22px;
+    top: 150px;
+    bottom: 24px;
+    width: 44vw;
+    min-width: 420px;
+    z-index: 56;
+    display: flex;
+    flex-direction: column;
+    background: #fff;
+    border: 1px solid #e2e0ef;
+    border-radius: 14px;
+    box-shadow: 0 14px 40px rgba(28, 20, 68, 0.25);
+    padding: 10px 12px 12px 12px;
+}
+
+.dg-pdf-frame {
+    flex: 1 1 auto;
+    width: 100%;
+    border: 1px solid #e2e0ef;
+    border-radius: 8px;
+    background: #525659;
+}
+
+.dg-pdf-preview-btn {
+    color: #0b7a3e;
+    border-color: #bfe5cf;
+    background: #f2fbf6;
+}
+
+.dg-logo-preview {
+    display: block;
+    max-width: 160px;
+    max-height: 64px;
+    margin-top: 6px;
+    border: 1px solid #e2e0ef;
+    border-radius: 8px;
+    padding: 4px;
+    background: #fff;
+}
+
+.dg-asset-thumb-tag {
+    display: block;
+    font-family: 'SF Mono', Consolas, Menlo, monospace;
+    font-size: 0.62rem;
+    color: #0b7a3e;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -1248,3 +1248,28 @@
     padding: 2px 8px;
     cursor: help;
 }
+
+.dg-pill-menu-scroll {
+    max-height: 340px;
+    overflow-y: auto;
+}
+
+.dg-pill-menu-sec {
+    font-size: 0.65rem;
+    font-weight: 800;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    color: #9a93b5;
+    padding: 7px 10px 3px 10px;
+    border-top: 1px solid #f0eef8;
+    margin-top: 2px;
+}
+
+.dg-pill-menu-sec:first-child {
+    border-top: 0;
+}
+
+.dg-pill-menu-item_active {
+    background: #f4f2ff;
+    outline: 1px solid #c9b8f5;
+}

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -509,10 +509,12 @@
     white-space: nowrap;
 }
 
-.dg-visual-editor-wrap {
-    border: 1px solid #d8dde6;
-    border-radius: 6px;
-    background: #fff;
+/* Visual mode: the editable rendered page needs a visible caret + focus cue */
+.dg-html-preview-frame .dg-pv[contenteditable='true'] {
+    outline: 2px dashed #b49aef;
+    outline-offset: 6px;
+    cursor: text;
+    caret-color: #7c3aed;
 }
 
 .dg-tag-panel {

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -1231,3 +1231,8 @@
 .dg-slash-foot a:hover {
     text-decoration: underline;
 }
+
+.dg-designer-template-switch {
+    min-width: 220px;
+    max-width: 300px;
+}

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -292,3 +292,129 @@
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
     padding: 4px 0;
 }
+
+/* --- HTML-first authoring path (create wizard) --- */
+.dg-authoring-cards {
+    display: flex;
+    gap: 12px;
+}
+
+.dg-authoring-card {
+    flex: 1 1 0;
+    border: 2px solid #d8dde6;
+    border-radius: 10px;
+    padding: 14px 16px;
+    cursor: pointer;
+    background: #fff;
+    transition:
+        border-color 0.12s ease,
+        box-shadow 0.12s ease;
+}
+
+.dg-authoring-card:hover {
+    border-color: #9a77e8;
+    box-shadow: 0 2px 8px rgba(124, 58, 237, 0.12);
+}
+
+.dg-authoring-card_selected,
+.dg-authoring-card_selected:hover {
+    border-color: #7c3aed;
+    background: #faf8ff;
+    box-shadow: 0 2px 10px rgba(124, 58, 237, 0.18);
+}
+
+.dg-authoring-card-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+}
+
+.dg-authoring-card-title {
+    font-weight: 700;
+    font-size: 0.95rem;
+}
+
+.dg-authoring-badge {
+    margin-left: auto;
+    font-size: 0.68rem;
+    font-weight: 700;
+    color: #fff;
+    background: #7c3aed;
+    padding: 2px 9px;
+    border-radius: 10px;
+    white-space: nowrap;
+}
+
+.dg-authoring-card-desc {
+    font-size: 0.8rem;
+    color: #54585d;
+    margin: 0;
+    line-height: 1.4;
+}
+
+.dg-starter-card {
+    border: 1.5px solid #d8dde6;
+    border-radius: 8px;
+    padding: 10px 12px;
+    margin-bottom: 8px;
+    cursor: pointer;
+    background: #fff;
+}
+
+.dg-starter-card:hover {
+    border-color: #9a77e8;
+}
+
+.dg-starter-card_selected,
+.dg-starter-card_selected:hover {
+    border-color: #7c3aed;
+    background: #faf8ff;
+}
+
+.dg-starter-card-head {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 3px;
+}
+
+.dg-starter-card-title {
+    font-weight: 700;
+    font-size: 0.85rem;
+}
+
+.dg-starter-card-desc {
+    font-size: 0.76rem;
+    color: #54585d;
+    margin: 0;
+    line-height: 1.35;
+}
+
+.dg-ai-prompt {
+    font-family: ui-monospace, Menlo, Consolas, monospace;
+    font-size: 0.72rem;
+    background: #f3f2f2;
+    border: 1px solid #d8dde6;
+    border-radius: 6px;
+    padding: 12px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 320px;
+    overflow-y: auto;
+    margin: 0;
+}
+
+.dg-html-body-editor {
+    width: 100%;
+    min-height: 320px;
+    font-family: ui-monospace, Menlo, Consolas, monospace;
+    font-size: 0.78rem;
+    line-height: 1.45;
+    border: 1px solid #d8dde6;
+    border-radius: 6px;
+    padding: 10px;
+    resize: vertical;
+    background: #fff;
+    box-sizing: border-box;
+}

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -651,3 +651,80 @@
     border-color: #1b5e9e;
     color: #fff;
 }
+
+/* --- Visual-mode format bar --- */
+.dg-format-bar {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding: 6px 10px;
+    background: #fff;
+    border: 1px solid #d8dde6;
+    border-radius: 8px;
+    margin-bottom: 6px;
+}
+
+.dg-fmt-btn {
+    min-width: 28px;
+    height: 26px;
+    border: 1px solid #d8dde6;
+    border-radius: 5px;
+    background: #fff;
+    cursor: pointer;
+    font-size: 0.8rem;
+    color: #16325c;
+    padding: 0 6px;
+    font-family: inherit;
+}
+
+.dg-fmt-btn:hover {
+    background: #f4f2ff;
+    border-color: #c9b8f5;
+}
+
+.dg-fmt-btn_word {
+    font-size: 0.72rem;
+}
+
+.dg-fmt-sep {
+    width: 1px;
+    height: 20px;
+    background: #d8dde6;
+    margin: 0 4px;
+}
+
+.dg-fmt-label {
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: #706e6b;
+    margin: 0 2px;
+}
+
+.dg-fmt-swatch {
+    width: 18px;
+    height: 18px;
+    border: 1px solid #d8dde6;
+    border-radius: 4px;
+    cursor: pointer;
+    padding: 0;
+}
+
+.dg-fmt-swatch:hover {
+    outline: 2px solid #7c3aed;
+    outline-offset: 1px;
+}
+
+.dg-watermark-preview {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+}
+
+.dg-watermark-preview img {
+    max-width: 110px;
+    max-height: 140px;
+    border: 1px solid #d8dde6;
+    padding: 3px;
+    background: #fff;
+}

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -1291,3 +1291,31 @@
     border-color: #7c3aed;
     box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.15);
 }
+
+.dg-ctx-menu {
+    min-width: 220px;
+}
+
+.dg-version-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 6px 2px;
+    border-bottom: 1px solid #f0eef8;
+}
+
+.dg-version-meta {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.dg-version-file {
+    font-size: 0.68rem;
+    color: #9a93b5;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 220px;
+}

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -728,3 +728,9 @@
     padding: 3px;
     background: #fff;
 }
+
+/* Forces the Table tools onto their own row of the format bar */
+.dg-fmt-break {
+    flex-basis: 100%;
+    height: 0;
+}

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -1273,3 +1273,21 @@
     background: #f4f2ff;
     outline: 1px solid #c9b8f5;
 }
+
+.dg-hf-ta {
+    width: 100%;
+    height: 90px;
+    box-sizing: border-box;
+    font-family: 'SF Mono', Consolas, Menlo, monospace;
+    font-size: 0.75rem;
+    border: 1px solid #d8dde6;
+    border-radius: 8px;
+    padding: 8px;
+    resize: vertical;
+}
+
+.dg-hf-ta:focus {
+    outline: none;
+    border-color: #7c3aed;
+    box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.15);
+}

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -1195,3 +1195,21 @@
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+/* Ghost chip that follows the cursor during a mouse-driven drag */
+.dg-drag-ghost {
+    position: fixed;
+    z-index: 120;
+    pointer-events: none;
+    background: #7c3aed;
+    color: #fff;
+    padding: 4px 12px;
+    border-radius: 9px;
+    font-size: 0.78rem;
+    font-weight: 700;
+    box-shadow: 0 6px 18px rgba(124, 58, 237, 0.45);
+    white-space: nowrap;
+    max-width: 260px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.css
@@ -565,3 +565,89 @@
     border-color: #7c3aed;
     color: #fff;
 }
+
+/* --- Full-screen Designer tab --- */
+.dg-designer-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 10px;
+    padding: 10px 14px;
+    background: #fff;
+    border: 1px solid #d8dde6;
+    border-radius: 10px;
+}
+
+.dg-designer-toolbar__title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    flex: 0 1 auto;
+}
+
+.dg-designer-toolbar__title span {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.dg-designer-toolbar__sample {
+    flex: 1 1 240px;
+    max-width: 340px;
+}
+
+.dg-designer-toolbar__actions {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+}
+
+.dg-designer-layout {
+    display: flex;
+    gap: 14px;
+    align-items: flex-start;
+}
+
+.dg-designer-canvas-col {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.dg-designer-rail {
+    flex: 0 0 340px;
+    max-height: calc(100vh - 290px);
+    overflow-y: auto;
+    padding-right: 2px;
+}
+
+.dg-rail-section-label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 700;
+    font-size: 0.85rem;
+    color: #1f3a5f;
+    margin: 12px 0 6px 2px;
+}
+
+.dg-rail-section-label:first-child {
+    margin-top: 0;
+}
+
+.dg-designer-size {
+    height: calc(100vh - 360px) !important;
+    min-height: 480px !important;
+}
+
+.dg-block-chip {
+    background: #eaf3fb;
+    border-color: #a8cbe8;
+    color: #1b5e9e;
+}
+
+.dg-block-chip:hover {
+    background: #1b5e9e;
+    border-color: #1b5e9e;
+    color: #fff;
+}

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1547,7 +1547,7 @@
                                     class="dg-fmt-btn dg-panel-btn"
                                     data-panel="insert"
                                     onclick={handlePanelToggle}
-                                    title="Insert blocks, sections, tables — searchable. Or just type / in the page."
+                                    title="Insert blocks, sections, tables — searchable. Or just type ` or [ in the page."
                                 >
                                     + Insert
                                 </button>
@@ -2108,7 +2108,8 @@
                                     </template>
                                     <template if:true={isPanelInsert}>
                                         <p class="dg-float-panel-tip">
-                                            Tip: type <code>/</code> anywhere in the page for this menu at your cursor.
+                                            Tip: type <code>&#96;</code> or <code>[</code> anywhere in the page for this
+                                            menu at your cursor.
                                         </p>
                                         <template for:each={filteredBlockSections} for:item="section">
                                             <div key={section.key} class="dg-tag-section">
@@ -2124,9 +2125,7 @@
                                                             data-snippet={blk.snippet}
                                                             data-kind="block"
                                                             title={blk.title}
-                                                            draggable="true"
-                                                            ondragstart={handleTagDragStart}
-                                                            onmousedown={handleFmtMouseDown}
+                                                            onmousedown={handleChipDragMouseDown}
                                                             onclick={handleInsertTagSnippet}
                                                         >
                                                             {blk.label}
@@ -2150,9 +2149,7 @@
                                                             class="dg-tag-chip"
                                                             data-snippet={tag.snippet}
                                                             title={tag.title}
-                                                            draggable="true"
-                                                            ondragstart={handleTagDragStart}
-                                                            onmousedown={handleFmtMouseDown}
+                                                            onmousedown={handleChipDragMouseDown}
                                                             onclick={handleInsertTagSnippet}
                                                         >
                                                             {tag.label}
@@ -2176,9 +2173,7 @@
                                                             key={asset.id}
                                                             class="dg-image-thumb"
                                                             data-snippet={asset.mergeTag}
-                                                            draggable="true"
-                                                            ondragstart={handleTagDragStart}
-                                                            onmousedown={handleFmtMouseDown}
+                                                            onmousedown={handleChipDragMouseDown}
                                                             onclick={handleInsertTagSnippet}
                                                             title={asset.mergeTag}
                                                         >

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1632,6 +1632,14 @@
                                 </button>
                                 <button
                                     class="dg-fmt-btn dg-panel-btn"
+                                    data-panel="versions"
+                                    onclick={handlePanelToggle}
+                                    title="Load any previous version's body into the editor"
+                                >
+                                    Versions
+                                </button>
+                                <button
+                                    class="dg-fmt-btn dg-panel-btn"
                                     data-panel="hf"
                                     onclick={handlePanelToggle}
                                     title="Header and footer that repeat on every PDF page — with page numbers"
@@ -1774,6 +1782,96 @@
                                                 >Email hello@portwood.dev</a
                                             >
                                         </div>
+                                    </div>
+                                </template>
+                                <!-- Right-click context menu -->
+                                <template if:true={ctxMenu}>
+                                    <div class="dg-slash-menu dg-ctx-menu" style={ctxMenu.posStyle} role="menu">
+                                        <button class="dg-slash-item" onclick={handleCtxInsert}>
+                                            <span class="dg-slash-item-label">Insert&#8230;</span>
+                                            <span class="dg-slash-item-group">blocks &amp; tags</span>
+                                        </button>
+                                        <button
+                                            class="dg-slash-item"
+                                            data-cmd="bold"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleCtxFormat}
+                                        >
+                                            <span class="dg-slash-item-label"><b>Bold</b></span>
+                                        </button>
+                                        <button
+                                            class="dg-slash-item"
+                                            data-cmd="italic"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleCtxFormat}
+                                        >
+                                            <span class="dg-slash-item-label"><i>Italic</i></span>
+                                        </button>
+                                        <button
+                                            class="dg-slash-item"
+                                            data-kind="ul"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleCtxList}
+                                        >
+                                            <span class="dg-slash-item-label">&#8226; Bulleted list</span>
+                                        </button>
+                                        <button
+                                            class="dg-slash-item"
+                                            data-kind="ol"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleCtxList}
+                                        >
+                                            <span class="dg-slash-item-label">1. Numbered list</span>
+                                        </button>
+                                        <template if:true={ctxMenu.inTable}>
+                                            <div class="dg-slash-menu-head"><span>Table</span></div>
+                                            <button
+                                                class="dg-slash-item"
+                                                data-taction="rowAfter"
+                                                onmousedown={handleFmtMouseDown}
+                                                onclick={handleCtxTable}
+                                            >
+                                                <span class="dg-slash-item-label">+ Row below</span>
+                                            </button>
+                                            <button
+                                                class="dg-slash-item"
+                                                data-taction="colAfter"
+                                                onmousedown={handleFmtMouseDown}
+                                                onclick={handleCtxTable}
+                                            >
+                                                <span class="dg-slash-item-label">+ Column right</span>
+                                            </button>
+                                            <button
+                                                class="dg-slash-item"
+                                                data-taction="rowDel"
+                                                onmousedown={handleFmtMouseDown}
+                                                onclick={handleCtxTable}
+                                            >
+                                                <span class="dg-slash-item-label">&#8722; Delete row</span>
+                                            </button>
+                                            <button
+                                                class="dg-slash-item"
+                                                data-taction="colDel"
+                                                onmousedown={handleFmtMouseDown}
+                                                onclick={handleCtxTable}
+                                            >
+                                                <span class="dg-slash-item-label">&#8722; Delete column</span>
+                                            </button>
+                                            <button
+                                                class="dg-slash-item"
+                                                data-taction="repeatHeader"
+                                                onmousedown={handleFmtMouseDown}
+                                                onclick={handleCtxTable}
+                                            >
+                                                <span class="dg-slash-item-label">Repeat header each page</span>
+                                            </button>
+                                        </template>
+                                        <button
+                                            class="dg-slash-item dg-pill-menu-remove"
+                                            onclick={handleCtxDeleteBlock}
+                                        >
+                                            <span class="dg-slash-item-label">Delete this block</span>
+                                        </button>
                                     </div>
                                 </template>
                                 <template if:true={isLoadingHtmlBody}>
@@ -2283,6 +2381,33 @@
                                         </div>
                                     </template>
 
+                                    <template if:true={isPanelVersions}>
+                                        <div class="dg-image-panel">
+                                            <p class="slds-text-body_small slds-var-m-bottom_x-small">
+                                                Load any version into the editor to view or branch from it. Loading
+                                                changes nothing — <strong>Save as New Version</strong> creates a new
+                                                version from whatever is loaded.
+                                            </p>
+                                            <template for:each={versions} for:item="ver">
+                                                <div key={ver.Id} class="dg-version-row">
+                                                    <div class="dg-version-meta">
+                                                        <span class={ver.activeClass}
+                                                            >{ver.VersionNumber} {ver.isActiveLabel}</span
+                                                        >
+                                                        <span class="dg-version-file">{ver.bodyCvFileName}</span>
+                                                    </div>
+                                                    <button
+                                                        class="dg-tag-chip"
+                                                        data-cvid={ver.bodyCvId}
+                                                        data-ver={ver.VersionNumber}
+                                                        onclick={handleLoadVersionIntoDesigner}
+                                                    >
+                                                        Load
+                                                    </button>
+                                                </div>
+                                            </template>
+                                        </div>
+                                    </template>
                                     <template if:true={isPanelHf}>
                                         <div class="dg-image-panel">
                                             <p class="slds-text-body_small slds-var-m-bottom_x-small">

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1278,6 +1278,142 @@
                                     placeholder="Paste your template HTML here — from your AI assistant, Google Docs (File → Download → Web Page), or hand-written. Merge tags like &#123;Name&#125; fill from your Query Config."
                                 ></textarea>
                                 <template if:true={showHtmlBodyVisual}>
+                                    <div class="dg-format-bar" role="toolbar" aria-label="Text formatting">
+                                        <button
+                                            class="dg-fmt-btn"
+                                            data-cmd="bold"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleFormatAction}
+                                            title="Bold"
+                                        >
+                                            <b>B</b>
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn"
+                                            data-cmd="italic"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleFormatAction}
+                                            title="Italic"
+                                        >
+                                            <i>I</i>
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn"
+                                            data-cmd="underline"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleFormatAction}
+                                            title="Underline"
+                                        >
+                                            <u>U</u>
+                                        </button>
+                                        <span class="dg-fmt-sep"></span>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-cmd="justifyLeft"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleFormatAction}
+                                            title="Align left"
+                                        >
+                                            Left
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-cmd="justifyCenter"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleFormatAction}
+                                            title="Align center"
+                                        >
+                                            Center
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-cmd="justifyRight"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleFormatAction}
+                                            title="Align right"
+                                        >
+                                            Right
+                                        </button>
+                                        <span class="dg-fmt-sep"></span>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-cmd="fontSize"
+                                            data-value="2"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleFormatAction}
+                                            title="Small text"
+                                        >
+                                            S
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-cmd="fontSize"
+                                            data-value="3"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleFormatAction}
+                                            title="Normal text"
+                                        >
+                                            M
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-cmd="fontSize"
+                                            data-value="5"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleFormatAction}
+                                            title="Large text"
+                                        >
+                                            L
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-cmd="fontSize"
+                                            data-value="6"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleFormatAction}
+                                            title="Extra large text"
+                                        >
+                                            XL
+                                        </button>
+                                        <span class="dg-fmt-sep"></span>
+                                        <span class="dg-fmt-label" title="Text color">A</span>
+                                        <template for:each={textColorSwatches} for:item="sw">
+                                            <button
+                                                key={sw.key}
+                                                class="dg-fmt-swatch"
+                                                style={sw.style}
+                                                data-cmd="foreColor"
+                                                data-value={sw.value}
+                                                onmousedown={handleFmtMouseDown}
+                                                onclick={handleFormatAction}
+                                                title={sw.title}
+                                            ></button>
+                                        </template>
+                                        <span class="dg-fmt-sep"></span>
+                                        <span class="dg-fmt-label" title="Highlight color">BG</span>
+                                        <template for:each={highlightSwatches} for:item="sw">
+                                            <button
+                                                key={sw.key}
+                                                class="dg-fmt-swatch"
+                                                style={sw.style}
+                                                data-cmd="hiliteColor"
+                                                data-value={sw.value}
+                                                onmousedown={handleFmtMouseDown}
+                                                onclick={handleFormatAction}
+                                                title={sw.title}
+                                            ></button>
+                                        </template>
+                                        <span class="dg-fmt-sep"></span>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-cmd="removeFormat"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleFormatAction}
+                                            title="Clear formatting from the selection"
+                                        >
+                                            Clear
+                                        </button>
+                                    </div>
                                     <div
                                         class="dg-html-preview-frame dg-visual-host dg-designer-size"
                                         lwc:dom="manual"
@@ -1446,6 +1582,42 @@
                                         </p>
                                     </template>
                                 </div>
+
+                                <template if:true={editTemplateOutputIsPdf}>
+                                    <div class="dg-rail-section-label">
+                                        <lightning-icon icon-name="utility:layers" size="xx-small"></lightning-icon>
+                                        Watermark
+                                    </div>
+                                    <div class="dg-image-panel">
+                                        <p class="slds-text-body_small slds-var-m-bottom_x-small">
+                                            Full-page background image behind your content (PDF output). Pre-fade the
+                                            image (~15-20% opacity over white) for a watermark look. Needs a saved
+                                            version first.
+                                        </p>
+                                        <template if:true={watermarkPreviewUrl}>
+                                            <div class="dg-watermark-preview">
+                                                <img src={watermarkPreviewUrl} alt="Current watermark" />
+                                                <lightning-button
+                                                    label="Remove"
+                                                    icon-name="utility:delete"
+                                                    variant="destructive-text"
+                                                    onclick={handleClearWatermark}
+                                                    disabled={isUploadingWatermark}
+                                                ></lightning-button>
+                                            </div>
+                                        </template>
+                                        <input
+                                            type="file"
+                                            accept="image/*"
+                                            onchange={handleWatermarkFileSelected}
+                                            disabled={isUploadingWatermark}
+                                            class="slds-var-m-top_x-small"
+                                        />
+                                        <template if:true={isUploadingWatermark}>
+                                            <p class="slds-text-body_small slds-var-m-top_x-small">Uploading…</p>
+                                        </template>
+                                    </div>
+                                </template>
                             </div>
                         </div>
                     </template>

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -2775,6 +2775,24 @@
                                                                 <span class="dg-html-editor-status"
                                                                     >{docxViewerStatusText}</span
                                                                 >
+                                                                <lightning-button
+                                                                    label="Format Code"
+                                                                    icon-name="utility:magicwand"
+                                                                    variant="base"
+                                                                    data-target="docx"
+                                                                    onclick={handleFormatHtml}
+                                                                    title="Pretty-print the converted HTML — the converter emits it as one long line."
+                                                                    class="slds-var-m-left_small"
+                                                                ></lightning-button>
+                                                                <lightning-button
+                                                                    label={docxHtmlPreviewToggleLabel}
+                                                                    icon-name="utility:preview"
+                                                                    variant="base"
+                                                                    data-target="docx"
+                                                                    onclick={handleToggleHtmlPreview}
+                                                                    title="Render the converted HTML inline. Merge tags show as-is."
+                                                                    class="slds-var-m-left_small"
+                                                                ></lightning-button>
                                                             </div>
                                                             <template if:true={isLoadingDocxHtml}>
                                                                 <div class="slds-is-relative" style="height: 40px">
@@ -2785,11 +2803,18 @@
                                                                 </div>
                                                             </template>
                                                             <textarea
-                                                                class="dg-html-body-editor dg-docx-html-editor"
+                                                                class={docxHtmlEditorClass}
                                                                 spellcheck="false"
                                                                 aria-label="Converted HTML (what the PDF engine renders)"
                                                                 placeholder="No conversion snapshot yet — upload a Word file and Save as New Version, then reopen this viewer."
                                                             ></textarea>
+                                                            <template if:true={showDocxHtmlPreview}>
+                                                                <div
+                                                                    class="dg-html-preview-frame dg-docx-preview"
+                                                                    lwc:dom="manual"
+                                                                    title="Rendered preview of the converted HTML"
+                                                                ></div>
+                                                            </template>
                                                             <div class="slds-var-m-top_x-small">
                                                                 <lightning-button
                                                                     variant="brand"
@@ -2874,6 +2899,24 @@
                                                             >{htmlEditorStatusText}</span
                                                         >
                                                         <lightning-button
+                                                            label="Format Code"
+                                                            icon-name="utility:magicwand"
+                                                            variant="base"
+                                                            data-target="body"
+                                                            onclick={handleFormatHtml}
+                                                            title="Pretty-print the HTML: indent nested tags without touching text or merge tags."
+                                                            class="slds-var-m-left_small"
+                                                        ></lightning-button>
+                                                        <lightning-button
+                                                            label={htmlBodyPreviewToggleLabel}
+                                                            icon-name="utility:preview"
+                                                            variant="base"
+                                                            data-target="body"
+                                                            onclick={handleToggleHtmlPreview}
+                                                            title="Render the HTML inline. Merge tags show as-is — use Generate Sample for real data."
+                                                            class="slds-var-m-left_small"
+                                                        ></lightning-button>
+                                                        <lightning-button
                                                             label="Reload"
                                                             icon-name="utility:refresh"
                                                             variant="base"
@@ -2891,12 +2934,19 @@
                                                         </div>
                                                     </template>
                                                     <textarea
-                                                        class="dg-html-body-editor"
+                                                        class={htmlBodyEditorClass}
                                                         spellcheck="false"
                                                         aria-label="Template HTML body"
                                                         oninput={handleHtmlBodyEditorInput}
                                                         placeholder="Paste your template HTML here — from your AI assistant, Google Docs (File → Download → Web Page), or hand-written. Merge tags like &#123;Name&#125; fill from your Query Config."
                                                     ></textarea>
+                                                    <template if:true={showHtmlBodyPreview}>
+                                                        <div
+                                                            class="dg-html-preview-frame dg-body-preview"
+                                                            lwc:dom="manual"
+                                                            title="Rendered preview — merge tags shown as-is"
+                                                        ></div>
+                                                    </template>
                                                     <div class="slds-var-m-top_x-small">
                                                         <lightning-button
                                                             variant="brand"

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1364,6 +1364,9 @@
                                                 </button>
                                             </template>
                                         </template>
+                                        <button class="dg-pill-menu-item" onclick={handlePillEdit}>
+                                            Edit tag&#8230; (or double-click the pill)
+                                        </button>
                                         <button
                                             class="dg-pill-menu-item dg-pill-menu-remove"
                                             onclick={handlePillRemove}
@@ -1635,8 +1638,48 @@
                                         >
                                             Header Row
                                         </button>
-                                        <span class="dg-fmt-label" title="Fill the current cell's background"
-                                            >Cell</span
+                                        <span class="dg-fmt-sep"></span>
+                                        <span class="dg-fmt-label" title="Table borders">Borders</span>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-taction="bordersAll"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleTableAction}
+                                            title="Full grid — every cell outlined"
+                                        >
+                                            All
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-taction="bordersOutline"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleTableAction}
+                                            title="Outline around the table only"
+                                        >
+                                            Outline
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-taction="bordersRows"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleTableAction}
+                                            title="Horizontal row lines only"
+                                        >
+                                            Rows
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-taction="bordersNone"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleTableAction}
+                                            title="No borders"
+                                        >
+                                            None
+                                        </button>
+                                        <span
+                                            class="dg-fmt-label"
+                                            title="Fill the current cell — or, outside a table, the paragraph/panel the cursor is in"
+                                            >Fill</span
                                         >
                                         <template for:each={highlightSwatches} for:item="sw">
                                             <button

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1695,16 +1695,23 @@
                                             </button>
                                         </div>
                                         <template if:true={pillMenu.hasOptions}>
-                                            <template for:each={pillMenu.options} for:item="opt">
-                                                <button
-                                                    key={opt.key}
-                                                    class="dg-pill-menu-item"
-                                                    data-tag={opt.tag}
-                                                    onclick={handlePillTransform}
-                                                >
-                                                    {opt.label}
-                                                </button>
-                                            </template>
+                                            <div class="dg-pill-menu-scroll">
+                                                <template for:each={pillMenu.sections} for:item="sec">
+                                                    <div key={sec.key}>
+                                                        <div class="dg-pill-menu-sec">{sec.label}</div>
+                                                        <template for:each={sec.options} for:item="opt">
+                                                            <button
+                                                                key={opt.key}
+                                                                class={opt.cls}
+                                                                data-tag={opt.tag}
+                                                                onclick={handlePillTransform}
+                                                            >
+                                                                {opt.label}
+                                                            </button>
+                                                        </template>
+                                                    </div>
+                                                </template>
+                                            </div>
                                         </template>
                                         <button class="dg-pill-menu-item" onclick={handlePillEdit}>
                                             Edit tag&#8230; (or double-click the pill)

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1270,13 +1270,20 @@
                                         ></lightning-spinner>
                                     </div>
                                 </template>
-                                <textarea
-                                    class={designerEditorClass}
-                                    spellcheck="false"
-                                    aria-label="Template HTML body"
-                                    oninput={handleHtmlBodyEditorInput}
-                                    placeholder="Paste your template HTML here — from your AI assistant, Google Docs (File → Download → Web Page), or hand-written. Merge tags like &#123;Name&#125; fill from your Query Config."
-                                ></textarea>
+                                <div class={codeSplitClass}>
+                                    <textarea
+                                        class={designerEditorClass}
+                                        spellcheck="false"
+                                        aria-label="Template HTML body"
+                                        oninput={handleHtmlBodyEditorInput}
+                                        placeholder="Paste your template HTML here — from your AI assistant, Google Docs (File → Download → Web Page), or hand-written. Merge tags like &#123;Name&#125; fill from your Query Config."
+                                    ></textarea>
+                                    <div
+                                        class="dg-html-preview-frame dg-code-preview dg-designer-size"
+                                        lwc:dom="manual"
+                                        title="Live preview — updates as you type"
+                                    ></div>
+                                </div>
                                 <template if:true={showHtmlBodyVisual}>
                                     <div class="dg-format-bar" role="toolbar" aria-label="Text formatting">
                                         <button
@@ -1389,6 +1396,15 @@
                                                 title={sw.title}
                                             ></button>
                                         </template>
+                                        <input
+                                            type="color"
+                                            class="dg-fmt-colorpick"
+                                            data-cmd="foreColor"
+                                            value="#1f3a5f"
+                                            onmousedown={handleColorPickMouseDown}
+                                            onchange={handleColorPickChange}
+                                            title="Custom text color — any color you want"
+                                        />
                                         <span class="dg-fmt-sep"></span>
                                         <span class="dg-fmt-label" title="Highlight color">BG</span>
                                         <template for:each={highlightSwatches} for:item="sw">
@@ -1403,6 +1419,15 @@
                                                 title={sw.title}
                                             ></button>
                                         </template>
+                                        <input
+                                            type="color"
+                                            class="dg-fmt-colorpick"
+                                            data-cmd="hiliteColor"
+                                            value="#fef3c7"
+                                            onmousedown={handleColorPickMouseDown}
+                                            onchange={handleColorPickChange}
+                                            title="Custom highlight color"
+                                        />
                                         <span class="dg-fmt-sep"></span>
                                         <span
                                             class="dg-fmt-label"
@@ -1432,6 +1457,24 @@
                                             title="Clear formatting from the selection"
                                         >
                                             Clear
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-cmd="undo"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleFormatAction}
+                                            title="Undo"
+                                        >
+                                            &#8630; Undo
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-cmd="redo"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleFormatAction}
+                                            title="Redo"
+                                        >
+                                            &#8631; Redo
                                         </button>
                                         <span class="dg-fmt-break"></span>
                                         <span class="dg-fmt-label" title="Table tools — put your cursor in a cell first"
@@ -1497,6 +1540,15 @@
                                                 title={sw.title}
                                             ></button>
                                         </template>
+                                        <input
+                                            type="color"
+                                            class="dg-fmt-colorpick"
+                                            data-cmd="cellFill"
+                                            value="#f2f4f7"
+                                            onmousedown={handleColorPickMouseDown}
+                                            onchange={handleColorPickChange}
+                                            title="Custom cell fill color"
+                                        />
                                     </div>
                                     <div
                                         class="dg-html-preview-frame dg-visual-host dg-designer-size"

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -313,10 +313,37 @@
                                                 </div>
                                             </template>
                                         </div>
-                                        <p class="slds-text-body_small slds-text-color_weak slds-var-m-top_x-small">
-                                            Your Query Config fields are merged into the design automatically — pick
-                                            data in the next step, review the HTML, done.
-                                        </p>
+                                        <div class="slds-var-m-top_small">
+                                            <label class="slds-form-element__label">Company logo (optional)</label>
+                                            <input type="file" accept=".png,.jpg,.jpeg" onchange={handleLogoSelected} />
+                                            <template if:true={newTemplateLogoName}>
+                                                <p class="slds-text-body_small slds-text-color_weak">
+                                                    {newTemplateLogoName} — saved as your shared logo, placed in the
+                                                    template header, reusable in every template.
+                                                </p>
+                                            </template>
+                                        </div>
+                                        <div class="slds-var-m-top_medium">
+                                            <lightning-button
+                                                variant="brand"
+                                                label="Create &amp; Open Designer"
+                                                icon-name="utility:magicwand"
+                                                onclick={handleCreateAndDesign}
+                                                disabled={isAutoCreating}
+                                            ></lightning-button>
+                                            <template if:true={isAutoCreating}>
+                                                <lightning-spinner
+                                                    alternative-text="Creating..."
+                                                    size="small"
+                                                    class="slds-var-m-left_small"
+                                                ></lightning-spinner>
+                                            </template>
+                                            <p class="slds-text-body_small slds-text-color_weak slds-var-m-top_x-small">
+                                                One click: we pick sensible fields for your object automatically, build
+                                                the document, and open it in the designer. Refine fields anytime under
+                                                Query Configuration — or use Next to pick them yourself.
+                                            </p>
+                                        </div>
                                     </template>
 
                                     <!-- AI path: explain the prompt handoff -->
@@ -333,6 +360,26 @@
                                                 DocGen's merge-tag syntax, and the PDF engine's layout rules. Copy it
                                                 into Claude, ChatGPT, Gemini, or Copilot, then paste the returned HTML
                                                 into the template editor. No data leaves Salesforce unless you paste it.
+                                            </p>
+                                        </div>
+                                        <div class="slds-var-m-top_medium">
+                                            <lightning-button
+                                                variant="brand"
+                                                label="Create &amp; Open Designer"
+                                                icon-name="utility:magicwand"
+                                                onclick={handleCreateAndDesign}
+                                                disabled={isAutoCreating}
+                                            ></lightning-button>
+                                            <template if:true={isAutoCreating}>
+                                                <lightning-spinner
+                                                    alternative-text="Creating..."
+                                                    size="small"
+                                                    class="slds-var-m-left_small"
+                                                ></lightning-spinner>
+                                            </template>
+                                            <p class="slds-text-body_small slds-text-color_weak slds-var-m-top_x-small">
+                                                One click: sensible fields are picked automatically and the designer
+                                                opens with your Copy AI Prompt ready.
                                             </p>
                                         </div>
                                     </template>

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -2909,19 +2909,10 @@
                                                         ></lightning-button>
                                                         <lightning-button
                                                             label={visualToggleLabel}
-                                                            icon-name="utility:richtextbulletedlist"
-                                                            variant="base"
-                                                            onclick={handleToggleHtmlVisual}
-                                                            title="Edit the document text like a rich-text editor. Your @page/style shell is preserved and reapplied when you switch back. Table layouts need Code view."
-                                                            class="slds-var-m-left_small"
-                                                        ></lightning-button>
-                                                        <lightning-button
-                                                            label={htmlBodyPreviewToggleLabel}
                                                             icon-name="utility:preview"
                                                             variant="base"
-                                                            data-target="body"
-                                                            onclick={handleToggleHtmlPreview}
-                                                            title="Render the HTML inline. Merge tags show as-is — use Generate Sample for real data."
+                                                            onclick={handleToggleHtmlVisual}
+                                                            title="See and edit the document as it renders — click anywhere and type. Your @page/style shell is never touched; structure work happens in Code."
                                                             class="slds-var-m-left_small"
                                                         ></lightning-button>
                                                         <lightning-button
@@ -2948,13 +2939,6 @@
                                                         oninput={handleHtmlBodyEditorInput}
                                                         placeholder="Paste your template HTML here — from your AI assistant, Google Docs (File → Download → Web Page), or hand-written. Merge tags like &#123;Name&#125; fill from your Query Config."
                                                     ></textarea>
-                                                    <template if:true={showHtmlBodyPreview}>
-                                                        <div
-                                                            class="dg-html-preview-frame dg-body-preview"
-                                                            lwc:dom="manual"
-                                                            title="Rendered preview — merge tags shown as-is"
-                                                        ></div>
-                                                    </template>
                                                     <template if:true={showHtmlBodyVisual}>
                                                         <div
                                                             class="dg-html-preview-frame dg-visual-host"

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -8,7 +8,7 @@
             <lightning-tab label="Create New" value="new_template" onactive={handleWizardTabActive}>
                 <div class="slds-var-p-around_large">
                     <div class="wizard-header">
-                        <lightning-progress-indicator current-step={currentWizardStep} type="base" variant="base">
+                        <lightning-progress-indicator current-step={wizardProgressStep} type="base" variant="base">
                             <lightning-progress-step label="Name Your Template" value="1"></lightning-progress-step>
                             <lightning-progress-step label="Pick Your Data" value="2"></lightning-progress-step>
                             <lightning-progress-step label="Review &amp; Create" value="3"></lightning-progress-step>
@@ -54,38 +54,44 @@
                                         onchange={handleNameChange}
                                         required
                                     ></lightning-input>
-                                    <lightning-input
-                                        label="API Name"
-                                        value={newTemplateApiName}
-                                        onchange={handleNewApiNameChange}
-                                        max-length="80"
-                                        pattern="[a-zA-Z][a-zA-Z0-9_]*"
-                                        message-when-pattern-mismatch="Letters, numbers, and underscores only; must start with a letter."
-                                        field-level-help="Stable key for referencing this template from Flows and DocGen Buttons (Template API Name input). Auto-fills from the name; survives sandbox-to-production deploys, unlike the record Id. Must be unique. Clear it to re-sync with the name."
-                                        class="slds-var-m-top_medium"
-                                    ></lightning-input>
-                                    <lightning-input
-                                        label="Category"
-                                        value={newTemplateCategory}
-                                        onchange={handleCategoryChange}
-                                        class="slds-var-m-top_medium"
-                                    ></lightning-input>
+                                    <!-- Starter/AI paths keep Step 1 minimal: name, object,
+                                         logo. Power-user fields live behind Advanced. -->
+                                    <template if:true={showStep1AdvancedFields}>
+                                        <lightning-input
+                                            label="API Name"
+                                            value={newTemplateApiName}
+                                            onchange={handleNewApiNameChange}
+                                            max-length="80"
+                                            pattern="[a-zA-Z][a-zA-Z0-9_]*"
+                                            message-when-pattern-mismatch="Letters, numbers, and underscores only; must start with a letter."
+                                            field-level-help="Stable key for referencing this template from Flows and DocGen Buttons (Template API Name input). Auto-fills from the name; survives sandbox-to-production deploys, unlike the record Id. Must be unique. Clear it to re-sync with the name."
+                                            class="slds-var-m-top_medium"
+                                        ></lightning-input>
+                                        <lightning-input
+                                            label="Category"
+                                            value={newTemplateCategory}
+                                            onchange={handleCategoryChange}
+                                            class="slds-var-m-top_medium"
+                                        ></lightning-input>
 
-                                    <!-- Data Source: Salesforce Record vs Apex Class -->
-                                    <lightning-radio-group
-                                        class="slds-var-m-top_medium"
-                                        label="Data Source"
-                                        name="dataSourceMode"
-                                        options={dataSourceModeOptions}
-                                        value={dataSourceMode}
-                                        onchange={handleDataSourceModeChange}
-                                        type="radio"
-                                        required
-                                    >
-                                    </lightning-radio-group>
+                                        <!-- Data Source: Salesforce Record vs Apex Class -->
+                                        <lightning-radio-group
+                                            class="slds-var-m-top_medium"
+                                            label="Data Source"
+                                            name="dataSourceMode"
+                                            options={dataSourceModeOptions}
+                                            value={dataSourceMode}
+                                            onchange={handleDataSourceModeChange}
+                                            type="radio"
+                                            required
+                                        >
+                                        </lightning-radio-group>
+                                    </template>
 
-                                    <!-- Salesforce Record path: Base Object picker -->
-                                    <template if:true={isRecordDataSource}>
+                                    <!-- Salesforce Record path: Base Object picker.
+                                         Hidden for predesigned starters — each starter
+                                         brings its own object and query. -->
+                                    <template if:true={showBaseObjectField}>
                                         <div style="position: relative" class="slds-var-m-top_medium">
                                             <lightning-input
                                                 label="Base Object"
@@ -286,6 +292,16 @@
                                             </template>
                                         </div>
                                     </template>
+                                    <template if:true={showAdvancedToggle}>
+                                        <div class="slds-var-m-top_medium">
+                                            <lightning-button
+                                                variant="base"
+                                                label={advancedToggleLabel}
+                                                icon-name="utility:settings"
+                                                onclick={handleToggleAdvanced}
+                                            ></lightning-button>
+                                        </div>
+                                    </template>
                                 </div>
                                 <div class="slds-col slds-size_1-of-2">
                                     <!-- Starter path: design gallery -->
@@ -308,14 +324,29 @@
                                                             size="x-small"
                                                         ></lightning-icon>
                                                         <span class="dg-starter-card-title">{starter.label}</span>
+                                                        <span class="dg-starter-card-obj">{starter.targetObject}</span>
                                                     </div>
                                                     <p class="dg-starter-card-desc">{starter.description}</p>
                                                 </div>
                                             </template>
                                         </div>
                                         <div class="slds-var-m-top_small">
-                                            <label class="slds-form-element__label">Company logo (optional)</label>
-                                            <input type="file" accept=".png,.jpg,.jpeg" onchange={handleLogoSelected} />
+                                            <lightning-combobox
+                                                label="Company logo (optional)"
+                                                value={newTemplateLogoChoice}
+                                                options={logoChoiceOptions}
+                                                onchange={handleLogoChoiceChange}
+                                                field-level-help="Pick a shared image asset you already saved, or upload a new one. The starter header carries the logo slot either way."
+                                            ></lightning-combobox>
+                                            <template if:true={showLogoUpload}>
+                                                <div class="slds-var-m-top_x-small">
+                                                    <input
+                                                        type="file"
+                                                        accept=".png,.jpg,.jpeg"
+                                                        onchange={handleLogoSelected}
+                                                    />
+                                                </div>
+                                            </template>
                                             <template if:true={newTemplateLogoName}>
                                                 <p class="slds-text-body_small slds-text-color_weak">
                                                     {newTemplateLogoName} — saved as your shared logo, placed in the
@@ -323,6 +354,20 @@
                                                 </p>
                                             </template>
                                         </div>
+                                        <template if:true={isRecordDataSource}>
+                                            <template if:true={newTemplateObject}>
+                                                <div class="slds-var-m-top_small">
+                                                    <lightning-record-picker
+                                                        label="Sample Record (optional)"
+                                                        object-api-name={newTemplateObject}
+                                                        value={newTemplateSampleRecordId}
+                                                        onchange={handleSampleRecordChange}
+                                                        placeholder="Pick a record to preview with real data..."
+                                                    >
+                                                    </lightning-record-picker>
+                                                </div>
+                                            </template>
+                                        </template>
                                         <div class="slds-var-m-top_medium">
                                             <lightning-button
                                                 variant="brand"
@@ -341,12 +386,12 @@
                                             <p class="slds-text-body_small slds-text-color_weak slds-var-m-top_x-small">
                                                 One click: we pick sensible fields for your object automatically, build
                                                 the document, and open it in the designer. Refine fields anytime under
-                                                Query Configuration — or use Next to pick them yourself.
+                                                Query Configuration.
                                             </p>
                                         </div>
                                     </template>
 
-                                    <!-- AI path: explain the prompt handoff -->
+                                    <!-- AI path: name + logo here, prompt + paste on the next screen -->
                                     <template if:true={isAuthoringAi}>
                                         <div class="slds-box slds-theme_shade" style="border-radius: 8px" role="note">
                                             <p class="slds-text-body_small">
@@ -355,31 +400,55 @@
                                                     size="x-small"
                                                     class="slds-var-m-right_x-small"
                                                 ></lightning-icon>
-                                                After you pick your data in the next step, the
-                                                <strong>Review</strong> screen shows a complete prompt — your fields,
-                                                DocGen's merge-tag syntax, and the PDF engine's layout rules. Copy it
-                                                into Claude, ChatGPT, Gemini, or Copilot, then paste the returned HTML
-                                                into the template editor. No data leaves Salesforce unless you paste it.
+                                                Next builds a complete prompt for you — your fields, DocGen's merge-tag
+                                                syntax, the PDF engine's layout rules, and your shared image assets.
+                                                Copy it into Claude, ChatGPT, Gemini, or Copilot, paste the HTML it
+                                                returns, and you land in the designer. No data leaves Salesforce unless
+                                                you paste it.
                                             </p>
+                                        </div>
+                                        <div class="slds-var-m-top_small">
+                                            <lightning-combobox
+                                                label="Company logo (optional)"
+                                                value={newTemplateLogoChoice}
+                                                options={logoChoiceOptions}
+                                                onchange={handleLogoChoiceChange}
+                                                field-level-help="Pick a shared image asset you already saved, or upload a new one. The AI prompt tells the assistant how to reference it."
+                                            ></lightning-combobox>
+                                            <template if:true={showLogoUpload}>
+                                                <div class="slds-var-m-top_x-small">
+                                                    <input
+                                                        type="file"
+                                                        accept=".png,.jpg,.jpeg"
+                                                        onchange={handleLogoSelected}
+                                                    />
+                                                </div>
+                                            </template>
+                                            <template if:true={newTemplateLogoName}>
+                                                <p class="slds-text-body_small slds-text-color_weak">
+                                                    {newTemplateLogoName} — saved as your shared logo; the AI prompt
+                                                    will tell the assistant how to reference it.
+                                                </p>
+                                            </template>
                                         </div>
                                         <div class="slds-var-m-top_medium">
                                             <lightning-button
                                                 variant="brand"
-                                                label="Create &amp; Open Designer"
-                                                icon-name="utility:magicwand"
-                                                onclick={handleCreateAndDesign}
+                                                label="Next: Build My Prompt"
+                                                icon-name="utility:einstein"
+                                                onclick={handleNextStep}
                                                 disabled={isAutoCreating}
                                             ></lightning-button>
                                             <template if:true={isAutoCreating}>
                                                 <lightning-spinner
-                                                    alternative-text="Creating..."
+                                                    alternative-text="Preparing prompt..."
                                                     size="small"
                                                     class="slds-var-m-left_small"
                                                 ></lightning-spinner>
                                             </template>
                                             <p class="slds-text-body_small slds-text-color_weak slds-var-m-top_x-small">
-                                                One click: sensible fields are picked automatically and the designer
-                                                opens with your Copy AI Prompt ready.
+                                                Sensible fields are picked automatically — refine them anytime under
+                                                Query Configuration.
                                             </p>
                                         </div>
                                     </template>
@@ -476,23 +545,25 @@
                                             </p>
                                         </div>
                                     </template>
-                                    <template if:true={isRecordDataSource}>
-                                        <template if:true={newTemplateObject}>
-                                            <div class="slds-var-m-top_medium">
-                                                <lightning-record-picker
-                                                    label="Sample Record (optional)"
-                                                    object-api-name={newTemplateObject}
-                                                    value={newTemplateSampleRecordId}
-                                                    onchange={handleSampleRecordChange}
-                                                    placeholder="Pick a record to preview data..."
-                                                >
-                                                </lightning-record-picker>
-                                                <p
-                                                    class="slds-text-body_small slds-text-color_weak slds-var-m-top_xx-small"
-                                                >
-                                                    See real data from this record while building your query.
-                                                </p>
-                                            </div>
+                                    <template if:true={isAuthoringFile}>
+                                        <template if:true={isRecordDataSource}>
+                                            <template if:true={newTemplateObject}>
+                                                <div class="slds-var-m-top_medium">
+                                                    <lightning-record-picker
+                                                        label="Sample Record (optional)"
+                                                        object-api-name={newTemplateObject}
+                                                        value={newTemplateSampleRecordId}
+                                                        onchange={handleSampleRecordChange}
+                                                        placeholder="Pick a record to preview data..."
+                                                    >
+                                                    </lightning-record-picker>
+                                                    <p
+                                                        class="slds-text-body_small slds-text-color_weak slds-var-m-top_xx-small"
+                                                    >
+                                                        See real data from this record while building your query.
+                                                    </p>
+                                                </div>
+                                            </template>
                                         </template>
                                     </template>
                                     <template if:true={isApexDataSource}>
@@ -504,6 +575,107 @@
                                             supplies its own data shape at render time.
                                         </div>
                                     </template>
+                                </div>
+                            </div>
+                        </template>
+
+                        <!-- AI step: prompt → paste → designer, all on one screen -->
+                        <template if:true={isStepAi}>
+                            <div class="slds-grid slds-gutters_large slds-wrap">
+                                <div
+                                    class="slds-col slds-size_1-of-2 slds-medium-size_1-of-2 slds-max-small-size_1-of-1"
+                                >
+                                    <div class="dg-ai-step-head">
+                                        <span class="dg-ai-step-num">1</span>
+                                        <strong>Copy your prompt</strong>
+                                        <lightning-button
+                                            label="Copy Prompt"
+                                            icon-name="utility:copy"
+                                            variant="brand"
+                                            onclick={handleCopyAiPrompt}
+                                            class="slds-var-m-left_small"
+                                        ></lightning-button>
+                                    </div>
+                                    <p class="slds-text-body_small slds-text-color_weak slds-var-m-bottom_x-small">
+                                        Everything the AI needs: your {newTemplateObject} fields, DocGen's merge-tag
+                                        syntax, the PDF engine's layout rules, and your shared image assets. Paste it
+                                        into Claude, ChatGPT, Gemini, or Copilot and describe the document you want
+                                        where the prompt says so.
+                                    </p>
+                                    <pre class="dg-ai-prompt dg-ai-prompt_tall">{aiAuthoringPrompt}</pre>
+                                </div>
+                                <div
+                                    class="slds-col slds-size_1-of-2 slds-medium-size_1-of-2 slds-max-small-size_1-of-1"
+                                >
+                                    <template if:true={hasWizardAssets}>
+                                        <div class="dg-ai-step-head">
+                                            <span class="dg-ai-step-num">2</span>
+                                            <strong>Your shared image assets</strong>
+                                        </div>
+                                        <p class="slds-text-body_small slds-text-color_weak slds-var-m-bottom_x-small">
+                                            Already included in the prompt — the AI can place these. Click a tag to copy
+                                            it.
+                                        </p>
+                                        <div class="dg-ai-asset-chips">
+                                            <template for:each={wizardAssets} for:item="asset">
+                                                <button
+                                                    key={asset.id}
+                                                    type="button"
+                                                    class="dg-tag-chip"
+                                                    data-tag={asset.mergeTag}
+                                                    onclick={handleAssetTagCopy}
+                                                    title={asset.name}
+                                                >
+                                                    {asset.mergeTag}
+                                                </button>
+                                            </template>
+                                        </div>
+                                    </template>
+                                    <div class="dg-ai-step-head slds-var-m-top_medium">
+                                        <span class="dg-ai-step-num">{aiPasteStepNum}</span>
+                                        <strong>Paste the HTML it returns</strong>
+                                    </div>
+                                    <textarea
+                                        class="dg-ai-paste"
+                                        placeholder="Paste the complete HTML file your AI assistant returned (starts with <!DOCTYPE html>)..."
+                                        onchange={handleAiPasteChange}
+                                        spellcheck="false"
+                                    ></textarea>
+                                    <template if:true={isRecordDataSource}>
+                                        <template if:true={newTemplateObject}>
+                                            <div class="slds-var-m-top_small">
+                                                <lightning-record-picker
+                                                    label="Sample Record (optional)"
+                                                    object-api-name={newTemplateObject}
+                                                    value={newTemplateSampleRecordId}
+                                                    onchange={handleSampleRecordChange}
+                                                    placeholder="Pick a record to preview with real data..."
+                                                >
+                                                </lightning-record-picker>
+                                            </div>
+                                        </template>
+                                    </template>
+                                    <div class="slds-var-m-top_small">
+                                        <lightning-button
+                                            variant="brand"
+                                            label="Create &amp; Open Designer"
+                                            icon-name="utility:magicwand"
+                                            onclick={handleAiCreateFromPaste}
+                                            disabled={isAutoCreating}
+                                        ></lightning-button>
+                                        <template if:true={isAutoCreating}>
+                                            <lightning-spinner
+                                                alternative-text="Creating..."
+                                                size="small"
+                                                class="slds-var-m-left_small"
+                                            ></lightning-spinner>
+                                        </template>
+                                        <p class="slds-text-body_small slds-text-color_weak slds-var-m-top_x-small">
+                                            Pasted HTML is staged as the template body and opens in the visual designer.
+                                            Nothing pasted yet? That's fine — the designer opens empty and the prompt
+                                            stays available there.
+                                        </p>
+                                    </div>
                                 </div>
                             </div>
                         </template>
@@ -1136,7 +1308,7 @@
                             >
                             </lightning-button>
 
-                            <template if:false={isStep3}>
+                            <template if:false={hideWizardFooterNext}>
                                 <lightning-button label="Next" variant="brand" onclick={handleNextStep}>
                                 </lightning-button>
                             </template>
@@ -1235,158 +1407,163 @@
                         </div>
                     </template>
                     <template if:true={designerHasTemplate}>
-                        <div class="dg-designer-toolbar">
-                            <div class="dg-designer-toolbar__title">
-                                <lightning-icon icon-name="utility:brush" size="small"></lightning-icon>
-                                <span class="slds-text-heading_small">{designerTitle}</span>
-                            </div>
-                            <template if:true={isRealObject}>
-                                <div class="dg-designer-toolbar__sample">
-                                    <lightning-record-picker
-                                        label="Sample Record"
-                                        variant="label-hidden"
-                                        object-api-name={editTemplateObject}
-                                        value={editTemplateTestRecordId}
-                                        onchange={handleEditTestRecordChange}
-                                        placeholder="Sample record for previews..."
-                                    >
-                                    </lightning-record-picker>
+                        <div class="dg-designer-chrome">
+                            <div class="dg-designer-toolbar">
+                                <div class="dg-designer-toolbar__title">
+                                    <lightning-icon icon-name="utility:brush" size="small"></lightning-icon>
+                                    <span class="slds-text-heading_small">{designerTitle}</span>
                                 </div>
-                                <lightning-button
-                                    label="Generate Sample"
-                                    icon-name="utility:page"
-                                    onclick={handleTestGenerate}
-                                    disabled={editGenerateSampleDisabled}
-                                ></lightning-button>
-                                <template if:true={isLoadingVersions}>
-                                    <lightning-spinner alternative-text="Working..." size="small"></lightning-spinner>
+                                <template if:true={isRealObject}>
+                                    <div class="dg-designer-toolbar__sample">
+                                        <lightning-record-picker
+                                            label="Sample Record"
+                                            variant="label-hidden"
+                                            object-api-name={editTemplateObject}
+                                            value={editTemplateTestRecordId}
+                                            onchange={handleEditTestRecordChange}
+                                            placeholder="Sample record for previews..."
+                                        >
+                                        </lightning-record-picker>
+                                    </div>
+                                    <lightning-button
+                                        label="Generate Sample"
+                                        icon-name="utility:page"
+                                        onclick={handleTestGenerate}
+                                        disabled={editGenerateSampleDisabled}
+                                    ></lightning-button>
+                                    <template if:true={isLoadingVersions}>
+                                        <lightning-spinner
+                                            alternative-text="Working..."
+                                            size="small"
+                                        ></lightning-spinner>
+                                    </template>
                                 </template>
-                            </template>
-                            <div class="dg-designer-toolbar__actions">
-                                <lightning-button
-                                    variant="brand"
-                                    label="Save as New Version"
-                                    icon-name="utility:save"
-                                    onclick={handleSaveAndClose}
-                                ></lightning-button>
-                                <lightning-button
-                                    label="Back to Templates"
-                                    icon-name="utility:back"
-                                    onclick={handleCloseDesigner}
-                                    class="slds-var-m-left_x-small"
-                                ></lightning-button>
+                                <div class="dg-designer-toolbar__actions">
+                                    <lightning-button
+                                        variant="brand"
+                                        label="Save as New Version"
+                                        icon-name="utility:save"
+                                        onclick={handleSaveAndClose}
+                                    ></lightning-button>
+                                    <lightning-button
+                                        label="Back to Templates"
+                                        icon-name="utility:back"
+                                        onclick={handleCloseDesigner}
+                                        class="slds-var-m-left_x-small"
+                                    ></lightning-button>
+                                </div>
                             </div>
-                        </div>
 
-                        <div class="dg-html-editor-statusbar">
-                            <div class="dg-mode-seg" role="tablist" aria-label="Editor mode">
-                                <button
-                                    class={visualModeBtnClass}
-                                    onclick={handleSelectVisualMode}
-                                    title="Edit the document as it renders — click anywhere and type"
-                                >
-                                    Visual
-                                </button>
-                                <button
-                                    class={sourceModeBtnClass}
-                                    onclick={handleSelectSourceMode}
-                                    title="Edit the raw HTML with a live full-page preview below"
-                                >
-                                    Source
-                                </button>
-                            </div>
-                            <template if:true={selectionContextLabel}>
-                                <span class="dg-context-label">{selectionContextLabel}</span>
-                            </template>
-                            <span class={htmlEditorStatusClass}>{htmlEditorStatusText}</span>
-                            <span class="dg-fmt-label">Page</span>
-                            <select
-                                class="dg-page-select"
-                                data-field="size"
-                                onchange={handlePageSetupChange}
-                                title="Page size"
-                            >
-                                <option value="Letter">Letter</option>
-                                <option value="Legal">Legal</option>
-                                <option value="A4">A4</option>
-                                <option value="Custom">Custom…</option>
-                            </select>
-                            <template if:false={isCustomPageSize}>
+                            <div class="dg-html-editor-statusbar">
+                                <div class="dg-mode-seg" role="tablist" aria-label="Editor mode">
+                                    <button
+                                        class={visualModeBtnClass}
+                                        onclick={handleSelectVisualMode}
+                                        title="Edit the document as it renders — click anywhere and type"
+                                    >
+                                        Visual
+                                    </button>
+                                    <button
+                                        class={sourceModeBtnClass}
+                                        onclick={handleSelectSourceMode}
+                                        title="Edit the raw HTML with a live full-page preview below"
+                                    >
+                                        Source
+                                    </button>
+                                </div>
+                                <template if:true={selectionContextLabel}>
+                                    <span class="dg-context-label">{selectionContextLabel}</span>
+                                </template>
+                                <span class={htmlEditorStatusClass}>{htmlEditorStatusText}</span>
+                                <span class="dg-fmt-label">Page</span>
                                 <select
                                     class="dg-page-select"
-                                    data-field="orient"
+                                    data-field="size"
                                     onchange={handlePageSetupChange}
-                                    title="Orientation"
+                                    title="Page size"
                                 >
-                                    <option value="portrait">Portrait</option>
-                                    <option value="landscape">Landscape</option>
+                                    <option value="Letter">Letter</option>
+                                    <option value="Legal">Legal</option>
+                                    <option value="A4">A4</option>
+                                    <option value="Custom">Custom…</option>
                                 </select>
-                            </template>
-                            <template if:true={isCustomPageSize}>
-                                <input
-                                    type="number"
-                                    class="dg-page-input"
-                                    data-field="customW"
-                                    min="1"
-                                    max="200"
-                                    step="0.25"
+                                <template if:false={isCustomPageSize}>
+                                    <select
+                                        class="dg-page-select"
+                                        data-field="orient"
+                                        onchange={handlePageSetupChange}
+                                        title="Orientation"
+                                    >
+                                        <option value="portrait">Portrait</option>
+                                        <option value="landscape">Landscape</option>
+                                    </select>
+                                </template>
+                                <template if:true={isCustomPageSize}>
+                                    <input
+                                        type="number"
+                                        class="dg-page-input"
+                                        data-field="customW"
+                                        min="1"
+                                        max="200"
+                                        step="0.25"
+                                        onchange={handlePageSetupChange}
+                                        title="Page width in inches"
+                                    />
+                                    <span class="dg-fmt-label">×</span>
+                                    <input
+                                        type="number"
+                                        class="dg-page-input"
+                                        data-field="customH"
+                                        min="1"
+                                        max="200"
+                                        step="0.25"
+                                        onchange={handlePageSetupChange}
+                                        title="Page height in inches"
+                                    />
+                                    <span class="dg-fmt-label">in</span>
+                                </template>
+                                <select
+                                    class="dg-page-select"
+                                    data-field="margin"
                                     onchange={handlePageSetupChange}
-                                    title="Page width in inches"
-                                />
-                                <span class="dg-fmt-label">×</span>
-                                <input
-                                    type="number"
-                                    class="dg-page-input"
-                                    data-field="customH"
-                                    min="1"
-                                    max="200"
-                                    step="0.25"
-                                    onchange={handlePageSetupChange}
-                                    title="Page height in inches"
-                                />
-                                <span class="dg-fmt-label">in</span>
-                            </template>
-                            <select
-                                class="dg-page-select"
-                                data-field="margin"
-                                onchange={handlePageSetupChange}
-                                title="Page margins"
-                            >
-                                <option value="0.5">0.5&quot; margins</option>
-                                <option value="0.75">0.75&quot; margins</option>
-                                <option value="1">1&quot; margins</option>
-                                <option value="custom">Custom…</option>
-                            </select>
-                            <template if:true={isCustomMargin}>
-                                <input
-                                    type="number"
-                                    class="dg-page-input"
-                                    data-field="customMargin"
-                                    min="0"
-                                    max="10"
-                                    step="0.05"
-                                    onchange={handlePageSetupChange}
-                                    title="Margin in inches"
-                                />
-                                <span class="dg-fmt-label">in</span>
-                            </template>
-                            <lightning-button
-                                label="Format Code"
-                                icon-name="utility:magicwand"
-                                variant="base"
-                                data-target="body"
-                                onclick={handleFormatHtml}
-                                title="Pretty-print the HTML: indent nested tags without touching text or merge tags."
-                                class="slds-var-m-left_small"
-                            ></lightning-button>
-                            <lightning-button
-                                label="Reload"
-                                icon-name="utility:refresh"
-                                variant="base"
-                                onclick={handleReloadHtmlBodyEditor}
-                                title="Replace the editor contents with the currently staged body (or the saved body if nothing is staged). Discards unapplied edits."
-                                class="slds-var-m-left_small"
-                            ></lightning-button>
+                                    title="Page margins"
+                                >
+                                    <option value="0.5">0.5&quot; margins</option>
+                                    <option value="0.75">0.75&quot; margins</option>
+                                    <option value="1">1&quot; margins</option>
+                                    <option value="custom">Custom…</option>
+                                </select>
+                                <template if:true={isCustomMargin}>
+                                    <input
+                                        type="number"
+                                        class="dg-page-input"
+                                        data-field="customMargin"
+                                        min="0"
+                                        max="10"
+                                        step="0.05"
+                                        onchange={handlePageSetupChange}
+                                        title="Margin in inches"
+                                    />
+                                    <span class="dg-fmt-label">in</span>
+                                </template>
+                                <lightning-button
+                                    label="Format Code"
+                                    icon-name="utility:magicwand"
+                                    variant="base"
+                                    data-target="body"
+                                    onclick={handleFormatHtml}
+                                    title="Pretty-print the HTML: indent nested tags without touching text or merge tags."
+                                    class="slds-var-m-left_small"
+                                ></lightning-button>
+                                <lightning-button
+                                    label="Reload"
+                                    icon-name="utility:refresh"
+                                    variant="base"
+                                    onclick={handleReloadHtmlBodyEditor}
+                                    title="Replace the editor contents with the currently staged body (or the saved body if nothing is staged). Discards unapplied edits."
+                                    class="slds-var-m-left_small"
+                                ></lightning-button>
+                            </div>
                         </div>
 
                         <div class="dg-designer-layout">

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -2956,20 +2956,20 @@
                                                         ></div>
                                                     </template>
                                                     <template if:true={showHtmlBodyVisual}>
-                                                        <div class="dg-visual-editor-wrap">
-                                                            <lightning-input-rich-text
-                                                                class="dg-visual-editor"
-                                                                value={visualEditorHtml}
-                                                                onchange={handleVisualEditorChange}
-                                                            ></lightning-input-rich-text>
-                                                        </div>
+                                                        <div
+                                                            class="dg-html-preview-frame dg-visual-host"
+                                                            lwc:dom="manual"
+                                                            title="Visual editing — click into the page and type"
+                                                        ></div>
                                                         <p
                                                             class="slds-text-body_small slds-text-color_weak slds-var-m-top_xx-small"
                                                         >
-                                                            Visual mode edits the document text — your template's page
-                                                            setup and styles are preserved and reapplied when you switch
-                                                            back to Code. Merge tags are plain text: type
-                                                            &#123;Name&#125; anywhere.
+                                                            Click into the page and edit text right where it appears —
+                                                            tables and styling render exactly as the PDF engine sees
+                                                            them. Merge tags are plain text: type &#123;Name&#125;
+                                                            anywhere. Structure changes (new rows, sections) are Code
+                                                            work. "Back to Code" folds your edits in — only the document
+                                                            content changes, never your styles or page setup.
                                                         </p>
                                                     </template>
                                                     <div class="slds-var-m-top_x-small">

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -336,21 +336,19 @@
                                                 value={newTemplateLogoChoice}
                                                 options={logoChoiceOptions}
                                                 onchange={handleLogoChoiceChange}
-                                                field-level-help="Pick a shared image asset you already saved, or upload a new one. The starter header carries the logo slot either way."
+                                                field-level-help="Pick a shared image asset — the starter header carries its merge tag. Add new images under the Assets tab."
                                             ></lightning-combobox>
-                                            <template if:true={showLogoUpload}>
-                                                <div class="slds-var-m-top_x-small">
-                                                    <input
-                                                        type="file"
-                                                        accept=".png,.jpg,.jpeg"
-                                                        onchange={handleLogoSelected}
-                                                    />
-                                                </div>
+                                            <template if:true={selectedLogoPreviewUrl}>
+                                                <img
+                                                    class="dg-logo-preview"
+                                                    src={selectedLogoPreviewUrl}
+                                                    alt="Selected logo preview"
+                                                />
                                             </template>
-                                            <template if:true={newTemplateLogoName}>
+                                            <template if:true={hasNoAssetsYet}>
                                                 <p class="slds-text-body_small slds-text-color_weak">
-                                                    {newTemplateLogoName} — saved as your shared logo, placed in the
-                                                    template header, reusable in every template.
+                                                    No image assets yet — add your logo under the
+                                                    <strong>Assets</strong> tab and it becomes selectable here.
                                                 </p>
                                             </template>
                                         </div>
@@ -413,21 +411,19 @@
                                                 value={newTemplateLogoChoice}
                                                 options={logoChoiceOptions}
                                                 onchange={handleLogoChoiceChange}
-                                                field-level-help="Pick a shared image asset you already saved, or upload a new one. The AI prompt tells the assistant how to reference it."
+                                                field-level-help="Pick a shared image asset — the AI prompt tells the assistant how to reference it. Add new images under the Assets tab."
                                             ></lightning-combobox>
-                                            <template if:true={showLogoUpload}>
-                                                <div class="slds-var-m-top_x-small">
-                                                    <input
-                                                        type="file"
-                                                        accept=".png,.jpg,.jpeg"
-                                                        onchange={handleLogoSelected}
-                                                    />
-                                                </div>
+                                            <template if:true={selectedLogoPreviewUrl}>
+                                                <img
+                                                    class="dg-logo-preview"
+                                                    src={selectedLogoPreviewUrl}
+                                                    alt="Selected logo preview"
+                                                />
                                             </template>
-                                            <template if:true={newTemplateLogoName}>
+                                            <template if:true={hasNoAssetsYet}>
                                                 <p class="slds-text-body_small slds-text-color_weak">
-                                                    {newTemplateLogoName} — saved as your shared logo; the AI prompt
-                                                    will tell the assistant how to reference it.
+                                                    No image assets yet — add your logo under the
+                                                    <strong>Assets</strong> tab and it becomes selectable here.
                                                 </p>
                                             </template>
                                         </div>
@@ -1546,6 +1542,49 @@
                                     />
                                     <span class="dg-fmt-label">in</span>
                                 </template>
+                                <span class="dg-fmt-sep"></span>
+                                <button
+                                    class="dg-fmt-btn dg-panel-btn"
+                                    data-panel="insert"
+                                    onclick={handlePanelToggle}
+                                    title="Insert blocks, sections, tables — searchable. Or just type / in the page."
+                                >
+                                    + Insert
+                                </button>
+                                <button
+                                    class="dg-fmt-btn dg-panel-btn"
+                                    data-panel="tags"
+                                    onclick={handlePanelToggle}
+                                    title="Merge tags from your query — searchable"
+                                >
+                                    &#123;&nbsp;&#125; Tags
+                                </button>
+                                <button
+                                    class="dg-fmt-btn dg-panel-btn"
+                                    data-panel="images"
+                                    onclick={handlePanelToggle}
+                                    title="Upload and place images"
+                                >
+                                    Images
+                                </button>
+                                <template if:true={editTemplateOutputIsPdf}>
+                                    <button
+                                        class="dg-fmt-btn dg-panel-btn"
+                                        data-panel="watermark"
+                                        onclick={handlePanelToggle}
+                                        title="Full-page background image (PDF)"
+                                    >
+                                        Watermark
+                                    </button>
+                                    <button
+                                        class="dg-fmt-btn dg-panel-btn dg-pdf-preview-btn"
+                                        onclick={handlePdfPreview}
+                                        disabled={isPdfPreviewLoading}
+                                        title="Render the current draft through the REAL PDF engine with your sample record — see exactly what customers get."
+                                    >
+                                        {pdfPreviewBtnLabel}
+                                    </button>
+                                </template>
                                 <lightning-button
                                     label="Format Code"
                                     icon-name="utility:magicwand"
@@ -1597,6 +1636,40 @@
                                         >
                                             Remove from document
                                         </button>
+                                    </div>
+                                </template>
+                                <!-- Notion-style slash-command menu: type "/" in the page -->
+                                <template if:true={slashMenu}>
+                                    <div class="dg-slash-menu" style={slashMenu.posStyle} role="menu">
+                                        <div class="dg-slash-menu-head">
+                                            <span>Insert&nbsp;&#8212;&nbsp;keep typing to filter</span>
+                                            <button
+                                                class="dg-pill-menu-x"
+                                                onclick={handleSlashMenuClose}
+                                                title="Close (Esc)"
+                                            >
+                                                &#10005;
+                                            </button>
+                                        </div>
+                                        <template if:true={slashMenu.hasItems}>
+                                            <template for:each={slashMenu.items} for:item="opt">
+                                                <button
+                                                    key={opt.key}
+                                                    class={opt.itemClass}
+                                                    data-key={opt.key}
+                                                    onmousedown={handleFmtMouseDown}
+                                                    onclick={handleSlashItemClick}
+                                                >
+                                                    <span class="dg-slash-item-label">{opt.label}</span>
+                                                    <span class="dg-slash-item-group">{opt.group}</span>
+                                                </button>
+                                            </template>
+                                        </template>
+                                        <template if:false={slashMenu.hasItems}>
+                                            <div class="dg-slash-empty">
+                                                Nothing matches &#8220;{slashMenu.query}&#8221;
+                                            </div>
+                                        </template>
                                     </div>
                                 </template>
                                 <template if:true={isLoadingHtmlBody}>
@@ -2016,174 +2089,151 @@
                                 </div>
                             </div>
 
-                            <div class="dg-designer-rail">
-                                <div class="dg-rail-section-label">
-                                    <lightning-icon icon-name="utility:apps" size="xx-small"></lightning-icon>
-                                    Blocks
-                                </div>
-                                <div class="dg-tag-panel">
-                                    <template for:each={blockPaletteSections} for:item="section">
-                                        <div key={section.key} class="dg-tag-section">
-                                            <div class="dg-tag-section-label">{section.label}</div>
-                                            <template if:true={section.hint}>
-                                                <div class="dg-tag-section-hint">{section.hint}</div>
-                                            </template>
-                                            <div class="dg-tag-chips">
-                                                <template for:each={section.items} for:item="blk">
-                                                    <button
-                                                        key={blk.key}
-                                                        class="dg-tag-chip dg-block-chip"
-                                                        data-snippet={blk.snippet}
-                                                        data-kind="block"
-                                                        title={blk.title}
-                                                        draggable="true"
-                                                        ondragstart={handleTagDragStart}
-                                                        onmousedown={handleFmtMouseDown}
-                                                        onclick={handleInsertTagSnippet}
-                                                    >
-                                                        {blk.label}
-                                                    </button>
-                                                </template>
-                                            </div>
-                                        </div>
-                                    </template>
-                                </div>
-
-                                <div class="dg-rail-section-label">
-                                    <lightning-icon icon-name="utility:merge_field" size="xx-small"></lightning-icon>
-                                    Tags
-                                </div>
-                                <div class="dg-tag-panel">
-                                    <template for:each={tagPaletteSections} for:item="section">
-                                        <div key={section.key} class="dg-tag-section">
-                                            <div class="dg-tag-section-label">{section.label}</div>
-                                            <template if:true={section.hint}>
-                                                <div class="dg-tag-section-hint">{section.hint}</div>
-                                            </template>
-                                            <div class="dg-tag-chips">
-                                                <template for:each={section.items} for:item="tag">
-                                                    <button
-                                                        key={tag.key}
-                                                        class="dg-tag-chip"
-                                                        data-snippet={tag.snippet}
-                                                        title={tag.title}
-                                                        draggable="true"
-                                                        ondragstart={handleTagDragStart}
-                                                        onmousedown={handleFmtMouseDown}
-                                                        onclick={handleInsertTagSnippet}
-                                                    >
-                                                        {tag.label}
-                                                    </button>
-                                                </template>
-                                            </div>
-                                        </div>
-                                    </template>
-                                </div>
-
-                                <div class="dg-rail-section-label">
-                                    <lightning-icon icon-name="utility:image" size="xx-small"></lightning-icon>
-                                    Images
-                                </div>
-                                <div class="dg-image-panel">
-                                    <div class="dg-image-panel-head">
-                                        <span class="slds-text-body_small">
-                                            Upload once — click or drag a thumbnail onto the page. PNG or JPG (SVG
-                                            doesn't render in PDF).
-                                        </span>
-                                        <lightning-button
-                                            variant="brand"
-                                            label="Upload"
-                                            icon-name="utility:upload"
-                                            onclick={triggerInsertImagePicker}
-                                            disabled={isUploadingInsertImage}
-                                        ></lightning-button>
+                            <template if:true={showFloatPanel}>
+                                <div class="dg-float-panel">
+                                    <div class="dg-float-panel-head">
+                                        <span class="dg-float-panel-title">{floatPanelTitle}</span>
+                                        <button class="dg-pill-menu-x" onclick={handlePanelClose} title="Close">
+                                            &#10005;
+                                        </button>
                                     </div>
-                                    <input
-                                        type="file"
-                                        class="dg-insert-image-input"
-                                        accept=".png,.jpg,.jpeg,.gif,.bmp"
-                                        style="display: none"
-                                        onchange={handleInsertImageSelected}
-                                    />
-                                    <template if:true={isUploadingInsertImage}>
-                                        <div class="slds-is-relative slds-var-m-top_small" style="height: 30px">
-                                            <lightning-spinner
-                                                alternative-text="Uploading image"
-                                                size="small"
-                                            ></lightning-spinner>
-                                        </div>
+                                    <template if:false={isPanelWatermark}>
+                                        <input
+                                            type="search"
+                                            class="dg-panel-search"
+                                            placeholder={panelSearchPlaceholder}
+                                            oninput={handlePanelSearch}
+                                            autocomplete="off"
+                                        />
                                     </template>
-                                    <template if:true={isLoadingTemplateImages}>
-                                        <div class="slds-is-relative slds-var-m-top_small" style="height: 30px">
-                                            <lightning-spinner
-                                                alternative-text="Loading images"
-                                                size="small"
-                                            ></lightning-spinner>
-                                        </div>
+                                    <template if:true={isPanelInsert}>
+                                        <p class="dg-float-panel-tip">
+                                            Tip: type <code>/</code> anywhere in the page for this menu at your cursor.
+                                        </p>
+                                        <template for:each={filteredBlockSections} for:item="section">
+                                            <div key={section.key} class="dg-tag-section">
+                                                <div class="dg-tag-section-label">{section.label}</div>
+                                                <template if:true={section.hint}>
+                                                    <div class="dg-tag-section-hint">{section.hint}</div>
+                                                </template>
+                                                <div class="dg-tag-chips">
+                                                    <template for:each={section.items} for:item="blk">
+                                                        <button
+                                                            key={blk.key}
+                                                            class="dg-tag-chip dg-block-chip"
+                                                            data-snippet={blk.snippet}
+                                                            data-kind="block"
+                                                            title={blk.title}
+                                                            draggable="true"
+                                                            ondragstart={handleTagDragStart}
+                                                            onmousedown={handleFmtMouseDown}
+                                                            onclick={handleInsertTagSnippet}
+                                                        >
+                                                            {blk.label}
+                                                        </button>
+                                                    </template>
+                                                </div>
+                                            </div>
+                                        </template>
                                     </template>
-                                    <template if:true={hasTemplateImages}>
-                                        <div class="dg-image-grid">
-                                            <template for:each={templateImages} for:item="img">
-                                                <div
-                                                    key={img.contentVersionId}
-                                                    class="dg-image-thumb"
-                                                    data-url={img.url}
-                                                    data-name={img.fileName}
-                                                    draggable="true"
-                                                    ondragstart={handleImageDragStart}
-                                                    onmousedown={handleFmtMouseDown}
-                                                    onclick={handleInsertExistingImage}
-                                                    title={img.fileName}
-                                                >
-                                                    <img src={img.url} alt={img.fileName} />
-                                                    <span class="dg-image-thumb-name">{img.fileName}</span>
+                                    <template if:true={isPanelTags}>
+                                        <template for:each={filteredTagSections} for:item="section">
+                                            <div key={section.key} class="dg-tag-section">
+                                                <div class="dg-tag-section-label">{section.label}</div>
+                                                <template if:true={section.hint}>
+                                                    <div class="dg-tag-section-hint">{section.hint}</div>
+                                                </template>
+                                                <div class="dg-tag-chips">
+                                                    <template for:each={section.items} for:item="tag">
+                                                        <button
+                                                            key={tag.key}
+                                                            class="dg-tag-chip"
+                                                            data-snippet={tag.snippet}
+                                                            title={tag.title}
+                                                            draggable="true"
+                                                            ondragstart={handleTagDragStart}
+                                                            onmousedown={handleFmtMouseDown}
+                                                            onclick={handleInsertTagSnippet}
+                                                        >
+                                                            {tag.label}
+                                                        </button>
+                                                    </template>
+                                                </div>
+                                            </div>
+                                        </template>
+                                    </template>
+                                    <template if:true={isPanelImages}>
+                                        <div class="dg-image-panel">
+                                            <p class="slds-text-body_small slds-var-m-bottom_x-small">
+                                                Every image lives in the shared <strong>Asset Library</strong> and is
+                                                placed by merge tag — the engine renders these natively. Add or update
+                                                images under the Assets tab.
+                                            </p>
+                                            <template if:true={hasFilteredAssets}>
+                                                <div class="dg-image-grid">
+                                                    <template for:each={filteredAssets} for:item="asset">
+                                                        <div
+                                                            key={asset.id}
+                                                            class="dg-image-thumb"
+                                                            data-snippet={asset.mergeTag}
+                                                            draggable="true"
+                                                            ondragstart={handleTagDragStart}
+                                                            onmousedown={handleFmtMouseDown}
+                                                            onclick={handleInsertTagSnippet}
+                                                            title={asset.mergeTag}
+                                                        >
+                                                            <template if:true={asset.previewUrl}>
+                                                                <img src={asset.previewUrl} alt={asset.name} />
+                                                            </template>
+                                                            <span class="dg-image-thumb-name">{asset.name}</span>
+                                                            <span class="dg-asset-thumb-tag">{asset.mergeTag}</span>
+                                                        </div>
+                                                    </template>
                                                 </div>
                                             </template>
+                                            <template if:false={hasFilteredAssets}>
+                                                <p
+                                                    class="slds-text-body_small slds-text-color_weak slds-var-m-top_x-small"
+                                                >
+                                                    No matching assets — add images under the Assets tab.
+                                                </p>
+                                            </template>
                                         </div>
                                     </template>
-                                    <template if:false={hasTemplateImages}>
-                                        <p class="slds-text-body_small slds-text-color_weak slds-var-m-top_x-small">
-                                            No images attached yet.
-                                        </p>
+
+                                    <template if:true={isPanelWatermark}>
+                                        <div class="dg-image-panel">
+                                            <p class="slds-text-body_small slds-var-m-bottom_x-small">
+                                                Full-page background image behind your content (PDF output). Pre-fade
+                                                the image (~15-20% opacity over white) for a watermark look. Needs a
+                                                saved version first.
+                                            </p>
+                                            <template if:true={watermarkPreviewUrl}>
+                                                <div class="dg-watermark-preview">
+                                                    <img src={watermarkPreviewUrl} alt="Current watermark" />
+                                                    <lightning-button
+                                                        label="Remove"
+                                                        icon-name="utility:delete"
+                                                        variant="destructive-text"
+                                                        onclick={handleClearWatermark}
+                                                        disabled={isUploadingWatermark}
+                                                    ></lightning-button>
+                                                </div>
+                                            </template>
+                                            <input
+                                                type="file"
+                                                accept="image/*"
+                                                onchange={handleWatermarkFileSelected}
+                                                disabled={isUploadingWatermark}
+                                                class="slds-var-m-top_x-small"
+                                            />
+                                            <template if:true={isUploadingWatermark}>
+                                                <p class="slds-text-body_small slds-var-m-top_x-small">Uploading…</p>
+                                            </template>
+                                        </div>
                                     </template>
                                 </div>
-
-                                <template if:true={editTemplateOutputIsPdf}>
-                                    <div class="dg-rail-section-label">
-                                        <lightning-icon icon-name="utility:layers" size="xx-small"></lightning-icon>
-                                        Watermark
-                                    </div>
-                                    <div class="dg-image-panel">
-                                        <p class="slds-text-body_small slds-var-m-bottom_x-small">
-                                            Full-page background image behind your content (PDF output). Pre-fade the
-                                            image (~15-20% opacity over white) for a watermark look. Needs a saved
-                                            version first.
-                                        </p>
-                                        <template if:true={watermarkPreviewUrl}>
-                                            <div class="dg-watermark-preview">
-                                                <img src={watermarkPreviewUrl} alt="Current watermark" />
-                                                <lightning-button
-                                                    label="Remove"
-                                                    icon-name="utility:delete"
-                                                    variant="destructive-text"
-                                                    onclick={handleClearWatermark}
-                                                    disabled={isUploadingWatermark}
-                                                ></lightning-button>
-                                            </div>
-                                        </template>
-                                        <input
-                                            type="file"
-                                            accept="image/*"
-                                            onchange={handleWatermarkFileSelected}
-                                            disabled={isUploadingWatermark}
-                                            class="slds-var-m-top_x-small"
-                                        />
-                                        <template if:true={isUploadingWatermark}>
-                                            <p class="slds-text-body_small slds-var-m-top_x-small">Uploading…</p>
-                                        </template>
-                                    </div>
-                                </template>
-                            </div>
+                            </template>
                         </div>
                     </template>
                 </div>

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1169,6 +1169,288 @@
                     </template>
                 </div>
             </lightning-tab>
+
+            <!-- Full-screen template designer: the page is the canvas, palettes ride the rail -->
+            <lightning-tab label="Designer" value="design" onactive={handleTabActive}>
+                <div class="slds-var-p-around_medium">
+                    <template if:false={designerHasTemplate}>
+                        <div class="slds-text-align_center slds-var-p-around_xx-large slds-text-color_weak">
+                            <lightning-icon icon-name="utility:brush" size="medium"></lightning-icon>
+                            <p class="slds-text-heading_small slds-var-m-top_small slds-var-m-bottom_x-small">
+                                No template open
+                            </p>
+                            <p class="slds-text-body_small">
+                                Pick an HTML template under&nbsp;<strong>Your Templates</strong>&nbsp;and choose
+                                the&nbsp;<strong>Design</strong>&nbsp;row action — or build one from&nbsp;<strong
+                                    >Create New</strong
+                                >.
+                            </p>
+                        </div>
+                    </template>
+                    <template if:true={designerHasTemplate}>
+                        <div class="dg-designer-toolbar">
+                            <div class="dg-designer-toolbar__title">
+                                <lightning-icon icon-name="utility:brush" size="small"></lightning-icon>
+                                <span class="slds-text-heading_small">{designerTitle}</span>
+                            </div>
+                            <template if:true={isRealObject}>
+                                <div class="dg-designer-toolbar__sample">
+                                    <lightning-record-picker
+                                        label="Sample Record"
+                                        variant="label-hidden"
+                                        object-api-name={editTemplateObject}
+                                        value={editTemplateTestRecordId}
+                                        onchange={handleEditTestRecordChange}
+                                        placeholder="Sample record for previews..."
+                                    >
+                                    </lightning-record-picker>
+                                </div>
+                                <lightning-button
+                                    label="Generate Sample"
+                                    icon-name="utility:page"
+                                    onclick={handleTestGenerate}
+                                    disabled={editGenerateSampleDisabled}
+                                ></lightning-button>
+                                <template if:true={isLoadingVersions}>
+                                    <lightning-spinner alternative-text="Working..." size="small"></lightning-spinner>
+                                </template>
+                            </template>
+                            <div class="dg-designer-toolbar__actions">
+                                <lightning-button
+                                    variant="brand"
+                                    label="Save as New Version"
+                                    icon-name="utility:save"
+                                    onclick={handleSaveAndClose}
+                                ></lightning-button>
+                                <lightning-button
+                                    label="Back to Templates"
+                                    icon-name="utility:back"
+                                    onclick={handleCloseDesigner}
+                                    class="slds-var-m-left_x-small"
+                                ></lightning-button>
+                            </div>
+                        </div>
+
+                        <div class="dg-html-editor-statusbar">
+                            <span class={htmlEditorStatusClass}>{htmlEditorStatusText}</span>
+                            <lightning-button
+                                label="Format Code"
+                                icon-name="utility:magicwand"
+                                variant="base"
+                                data-target="body"
+                                onclick={handleFormatHtml}
+                                title="Pretty-print the HTML: indent nested tags without touching text or merge tags."
+                                class="slds-var-m-left_small"
+                            ></lightning-button>
+                            <lightning-button
+                                label={visualToggleLabel}
+                                icon-name="utility:preview"
+                                variant="base"
+                                onclick={handleToggleHtmlVisual}
+                                title="See and edit the document as it renders — click anywhere and type. Your @page/style shell is never touched; structure work happens in Code."
+                                class="slds-var-m-left_small"
+                            ></lightning-button>
+                            <lightning-button
+                                label="Reload"
+                                icon-name="utility:refresh"
+                                variant="base"
+                                onclick={handleReloadHtmlBodyEditor}
+                                title="Replace the editor contents with the currently staged body (or the saved body if nothing is staged). Discards unapplied edits."
+                                class="slds-var-m-left_small"
+                            ></lightning-button>
+                        </div>
+
+                        <div class="dg-designer-layout">
+                            <div class="dg-designer-canvas-col">
+                                <template if:true={isLoadingHtmlBody}>
+                                    <div class="slds-is-relative" style="height: 40px">
+                                        <lightning-spinner
+                                            alternative-text="Loading HTML body"
+                                            size="small"
+                                        ></lightning-spinner>
+                                    </div>
+                                </template>
+                                <textarea
+                                    class={designerEditorClass}
+                                    spellcheck="false"
+                                    aria-label="Template HTML body"
+                                    oninput={handleHtmlBodyEditorInput}
+                                    placeholder="Paste your template HTML here — from your AI assistant, Google Docs (File → Download → Web Page), or hand-written. Merge tags like &#123;Name&#125; fill from your Query Config."
+                                ></textarea>
+                                <template if:true={showHtmlBodyVisual}>
+                                    <div
+                                        class="dg-html-preview-frame dg-visual-host dg-designer-size"
+                                        lwc:dom="manual"
+                                        title="Visual editing — click into the page and type"
+                                    ></div>
+                                    <p class="slds-text-body_small slds-text-color_weak slds-var-m-top_xx-small">
+                                        This is your document — click anywhere and type. The colored pills are your data
+                                        fields. Drag anything from the rail on the right straight onto the page.
+                                        Deleting a pill removes the whole field — they can't break. Your styles and page
+                                        setup are never touched here.
+                                    </p>
+                                </template>
+                                <div class="slds-var-m-top_x-small">
+                                    <lightning-button
+                                        variant="brand"
+                                        label="Apply Editor HTML"
+                                        icon-name="utility:check"
+                                        onclick={handleApplyHtmlBody}
+                                        disabled={isApplyingHtmlBody}
+                                    ></lightning-button>
+                                    <lightning-button
+                                        label="Copy AI Prompt"
+                                        icon-name="utility:copy"
+                                        onclick={handleCopyEditAiPrompt}
+                                        title="Copies a ready-to-paste prompt (your fields + DocGen tag syntax + PDF layout rules) for Claude / ChatGPT / Gemini / Copilot."
+                                        class="slds-var-m-left_x-small"
+                                    ></lightning-button>
+                                    <template if:true={isApplyingHtmlBody}>
+                                        <lightning-spinner
+                                            alternative-text="Applying"
+                                            size="small"
+                                            class="slds-var-m-left_small"
+                                        ></lightning-spinner>
+                                    </template>
+                                    <span class="slds-text-body_small slds-text-color_weak slds-var-m-left_small">
+                                        Stage your changes, then "Save as New Version" makes them the active body.
+                                    </span>
+                                </div>
+                            </div>
+
+                            <div class="dg-designer-rail">
+                                <div class="dg-rail-section-label">
+                                    <lightning-icon icon-name="utility:apps" size="xx-small"></lightning-icon>
+                                    Blocks
+                                </div>
+                                <div class="dg-tag-panel">
+                                    <template for:each={blockPaletteSections} for:item="section">
+                                        <div key={section.key} class="dg-tag-section">
+                                            <div class="dg-tag-section-label">{section.label}</div>
+                                            <template if:true={section.hint}>
+                                                <div class="dg-tag-section-hint">{section.hint}</div>
+                                            </template>
+                                            <div class="dg-tag-chips">
+                                                <template for:each={section.items} for:item="blk">
+                                                    <button
+                                                        key={blk.key}
+                                                        class="dg-tag-chip dg-block-chip"
+                                                        data-snippet={blk.snippet}
+                                                        data-kind="block"
+                                                        title={blk.title}
+                                                        draggable="true"
+                                                        ondragstart={handleTagDragStart}
+                                                        onclick={handleInsertTagSnippet}
+                                                    >
+                                                        {blk.label}
+                                                    </button>
+                                                </template>
+                                            </div>
+                                        </div>
+                                    </template>
+                                </div>
+
+                                <div class="dg-rail-section-label">
+                                    <lightning-icon icon-name="utility:merge_field" size="xx-small"></lightning-icon>
+                                    Tags
+                                </div>
+                                <div class="dg-tag-panel">
+                                    <template for:each={tagPaletteSections} for:item="section">
+                                        <div key={section.key} class="dg-tag-section">
+                                            <div class="dg-tag-section-label">{section.label}</div>
+                                            <template if:true={section.hint}>
+                                                <div class="dg-tag-section-hint">{section.hint}</div>
+                                            </template>
+                                            <div class="dg-tag-chips">
+                                                <template for:each={section.items} for:item="tag">
+                                                    <button
+                                                        key={tag.key}
+                                                        class="dg-tag-chip"
+                                                        data-snippet={tag.snippet}
+                                                        title={tag.title}
+                                                        draggable="true"
+                                                        ondragstart={handleTagDragStart}
+                                                        onclick={handleInsertTagSnippet}
+                                                    >
+                                                        {tag.label}
+                                                    </button>
+                                                </template>
+                                            </div>
+                                        </div>
+                                    </template>
+                                </div>
+
+                                <div class="dg-rail-section-label">
+                                    <lightning-icon icon-name="utility:image" size="xx-small"></lightning-icon>
+                                    Images
+                                </div>
+                                <div class="dg-image-panel">
+                                    <div class="dg-image-panel-head">
+                                        <span class="slds-text-body_small">
+                                            Upload once — click or drag a thumbnail onto the page. PNG or JPG (SVG
+                                            doesn't render in PDF).
+                                        </span>
+                                        <lightning-button
+                                            variant="brand"
+                                            label="Upload"
+                                            icon-name="utility:upload"
+                                            onclick={triggerInsertImagePicker}
+                                            disabled={isUploadingInsertImage}
+                                        ></lightning-button>
+                                    </div>
+                                    <input
+                                        type="file"
+                                        class="dg-insert-image-input"
+                                        accept=".png,.jpg,.jpeg,.gif,.bmp"
+                                        style="display: none"
+                                        onchange={handleInsertImageSelected}
+                                    />
+                                    <template if:true={isUploadingInsertImage}>
+                                        <div class="slds-is-relative slds-var-m-top_small" style="height: 30px">
+                                            <lightning-spinner
+                                                alternative-text="Uploading image"
+                                                size="small"
+                                            ></lightning-spinner>
+                                        </div>
+                                    </template>
+                                    <template if:true={isLoadingTemplateImages}>
+                                        <div class="slds-is-relative slds-var-m-top_small" style="height: 30px">
+                                            <lightning-spinner
+                                                alternative-text="Loading images"
+                                                size="small"
+                                            ></lightning-spinner>
+                                        </div>
+                                    </template>
+                                    <template if:true={hasTemplateImages}>
+                                        <div class="dg-image-grid">
+                                            <template for:each={templateImages} for:item="img">
+                                                <div
+                                                    key={img.contentVersionId}
+                                                    class="dg-image-thumb"
+                                                    data-url={img.url}
+                                                    data-name={img.fileName}
+                                                    draggable="true"
+                                                    ondragstart={handleImageDragStart}
+                                                    onclick={handleInsertExistingImage}
+                                                    title={img.fileName}
+                                                >
+                                                    <img src={img.url} alt={img.fileName} />
+                                                    <span class="dg-image-thumb-name">{img.fileName}</span>
+                                                </div>
+                                            </template>
+                                        </div>
+                                    </template>
+                                    <template if:false={hasTemplateImages}>
+                                        <p class="slds-text-body_small slds-text-color_weak slds-var-m-top_x-small">
+                                            No images attached yet.
+                                        </p>
+                                    </template>
+                                </div>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+            </lightning-tab>
         </lightning-tabset>
     </div>
 
@@ -2867,9 +3149,11 @@
                                             >
                                             </lightning-button>
                                             <lightning-button
-                                                label={htmlBodyEditorToggleLabel}
-                                                icon-name="utility:edit"
-                                                onclick={toggleHtmlBodyEditor}
+                                                variant="brand"
+                                                label="Open Designer"
+                                                icon-name="utility:brush"
+                                                onclick={handleOpenDesignerFromModal}
+                                                title="Full-screen visual designer: edit the rendered page, drag in blocks, tags, and images."
                                                 class="slds-var-m-left_x-small"
                                             >
                                             </lightning-button>
@@ -2877,7 +3161,7 @@
                                                 label="Copy AI Prompt"
                                                 icon-name="utility:copy"
                                                 onclick={handleCopyEditAiPrompt}
-                                                title="Copies a ready-to-paste prompt (your fields + DocGen tag syntax + PDF layout rules) for Claude / ChatGPT / Gemini / Copilot. Paste the returned HTML into the editor."
+                                                title="Copies a ready-to-paste prompt (your fields + DocGen tag syntax + PDF layout rules) for Claude / ChatGPT / Gemini / Copilot. Paste the returned HTML into the designer."
                                                 class="slds-var-m-left_x-small"
                                             >
                                             </lightning-button>
@@ -2887,227 +3171,6 @@
                                                     size="small"
                                                     class="slds-var-m-left_small"
                                                 ></lightning-spinner>
-                                            </template>
-                                            <template if:true={showHtmlBodyEditor}>
-                                                <div class="slds-var-m-top_small">
-                                                    <!-- What the editor is showing, and where it stands vs. the
-                                                         staged body. "Clear is kind": whatever was staged LAST —
-                                                         an uploaded file or applied editor HTML — is what
-                                                         "Save as New Version" saves. -->
-                                                    <div class="dg-html-editor-statusbar">
-                                                        <span class={htmlEditorStatusClass}
-                                                            >{htmlEditorStatusText}</span
-                                                        >
-                                                        <lightning-button
-                                                            label="Format Code"
-                                                            icon-name="utility:magicwand"
-                                                            variant="base"
-                                                            data-target="body"
-                                                            onclick={handleFormatHtml}
-                                                            title="Pretty-print the HTML: indent nested tags without touching text or merge tags."
-                                                            class="slds-var-m-left_small"
-                                                        ></lightning-button>
-                                                        <lightning-button
-                                                            label={visualToggleLabel}
-                                                            icon-name="utility:preview"
-                                                            variant="base"
-                                                            onclick={handleToggleHtmlVisual}
-                                                            title="See and edit the document as it renders — click anywhere and type. Your @page/style shell is never touched; structure work happens in Code."
-                                                            class="slds-var-m-left_small"
-                                                        ></lightning-button>
-                                                        <lightning-button
-                                                            label="Reload"
-                                                            icon-name="utility:refresh"
-                                                            variant="base"
-                                                            onclick={handleReloadHtmlBodyEditor}
-                                                            title="Replace the editor contents with the currently staged body (or the saved body if nothing is staged). Discards unapplied edits."
-                                                            class="slds-var-m-left_small"
-                                                        ></lightning-button>
-                                                    </div>
-                                                    <template if:true={isLoadingHtmlBody}>
-                                                        <div class="slds-is-relative" style="height: 40px">
-                                                            <lightning-spinner
-                                                                alternative-text="Loading HTML body"
-                                                                size="small"
-                                                            ></lightning-spinner>
-                                                        </div>
-                                                    </template>
-                                                    <textarea
-                                                        class={htmlBodyEditorClass}
-                                                        spellcheck="false"
-                                                        aria-label="Template HTML body"
-                                                        oninput={handleHtmlBodyEditorInput}
-                                                        placeholder="Paste your template HTML here — from your AI assistant, Google Docs (File → Download → Web Page), or hand-written. Merge tags like &#123;Name&#125; fill from your Query Config."
-                                                    ></textarea>
-                                                    <template if:true={showHtmlBodyVisual}>
-                                                        <div
-                                                            class="dg-html-preview-frame dg-visual-host"
-                                                            lwc:dom="manual"
-                                                            title="Visual editing — click into the page and type"
-                                                        ></div>
-                                                        <p
-                                                            class="slds-text-body_small slds-text-color_weak slds-var-m-top_xx-small"
-                                                        >
-                                                            This is your document — click anywhere and type. The colored
-                                                            pills are your data fields: drag more in from&nbsp;<strong
-                                                                >Insert Tags</strong
-                                                            >&nbsp;or drop a picture from&nbsp;<strong>Add Image</strong
-                                                            >&nbsp;right where you want it. Deleting a pill removes the
-                                                            whole field — they can't break. Your styles and page setup
-                                                            are never touched here; "Back to Code" is one click away for
-                                                            structure work.
-                                                        </p>
-                                                    </template>
-                                                    <div class="slds-var-m-top_x-small">
-                                                        <lightning-button
-                                                            variant="brand"
-                                                            label="Apply Editor HTML"
-                                                            icon-name="utility:check"
-                                                            onclick={handleApplyHtmlBody}
-                                                            disabled={isApplyingHtmlBody}
-                                                        ></lightning-button>
-                                                        <lightning-button
-                                                            label={tagPanelToggleLabel}
-                                                            icon-name="utility:merge_field"
-                                                            onclick={toggleTagPanel}
-                                                            title="Click-to-insert merge tags: this template's fields, child loops, dates, running user, signatures, conditionals."
-                                                            class="slds-var-m-left_x-small"
-                                                        ></lightning-button>
-                                                        <lightning-button
-                                                            label={imagePanelToggleLabel}
-                                                            icon-name="utility:image"
-                                                            onclick={toggleImagePanel}
-                                                            title="Upload an image or pick one already attached — a PDF-safe <img> tag is inserted at your cursor."
-                                                            class="slds-var-m-left_x-small"
-                                                        ></lightning-button>
-                                                        <template if:true={isApplyingHtmlBody}>
-                                                            <lightning-spinner
-                                                                alternative-text="Applying"
-                                                                size="small"
-                                                                class="slds-var-m-left_small"
-                                                            ></lightning-spinner>
-                                                        </template>
-                                                        <span
-                                                            class="slds-text-body_small slds-text-color_weak slds-var-m-left_small"
-                                                        >
-                                                            Stages this HTML as the body (inline images extracted
-                                                            automatically). Uploading a file instead replaces it —
-                                                            whichever was staged last is what "Save as New Version"
-                                                            saves.
-                                                        </span>
-                                                    </div>
-                                                    <template if:true={showTagPanel}>
-                                                        <div class="dg-tag-panel slds-var-m-top_small">
-                                                            <template for:each={tagPaletteSections} for:item="section">
-                                                                <div key={section.key} class="dg-tag-section">
-                                                                    <div class="dg-tag-section-label">
-                                                                        {section.label}
-                                                                    </div>
-                                                                    <template if:true={section.hint}>
-                                                                        <div class="dg-tag-section-hint">
-                                                                            {section.hint}
-                                                                        </div>
-                                                                    </template>
-                                                                    <div class="dg-tag-chips">
-                                                                        <template
-                                                                            for:each={section.items}
-                                                                            for:item="tag"
-                                                                        >
-                                                                            <button
-                                                                                key={tag.key}
-                                                                                class="dg-tag-chip"
-                                                                                data-snippet={tag.snippet}
-                                                                                title={tag.title}
-                                                                                draggable="true"
-                                                                                ondragstart={handleTagDragStart}
-                                                                                onclick={handleInsertTagSnippet}
-                                                                            >
-                                                                                {tag.label}
-                                                                            </button>
-                                                                        </template>
-                                                                    </div>
-                                                                </div>
-                                                            </template>
-                                                        </div>
-                                                    </template>
-                                                    <template if:true={showImagePanel}>
-                                                        <div class="dg-image-panel slds-var-m-top_small">
-                                                            <div class="dg-image-panel-head">
-                                                                <span class="slds-text-body_small">
-                                                                    Upload once — DocGen stores the image with this
-                                                                    template and inserts a PDF-safe
-                                                                    <code>&lt;img&gt;</code>&nbsp;tag at your cursor.
-                                                                    Click a thumbnail to insert an existing image. Use
-                                                                    PNG or JPG — SVG doesn't render in PDF output.
-                                                                </span>
-                                                                <lightning-button
-                                                                    variant="brand"
-                                                                    label="Upload Image"
-                                                                    icon-name="utility:upload"
-                                                                    onclick={triggerInsertImagePicker}
-                                                                    disabled={isUploadingInsertImage}
-                                                                ></lightning-button>
-                                                            </div>
-                                                            <input
-                                                                type="file"
-                                                                class="dg-insert-image-input"
-                                                                accept=".png,.jpg,.jpeg,.gif,.bmp"
-                                                                style="display: none"
-                                                                onchange={handleInsertImageSelected}
-                                                            />
-                                                            <template if:true={isUploadingInsertImage}>
-                                                                <div
-                                                                    class="slds-is-relative slds-var-m-top_small"
-                                                                    style="height: 30px"
-                                                                >
-                                                                    <lightning-spinner
-                                                                        alternative-text="Uploading image"
-                                                                        size="small"
-                                                                    ></lightning-spinner>
-                                                                </div>
-                                                            </template>
-                                                            <template if:true={isLoadingTemplateImages}>
-                                                                <div
-                                                                    class="slds-is-relative slds-var-m-top_small"
-                                                                    style="height: 30px"
-                                                                >
-                                                                    <lightning-spinner
-                                                                        alternative-text="Loading images"
-                                                                        size="small"
-                                                                    ></lightning-spinner>
-                                                                </div>
-                                                            </template>
-                                                            <template if:true={hasTemplateImages}>
-                                                                <div class="dg-image-grid">
-                                                                    <template for:each={templateImages} for:item="img">
-                                                                        <div
-                                                                            key={img.contentVersionId}
-                                                                            class="dg-image-thumb"
-                                                                            data-url={img.url}
-                                                                            data-name={img.fileName}
-                                                                            draggable="true"
-                                                                            ondragstart={handleImageDragStart}
-                                                                            onclick={handleInsertExistingImage}
-                                                                            title={img.fileName}
-                                                                        >
-                                                                            <img src={img.url} alt={img.fileName} />
-                                                                            <span class="dg-image-thumb-name"
-                                                                                >{img.fileName}</span
-                                                                            >
-                                                                        </div>
-                                                                    </template>
-                                                                </div>
-                                                            </template>
-                                                            <template if:false={hasTemplateImages}>
-                                                                <p
-                                                                    class="slds-text-body_small slds-text-color_weak slds-var-m-top_x-small"
-                                                                >
-                                                                    No images attached to this template yet.
-                                                                </p>
-                                                            </template>
-                                                        </div>
-                                                    </template>
-                                                </div>
                                             </template>
                                         </template>
 

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -2757,6 +2757,67 @@
                                                 <em>Compress Pictures → Email (96 ppi)</em> — most 20 MB templates drop
                                                 to under 2 MB with no visible quality loss.
                                             </p>
+
+                                            <!-- DOCX→HTML transparency: show the exact HTML the PDF engine
+                                                 renders from the Word file. Editing it is a one-way ramp to an
+                                                 HTML template — the snapshot regenerates on every DOCX upload,
+                                                 so in-place edits would be silently clobbered. -->
+                                            <template if:true={showDocxConvertedHtmlSection}>
+                                                <div class="slds-var-m-top_small">
+                                                    <lightning-button
+                                                        label={docxHtmlViewerToggleLabel}
+                                                        icon-name="utility:preview"
+                                                        onclick={toggleDocxHtmlViewer}
+                                                    ></lightning-button>
+                                                    <template if:true={showDocxHtmlViewer}>
+                                                        <div class="slds-var-m-top_small">
+                                                            <div class="dg-html-editor-statusbar">
+                                                                <span class="dg-html-editor-status"
+                                                                    >{docxViewerStatusText}</span
+                                                                >
+                                                            </div>
+                                                            <template if:true={isLoadingDocxHtml}>
+                                                                <div class="slds-is-relative" style="height: 40px">
+                                                                    <lightning-spinner
+                                                                        alternative-text="Loading converted HTML"
+                                                                        size="small"
+                                                                    ></lightning-spinner>
+                                                                </div>
+                                                            </template>
+                                                            <textarea
+                                                                class="dg-html-body-editor dg-docx-html-editor"
+                                                                spellcheck="false"
+                                                                aria-label="Converted HTML (what the PDF engine renders)"
+                                                                placeholder="No conversion snapshot yet — upload a Word file and Save as New Version, then reopen this viewer."
+                                                            ></textarea>
+                                                            <div class="slds-var-m-top_x-small">
+                                                                <lightning-button
+                                                                    variant="brand"
+                                                                    label="Switch to HTML Template"
+                                                                    icon-name="utility:change_record_type"
+                                                                    onclick={handleSwitchToHtmlTemplate}
+                                                                    disabled={isSwitchingToHtml}
+                                                                ></lightning-button>
+                                                                <template if:true={isSwitchingToHtml}>
+                                                                    <lightning-spinner
+                                                                        alternative-text="Converting"
+                                                                        size="small"
+                                                                        class="slds-var-m-left_small"
+                                                                    ></lightning-spinner>
+                                                                </template>
+                                                                <span
+                                                                    class="slds-text-body_small slds-text-color_weak slds-var-m-left_small"
+                                                                >
+                                                                    Fine-tuned this HTML? Converting makes it the
+                                                                    template's real body (Type becomes HTML) so your
+                                                                    edits stick. Until then this view is regenerated
+                                                                    from the Word file on every upload.
+                                                                </span>
+                                                            </div>
+                                                        </div>
+                                                    </template>
+                                                </div>
+                                            </template>
                                         </template>
 
                                         <template if:true={isEditTypeHtml}>
@@ -2804,6 +2865,23 @@
                                             </template>
                                             <template if:true={showHtmlBodyEditor}>
                                                 <div class="slds-var-m-top_small">
+                                                    <!-- What the editor is showing, and where it stands vs. the
+                                                         staged body. "Clear is kind": whatever was staged LAST —
+                                                         an uploaded file or applied editor HTML — is what
+                                                         "Save as New Version" saves. -->
+                                                    <div class="dg-html-editor-statusbar">
+                                                        <span class={htmlEditorStatusClass}
+                                                            >{htmlEditorStatusText}</span
+                                                        >
+                                                        <lightning-button
+                                                            label="Reload"
+                                                            icon-name="utility:refresh"
+                                                            variant="base"
+                                                            onclick={handleReloadHtmlBodyEditor}
+                                                            title="Replace the editor contents with the currently staged body (or the saved body if nothing is staged). Discards unapplied edits."
+                                                            class="slds-var-m-left_small"
+                                                        ></lightning-button>
+                                                    </div>
                                                     <template if:true={isLoadingHtmlBody}>
                                                         <div class="slds-is-relative" style="height: 40px">
                                                             <lightning-spinner
@@ -2816,12 +2894,13 @@
                                                         class="dg-html-body-editor"
                                                         spellcheck="false"
                                                         aria-label="Template HTML body"
+                                                        oninput={handleHtmlBodyEditorInput}
                                                         placeholder="Paste your template HTML here — from your AI assistant, Google Docs (File → Download → Web Page), or hand-written. Merge tags like &#123;Name&#125; fill from your Query Config."
                                                     ></textarea>
                                                     <div class="slds-var-m-top_x-small">
                                                         <lightning-button
                                                             variant="brand"
-                                                            label="Apply HTML"
+                                                            label="Apply Editor HTML"
                                                             icon-name="utility:check"
                                                             onclick={handleApplyHtmlBody}
                                                             disabled={isApplyingHtmlBody}
@@ -2836,8 +2915,10 @@
                                                         <span
                                                             class="slds-text-body_small slds-text-color_weak slds-var-m-left_small"
                                                         >
-                                                            Applies as the uploaded body — then click "Save as New
-                                                            Version" below. Inline images are extracted automatically.
+                                                            Stages this HTML as the body (inline images extracted
+                                                            automatically). Uploading a file instead replaces it —
+                                                            whichever was staged last is what "Save as New Version"
+                                                            saves.
                                                         </span>
                                                     </div>
                                                 </div>

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1232,7 +1232,56 @@
                         </div>
 
                         <div class="dg-html-editor-statusbar">
+                            <div class="dg-mode-seg" role="tablist" aria-label="Editor mode">
+                                <button
+                                    class={visualModeBtnClass}
+                                    onclick={handleSelectVisualMode}
+                                    title="Edit the document as it renders — click anywhere and type"
+                                >
+                                    Visual
+                                </button>
+                                <button
+                                    class={sourceModeBtnClass}
+                                    onclick={handleSelectSourceMode}
+                                    title="Edit the raw HTML with a live full-page preview below"
+                                >
+                                    Source
+                                </button>
+                            </div>
+                            <template if:true={selectionContextLabel}>
+                                <span class="dg-context-label">{selectionContextLabel}</span>
+                            </template>
                             <span class={htmlEditorStatusClass}>{htmlEditorStatusText}</span>
+                            <span class="dg-fmt-label">Page</span>
+                            <select
+                                class="dg-page-select"
+                                data-field="size"
+                                onchange={handlePageSetupChange}
+                                title="Page size"
+                            >
+                                <option value="Letter">Letter</option>
+                                <option value="Legal">Legal</option>
+                                <option value="A4">A4</option>
+                            </select>
+                            <select
+                                class="dg-page-select"
+                                data-field="orient"
+                                onchange={handlePageSetupChange}
+                                title="Orientation"
+                            >
+                                <option value="portrait">Portrait</option>
+                                <option value="landscape">Landscape</option>
+                            </select>
+                            <select
+                                class="dg-page-select"
+                                data-field="margin"
+                                onchange={handlePageSetupChange}
+                                title="Page margins"
+                            >
+                                <option value="0.5">0.5&quot; margins</option>
+                                <option value="0.75">0.75&quot; margins</option>
+                                <option value="1">1&quot; margins</option>
+                            </select>
                             <lightning-button
                                 label="Format Code"
                                 icon-name="utility:magicwand"
@@ -1240,14 +1289,6 @@
                                 data-target="body"
                                 onclick={handleFormatHtml}
                                 title="Pretty-print the HTML: indent nested tags without touching text or merge tags."
-                                class="slds-var-m-left_small"
-                            ></lightning-button>
-                            <lightning-button
-                                label={visualToggleLabel}
-                                icon-name="utility:preview"
-                                variant="base"
-                                onclick={handleToggleHtmlVisual}
-                                title="See and edit the document as it renders — click anywhere and type. Your @page/style shell is never touched; structure work happens in Code."
                                 class="slds-var-m-left_small"
                             ></lightning-button>
                             <lightning-button

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1499,9 +1499,10 @@
                                         onclick={handleSaveAndClose}
                                     ></lightning-button>
                                     <lightning-button
-                                        label="Back to Templates"
-                                        icon-name="utility:back"
-                                        onclick={handleCloseDesigner}
+                                        label="Edit Template"
+                                        icon-name="utility:settings"
+                                        onclick={handleEditTemplateFromDesigner}
+                                        title="Open this template's full settings — query, versions, sharing, signatures — right from here."
                                         class="slds-var-m-left_x-small"
                                     ></lightning-button>
                                 </div>

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -2964,12 +2964,14 @@
                                                         <p
                                                             class="slds-text-body_small slds-text-color_weak slds-var-m-top_xx-small"
                                                         >
-                                                            Click into the page and edit text right where it appears —
-                                                            tables and styling render exactly as the PDF engine sees
-                                                            them. Merge tags are plain text: type &#123;Name&#125;
-                                                            anywhere. Structure changes (new rows, sections) are Code
-                                                            work. "Back to Code" folds your edits in — only the document
-                                                            content changes, never your styles or page setup.
+                                                            This is your document — click anywhere and type. The colored
+                                                            pills are your data fields: drag more in from&nbsp;<strong
+                                                                >Insert Tags</strong
+                                                            >&nbsp;or drop a picture from&nbsp;<strong>Add Image</strong
+                                                            >&nbsp;right where you want it. Deleting a pill removes the
+                                                            whole field — they can't break. Your styles and page setup
+                                                            are never touched here; "Back to Code" is one click away for
+                                                            structure work.
                                                         </p>
                                                     </template>
                                                     <div class="slds-var-m-top_x-small">
@@ -3032,6 +3034,8 @@
                                                                                 class="dg-tag-chip"
                                                                                 data-snippet={tag.snippet}
                                                                                 title={tag.title}
+                                                                                draggable="true"
+                                                                                ondragstart={handleTagDragStart}
                                                                                 onclick={handleInsertTagSnippet}
                                                                             >
                                                                                 {tag.label}
@@ -3097,6 +3101,8 @@
                                                                             class="dg-image-thumb"
                                                                             data-url={img.url}
                                                                             data-name={img.fileName}
+                                                                            draggable="true"
+                                                                            ondragstart={handleImageDragStart}
                                                                             onclick={handleInsertExistingImage}
                                                                             title={img.fileName}
                                                                         >

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1455,7 +1455,15 @@
                             <div class="dg-designer-toolbar">
                                 <div class="dg-designer-toolbar__title">
                                     <lightning-icon icon-name="utility:brush" size="small"></lightning-icon>
-                                    <span class="slds-text-heading_small">{designerTitle}</span>
+                                    <div class="dg-designer-template-switch">
+                                        <lightning-combobox
+                                            variant="label-hidden"
+                                            value={editTemplateId}
+                                            options={designerTemplateOptions}
+                                            onchange={handleDesignerTemplateSwitch}
+                                            title="Switch to another HTML template without leaving the designer"
+                                        ></lightning-combobox>
+                                    </div>
                                 </div>
                                 <template if:true={isRealObject}>
                                     <div class="dg-designer-toolbar__sample">
@@ -1644,6 +1652,23 @@
                                         class="slds-var-m-left_small"
                                     ></lightning-button>
                                 </template>
+                                <lightning-button
+                                    label="Apply Editor HTML"
+                                    icon-name="utility:check"
+                                    variant="base"
+                                    onclick={handleApplyHtmlBody}
+                                    disabled={isApplyingHtmlBody}
+                                    title="Stage the current editor contents now. Save as New Version does this automatically."
+                                    class="slds-var-m-left_small"
+                                ></lightning-button>
+                                <lightning-button
+                                    label="Copy AI Prompt"
+                                    icon-name="utility:copy"
+                                    variant="base"
+                                    onclick={handleCopyEditAiPrompt}
+                                    title="Copies a ready-to-paste prompt (your fields + DocGen tag syntax + PDF layout rules) for Claude / ChatGPT / Gemini / Copilot."
+                                    class="slds-var-m-left_small"
+                                ></lightning-button>
                                 <lightning-button
                                     label="Reload"
                                     icon-name="utility:refresh"
@@ -2121,32 +2146,6 @@
                                         setup are never touched here.
                                     </p>
                                 </template>
-                                <div class="slds-var-m-top_x-small">
-                                    <lightning-button
-                                        variant="brand"
-                                        label="Apply Editor HTML"
-                                        icon-name="utility:check"
-                                        onclick={handleApplyHtmlBody}
-                                        disabled={isApplyingHtmlBody}
-                                    ></lightning-button>
-                                    <lightning-button
-                                        label="Copy AI Prompt"
-                                        icon-name="utility:copy"
-                                        onclick={handleCopyEditAiPrompt}
-                                        title="Copies a ready-to-paste prompt (your fields + DocGen tag syntax + PDF layout rules) for Claude / ChatGPT / Gemini / Copilot."
-                                        class="slds-var-m-left_x-small"
-                                    ></lightning-button>
-                                    <template if:true={isApplyingHtmlBody}>
-                                        <lightning-spinner
-                                            alternative-text="Applying"
-                                            size="small"
-                                            class="slds-var-m-left_small"
-                                        ></lightning-spinner>
-                                    </template>
-                                    <span class="slds-text-body_small slds-text-color_weak slds-var-m-left_small">
-                                        Stage your changes, then "Save as New Version" makes them the active body.
-                                    </span>
-                                </div>
                             </div>
 
                             <template if:true={showFloatPanel}>

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -460,8 +460,9 @@
                                                 ></lightning-icon>
                                                 You get a clean page in the visual designer. Click anywhere and type,
                                                 drag in blocks and merge tags, or press&nbsp;<code>&#96;</code>&nbsp;for
-                                                the insert menu. Your object's fields are queried automatically so every
-                                                merge tag is ready to drop in.
+                                                the insert menu. All of your object's usable fields and its main child
+                                                lists are queried automatically, so the whole tag palette is ready to
+                                                drop in — fine-tune anytime under Query Configuration.
                                             </p>
                                         </div>
                                         <template if:true={isRecordDataSource}>

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -524,8 +524,9 @@
                                                         >Native (.docx)</strong
                                                     >&nbsp;for full fidelity, or use&nbsp;<strong
                                                         >Start from a Design</strong
-                                                    >&nbsp;/&nbsp;<strong>Generate with AI</strong>&nbsp;for
-                                                    pixel-perfect PDFs.
+                                                    >&nbsp;/&nbsp;<strong>Generate with AI</strong>&nbsp;/&nbsp;<strong
+                                                        >Start From Scratch</strong
+                                                    >&nbsp;for pixel-perfect PDFs.
                                                 </p>
                                             </div>
                                         </template>
@@ -1655,7 +1656,6 @@
                                 <lightning-button
                                     label="Apply Editor HTML"
                                     icon-name="utility:check"
-                                    variant="base"
                                     onclick={handleApplyHtmlBody}
                                     disabled={isApplyingHtmlBody}
                                     title="Stage the current editor contents now. Save as New Version does this automatically."
@@ -1664,7 +1664,6 @@
                                 <lightning-button
                                     label="Copy AI Prompt"
                                     icon-name="utility:copy"
-                                    variant="base"
                                     onclick={handleCopyEditAiPrompt}
                                     title="Copies a ready-to-paste prompt (your fields + DocGen tag syntax + PDF layout rules) for Claude / ChatGPT / Gemini / Copilot."
                                     class="slds-var-m-left_small"
@@ -1672,7 +1671,6 @@
                                 <lightning-button
                                     label="Reload"
                                     icon-name="utility:refresh"
-                                    variant="base"
                                     onclick={handleReloadHtmlBodyEditor}
                                     title="Replace the editor contents with the currently staged body (or the saved body if nothing is staged). Discards unapplied edits."
                                     class="slds-var-m-left_small"

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1719,6 +1719,16 @@
                                                 Nothing matches &#8220;{slashMenu.query}&#8221;
                                             </div>
                                         </template>
+                                        <template if:true={slashMenu.errorMsg}>
+                                            <div class="dg-slash-empty">{slashMenu.errorMsg}</div>
+                                        </template>
+                                        <div class="dg-slash-foot">
+                                            Think this should be a command?
+                                            <a
+                                                href="mailto:hello@portwood.dev?subject=DocGen%20designer%20command%20idea"
+                                                >Email hello@portwood.dev</a
+                                            >
+                                        </div>
                                     </div>
                                 </template>
                                 <template if:true={isLoadingHtmlBody}>

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -18,6 +18,34 @@
                     <div class="wizard-content">
                         <!-- Step 1: Details + Data Source Selection -->
                         <template if:true={isStep1}>
+                            <!-- HTML-first authoring path picker -->
+                            <div
+                                class="dg-authoring-cards slds-var-m-bottom_large"
+                                role="radiogroup"
+                                aria-label="How do you want to build this template?"
+                            >
+                                <template for:each={authoringCards} for:item="card">
+                                    <div
+                                        key={card.mode}
+                                        class={card.cardClass}
+                                        data-mode={card.mode}
+                                        onclick={handleAuthoringModeSelect}
+                                        onkeydown={handleAuthoringModeKeydown}
+                                        role="radio"
+                                        aria-checked={card.selected}
+                                        tabindex="0"
+                                    >
+                                        <div class="dg-authoring-card-head">
+                                            <lightning-icon icon-name={card.icon} size="small"></lightning-icon>
+                                            <span class="dg-authoring-card-title">{card.title}</span>
+                                            <template if:true={card.badge}>
+                                                <span class="dg-authoring-badge">{card.badge}</span>
+                                            </template>
+                                        </div>
+                                        <p class="dg-authoring-card-desc">{card.desc}</p>
+                                    </div>
+                                </template>
+                            </div>
                             <div class="slds-grid slds-gutters_large">
                                 <div class="slds-col slds-size_1-of-2">
                                     <lightning-input
@@ -260,21 +288,96 @@
                                     </template>
                                 </div>
                                 <div class="slds-col slds-size_1-of-2">
-                                    <lightning-combobox
-                                        label="Type"
-                                        value={newTemplateType}
-                                        options={typeOptions}
-                                        onchange={handleTypeChange}
-                                        required
-                                    ></lightning-combobox>
-                                    <lightning-combobox
-                                        label="Output Format"
-                                        value={newTemplateOutputFormat}
-                                        options={outputFormatOptions}
-                                        onchange={handleOutputFormatChange}
-                                        class="slds-var-m-top_medium"
-                                        required
-                                    ></lightning-combobox>
+                                    <!-- Starter path: design gallery -->
+                                    <template if:true={isAuthoringStarter}>
+                                        <label class="slds-form-element__label">Starter Design</label>
+                                        <div role="radiogroup" aria-label="Starter design">
+                                            <template for:each={starterCards} for:item="starter">
+                                                <div
+                                                    key={starter.key}
+                                                    class={starter.cardClass}
+                                                    data-key={starter.key}
+                                                    onclick={handleStarterSelect}
+                                                    role="radio"
+                                                    aria-checked={starter.selected}
+                                                    tabindex="0"
+                                                >
+                                                    <div class="dg-starter-card-head">
+                                                        <lightning-icon
+                                                            icon-name={starter.icon}
+                                                            size="x-small"
+                                                        ></lightning-icon>
+                                                        <span class="dg-starter-card-title">{starter.label}</span>
+                                                    </div>
+                                                    <p class="dg-starter-card-desc">{starter.description}</p>
+                                                </div>
+                                            </template>
+                                        </div>
+                                        <p class="slds-text-body_small slds-text-color_weak slds-var-m-top_x-small">
+                                            Your Query Config fields are merged into the design automatically — pick
+                                            data in the next step, review the HTML, done.
+                                        </p>
+                                    </template>
+
+                                    <!-- AI path: explain the prompt handoff -->
+                                    <template if:true={isAuthoringAi}>
+                                        <div class="slds-box slds-theme_shade" style="border-radius: 8px" role="note">
+                                            <p class="slds-text-body_small">
+                                                <lightning-icon
+                                                    icon-name="utility:einstein"
+                                                    size="x-small"
+                                                    class="slds-var-m-right_x-small"
+                                                ></lightning-icon>
+                                                After you pick your data in the next step, the
+                                                <strong>Review</strong> screen shows a complete prompt — your fields,
+                                                DocGen's merge-tag syntax, and the PDF engine's layout rules. Copy it
+                                                into Claude, ChatGPT, Gemini, or Copilot, then paste the returned HTML
+                                                into the template editor. No data leaves Salesforce unless you paste it.
+                                            </p>
+                                        </div>
+                                    </template>
+
+                                    <!-- File path: classic Type/Output Format pickers -->
+                                    <template if:true={isAuthoringFile}>
+                                        <lightning-combobox
+                                            label="Type"
+                                            value={newTemplateType}
+                                            options={typeOptions}
+                                            onchange={handleTypeChange}
+                                            field-level-help="What kind of source file you'll upload. HTML is the most reliable for PDF output; Word/PowerPoint/Excel keep their native format or convert to PDF."
+                                            required
+                                        ></lightning-combobox>
+                                        <template if:true={showWordConversionNote}>
+                                            <div
+                                                class="slds-box slds-box_x-small slds-theme_warning slds-var-m-top_x-small"
+                                                role="note"
+                                            >
+                                                <p class="slds-text-body_small">
+                                                    <lightning-icon
+                                                        icon-name="utility:info"
+                                                        size="x-small"
+                                                        class="slds-var-m-right_x-small"
+                                                    ></lightning-icon>
+                                                    Word templates are converted to HTML for PDF output — complex
+                                                    layouts (text boxes, floating images, unusual tables) may not
+                                                    convert exactly. Keep Output Format&nbsp;<strong
+                                                        >Native (.docx)</strong
+                                                    >&nbsp;for full fidelity, or use&nbsp;<strong
+                                                        >Start from a Design</strong
+                                                    >&nbsp;/&nbsp;<strong>Generate with AI</strong>&nbsp;for
+                                                    pixel-perfect PDFs.
+                                                </p>
+                                            </div>
+                                        </template>
+                                        <lightning-combobox
+                                            label="Output Format"
+                                            value={newTemplateOutputFormat}
+                                            options={outputFormatOptions}
+                                            onchange={handleOutputFormatChange}
+                                            class="slds-var-m-top_medium"
+                                            required
+                                        ></lightning-combobox>
+                                    </template>
                                     <template if:true={showNewPageLayoutFields}>
                                         <lightning-combobox
                                             label="Page Orientation"
@@ -311,7 +414,7 @@
                                             ></lightning-input>
                                         </template>
                                     </template>
-                                    <template if:true={isCreatingHtmlPdf}>
+                                    <template if:true={showHtmlPageRuleNote}>
                                         <div class="slds-box slds-theme_shade slds-var-m-top_medium" role="status">
                                             <p class="slds-text-body_small">
                                                 <lightning-icon
@@ -933,6 +1036,42 @@
                                     >
 {readableQueryConfig}</pre
                                     >
+                                </template>
+                                <template if:true={isAuthoringStarter}>
+                                    <p class="slds-var-m-bottom_small">
+                                        <strong>Starter design:</strong> {selectedStarterLabel} — a ready-to-render HTML
+                                        body with your merge fields is attached on create. Review it in the editor, then
+                                        click "Save as New Version" to activate v1.
+                                    </p>
+                                </template>
+                                <template if:true={isAuthoringAi}>
+                                    <div class="slds-var-m-top_medium">
+                                        <div
+                                            style="
+                                                display: flex;
+                                                align-items: center;
+                                                justify-content: space-between;
+                                                margin-bottom: 6px;
+                                            "
+                                        >
+                                            <strong
+                                                >Your AI prompt — copy this into Claude, ChatGPT, Gemini, or
+                                                Copilot</strong
+                                            >
+                                            <lightning-button
+                                                label="Copy Prompt"
+                                                icon-name="utility:copy"
+                                                variant="brand"
+                                                onclick={handleCopyAiPrompt}
+                                            ></lightning-button>
+                                        </div>
+                                        <pre class="dg-ai-prompt">{aiAuthoringPrompt}</pre>
+                                        <p class="slds-text-body_small slds-text-color_weak slds-var-m-top_x-small">
+                                            Paste the HTML your assistant returns into the template's&nbsp;<strong
+                                                >Edit HTML</strong
+                                            >&nbsp;editor (it opens after Create). The prompt stays available there too.
+                                        </p>
+                                    </div>
                                 </template>
                                 <p class="slds-var-m-top_large">Click "Create Template" to save.</p>
                             </div>
@@ -2641,12 +2780,67 @@
                                                 disabled={isUploadingHtml}
                                             >
                                             </lightning-button>
+                                            <lightning-button
+                                                label={htmlBodyEditorToggleLabel}
+                                                icon-name="utility:edit"
+                                                onclick={toggleHtmlBodyEditor}
+                                                class="slds-var-m-left_x-small"
+                                            >
+                                            </lightning-button>
+                                            <lightning-button
+                                                label="Copy AI Prompt"
+                                                icon-name="utility:copy"
+                                                onclick={handleCopyEditAiPrompt}
+                                                title="Copies a ready-to-paste prompt (your fields + DocGen tag syntax + PDF layout rules) for Claude / ChatGPT / Gemini / Copilot. Paste the returned HTML into the editor."
+                                                class="slds-var-m-left_x-small"
+                                            >
+                                            </lightning-button>
                                             <template if:true={isUploadingHtml}>
                                                 <lightning-spinner
                                                     alternative-text="Uploading"
                                                     size="small"
                                                     class="slds-var-m-left_small"
                                                 ></lightning-spinner>
+                                            </template>
+                                            <template if:true={showHtmlBodyEditor}>
+                                                <div class="slds-var-m-top_small">
+                                                    <template if:true={isLoadingHtmlBody}>
+                                                        <div class="slds-is-relative" style="height: 40px">
+                                                            <lightning-spinner
+                                                                alternative-text="Loading HTML body"
+                                                                size="small"
+                                                            ></lightning-spinner>
+                                                        </div>
+                                                    </template>
+                                                    <textarea
+                                                        class="dg-html-body-editor"
+                                                        spellcheck="false"
+                                                        aria-label="Template HTML body"
+                                                        placeholder="Paste your template HTML here — from your AI assistant, Google Docs (File → Download → Web Page), or hand-written. Merge tags like &#123;Name&#125; fill from your Query Config."
+                                                    ></textarea>
+                                                    <div class="slds-var-m-top_x-small">
+                                                        <lightning-button
+                                                            variant="brand"
+                                                            label="Apply HTML"
+                                                            icon-name="utility:check"
+                                                            onclick={handleApplyHtmlBody}
+                                                            disabled={isApplyingHtmlBody}
+                                                        ></lightning-button>
+                                                        <template if:true={isApplyingHtmlBody}>
+                                                            <lightning-spinner
+                                                                alternative-text="Applying"
+                                                                size="small"
+                                                                class="slds-var-m-left_small"
+                                                            ></lightning-spinner>
+                                                        </template>
+                                                        <span
+                                                            class="slds-text-body_small slds-text-color_weak slds-var-m-left_small"
+                                                        >
+                                                            Applies as the uploaded body — then click "Save as New
+                                                            Version" below. Inline images are extracted automatically.
+                                                        </span>
+                                                    </div>
+                                                </div>
                                             </template>
                                         </template>
 

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1435,7 +1435,7 @@
             </lightning-tab>
 
             <!-- Full-screen template designer: the page is the canvas, palettes ride the rail -->
-            <lightning-tab label="Designer" value="design" onactive={handleTabActive}>
+            <lightning-tab label="Designer (Beta)" value="design" onactive={handleTabActive}>
                 <div class="slds-var-p-around_medium">
                     <template if:false={designerHasTemplate}>
                         <div class="slds-text-align_center slds-var-p-around_xx-large slds-text-color_weak">
@@ -1456,6 +1456,11 @@
                             <div class="dg-designer-toolbar">
                                 <div class="dg-designer-toolbar__title">
                                     <lightning-icon icon-name="utility:brush" size="small"></lightning-icon>
+                                    <span
+                                        class="dg-beta-chip"
+                                        title="The visual designer is in beta — rough edge? Report a Bug in the sidebar or email support@portwood.dev."
+                                        >BETA</span
+                                    >
                                     <div class="dg-designer-template-switch">
                                         <lightning-combobox
                                             variant="label-hidden"

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -449,6 +449,53 @@
                                         </div>
                                     </template>
 
+                                    <!-- Scratch path: straight to a blank designer page -->
+                                    <template if:true={isAuthoringScratch}>
+                                        <div class="slds-box slds-theme_shade" style="border-radius: 8px" role="note">
+                                            <p class="slds-text-body_small">
+                                                <lightning-icon
+                                                    icon-name="utility:edit"
+                                                    size="x-small"
+                                                    class="slds-var-m-right_x-small"
+                                                ></lightning-icon>
+                                                You get a clean page in the visual designer. Click anywhere and type,
+                                                drag in blocks and merge tags, or press&nbsp;<code>&#96;</code>&nbsp;for
+                                                the insert menu. Your object's fields are queried automatically so every
+                                                merge tag is ready to drop in.
+                                            </p>
+                                        </div>
+                                        <template if:true={isRecordDataSource}>
+                                            <template if:true={newTemplateObject}>
+                                                <div class="slds-var-m-top_small">
+                                                    <lightning-record-picker
+                                                        label="Sample Record (optional)"
+                                                        object-api-name={newTemplateObject}
+                                                        value={newTemplateSampleRecordId}
+                                                        onchange={handleSampleRecordChange}
+                                                        placeholder="Pick a record to preview with real data..."
+                                                    >
+                                                    </lightning-record-picker>
+                                                </div>
+                                            </template>
+                                        </template>
+                                        <div class="slds-var-m-top_medium">
+                                            <lightning-button
+                                                variant="brand"
+                                                label="Create &amp; Open Designer"
+                                                icon-name="utility:edit"
+                                                onclick={handleCreateAndDesign}
+                                                disabled={isAutoCreating}
+                                            ></lightning-button>
+                                            <template if:true={isAutoCreating}>
+                                                <lightning-spinner
+                                                    alternative-text="Creating..."
+                                                    size="small"
+                                                    class="slds-var-m-left_small"
+                                                ></lightning-spinner>
+                                            </template>
+                                        </div>
+                                    </template>
+
                                     <!-- File path: classic Type/Output Format pickers -->
                                     <template if:true={isAuthoringFile}>
                                         <lightning-combobox
@@ -1585,15 +1632,17 @@
                                         {pdfPreviewBtnLabel}
                                     </button>
                                 </template>
-                                <lightning-button
-                                    label="Format Code"
-                                    icon-name="utility:magicwand"
-                                    variant="base"
-                                    data-target="body"
-                                    onclick={handleFormatHtml}
-                                    title="Pretty-print the HTML: indent nested tags without touching text or merge tags."
-                                    class="slds-var-m-left_small"
-                                ></lightning-button>
+                                <template if:false={showHtmlBodyVisual}>
+                                    <lightning-button
+                                        label="Format Code"
+                                        icon-name="utility:magicwand"
+                                        variant="base"
+                                        data-target="body"
+                                        onclick={handleFormatHtml}
+                                        title="Pretty-print the HTML: indent nested tags without touching text or merge tags."
+                                        class="slds-var-m-left_small"
+                                    ></lightning-button>
+                                </template>
                                 <lightning-button
                                     label="Reload"
                                     icon-name="utility:refresh"

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1391,11 +1391,6 @@
                                         oninput={handleHtmlBodyEditorInput}
                                         placeholder="Paste your template HTML here — from your AI assistant, Google Docs (File → Download → Web Page), or hand-written. Merge tags like &#123;Name&#125; fill from your Query Config."
                                     ></textarea>
-                                    <div
-                                        class="dg-html-preview-frame dg-code-preview dg-designer-size"
-                                        lwc:dom="manual"
-                                        title="Live preview — updates as you type"
-                                    ></div>
                                 </div>
                                 <template if:true={showHtmlBodyVisual}>
                                     <div class="dg-format-bar" role="toolbar" aria-label="Text formatting">
@@ -1425,6 +1420,52 @@
                                             title="Underline"
                                         >
                                             <u>U</u>
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn"
+                                            data-cmd="strikeThrough"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleFormatAction}
+                                            title="Strikethrough"
+                                        >
+                                            <s>S</s>
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn"
+                                            data-cmd="superscript"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleFormatAction}
+                                            title="Superscript"
+                                        >
+                                            x&#178;
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn"
+                                            data-cmd="subscript"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleFormatAction}
+                                            title="Subscript"
+                                        >
+                                            x&#8322;
+                                        </button>
+                                        <span class="dg-fmt-sep"></span>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-cmd="insertUnorderedList"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleFormatAction}
+                                            title="Bulleted list"
+                                        >
+                                            &#8226; List
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-cmd="insertOrderedList"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleFormatAction}
+                                            title="Numbered list"
+                                        >
+                                            1. List
                                         </button>
                                         <span class="dg-fmt-sep"></span>
                                         <button

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1262,16 +1262,43 @@
                                 <option value="Letter">Letter</option>
                                 <option value="Legal">Legal</option>
                                 <option value="A4">A4</option>
+                                <option value="Custom">Custom…</option>
                             </select>
-                            <select
-                                class="dg-page-select"
-                                data-field="orient"
-                                onchange={handlePageSetupChange}
-                                title="Orientation"
-                            >
-                                <option value="portrait">Portrait</option>
-                                <option value="landscape">Landscape</option>
-                            </select>
+                            <template if:false={isCustomPageSize}>
+                                <select
+                                    class="dg-page-select"
+                                    data-field="orient"
+                                    onchange={handlePageSetupChange}
+                                    title="Orientation"
+                                >
+                                    <option value="portrait">Portrait</option>
+                                    <option value="landscape">Landscape</option>
+                                </select>
+                            </template>
+                            <template if:true={isCustomPageSize}>
+                                <input
+                                    type="number"
+                                    class="dg-page-input"
+                                    data-field="customW"
+                                    min="1"
+                                    max="200"
+                                    step="0.25"
+                                    onchange={handlePageSetupChange}
+                                    title="Page width in inches"
+                                />
+                                <span class="dg-fmt-label">×</span>
+                                <input
+                                    type="number"
+                                    class="dg-page-input"
+                                    data-field="customH"
+                                    min="1"
+                                    max="200"
+                                    step="0.25"
+                                    onchange={handlePageSetupChange}
+                                    title="Page height in inches"
+                                />
+                                <span class="dg-fmt-label">in</span>
+                            </template>
                             <select
                                 class="dg-page-select"
                                 data-field="margin"
@@ -1281,7 +1308,21 @@
                                 <option value="0.5">0.5&quot; margins</option>
                                 <option value="0.75">0.75&quot; margins</option>
                                 <option value="1">1&quot; margins</option>
+                                <option value="custom">Custom…</option>
                             </select>
+                            <template if:true={isCustomMargin}>
+                                <input
+                                    type="number"
+                                    class="dg-page-input"
+                                    data-field="customMargin"
+                                    min="0"
+                                    max="10"
+                                    step="0.05"
+                                    onchange={handlePageSetupChange}
+                                    title="Margin in inches"
+                                />
+                                <span class="dg-fmt-label">in</span>
+                            </template>
                             <lightning-button
                                 label="Format Code"
                                 icon-name="utility:magicwand"
@@ -1303,6 +1344,34 @@
 
                         <div class="dg-designer-layout">
                             <div class="dg-designer-canvas-col">
+                                <template if:true={pillMenu}>
+                                    <div class="dg-pill-menu" style={pillMenu.posStyle} role="menu">
+                                        <div class="dg-pill-menu-head">
+                                            <code>{pillMenu.tagText}</code>
+                                            <button class="dg-pill-menu-x" onclick={handlePillMenuClose} title="Close">
+                                                &#10005;
+                                            </button>
+                                        </div>
+                                        <template if:true={pillMenu.hasOptions}>
+                                            <template for:each={pillMenu.options} for:item="opt">
+                                                <button
+                                                    key={opt.key}
+                                                    class="dg-pill-menu-item"
+                                                    data-tag={opt.tag}
+                                                    onclick={handlePillTransform}
+                                                >
+                                                    {opt.label}
+                                                </button>
+                                            </template>
+                                        </template>
+                                        <button
+                                            class="dg-pill-menu-item dg-pill-menu-remove"
+                                            onclick={handlePillRemove}
+                                        >
+                                            Remove from document
+                                        </button>
+                                    </div>
+                                </template>
                                 <template if:true={isLoadingHtmlBody}>
                                     <div class="slds-is-relative" style="height: 40px">
                                         <lightning-spinner

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1404,6 +1404,26 @@
                                             ></button>
                                         </template>
                                         <span class="dg-fmt-sep"></span>
+                                        <span
+                                            class="dg-fmt-label"
+                                            title="Font — the PDF engine ships exactly these four"
+                                            >Font</span
+                                        >
+                                        <template for:each={fontChoices} for:item="font">
+                                            <button
+                                                key={font.key}
+                                                class="dg-fmt-btn dg-fmt-btn_word"
+                                                style={font.style}
+                                                data-cmd="fontName"
+                                                data-value={font.value}
+                                                onmousedown={handleFmtMouseDown}
+                                                onclick={handleFormatAction}
+                                                title={font.title}
+                                            >
+                                                {font.label}
+                                            </button>
+                                        </template>
+                                        <span class="dg-fmt-sep"></span>
                                         <button
                                             class="dg-fmt-btn dg-fmt-btn_word"
                                             data-cmd="removeFormat"
@@ -1413,6 +1433,70 @@
                                         >
                                             Clear
                                         </button>
+                                        <span class="dg-fmt-break"></span>
+                                        <span class="dg-fmt-label" title="Table tools — put your cursor in a cell first"
+                                            >Table</span
+                                        >
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-taction="rowAfter"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleTableAction}
+                                            title="Add a row below the current cell"
+                                        >
+                                            + Row
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-taction="colAfter"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleTableAction}
+                                            title="Add a column to the right of the current cell"
+                                        >
+                                            + Col
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-taction="rowDel"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleTableAction}
+                                            title="Delete the current row"
+                                        >
+                                            − Row
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-taction="colDel"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleTableAction}
+                                            title="Delete the current column"
+                                        >
+                                            − Col
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-taction="headerRow"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleTableAction}
+                                            title="Style the current row as a header (navy fill, white bold text)"
+                                        >
+                                            Header Row
+                                        </button>
+                                        <span class="dg-fmt-label" title="Fill the current cell's background"
+                                            >Cell</span
+                                        >
+                                        <template for:each={highlightSwatches} for:item="sw">
+                                            <button
+                                                key={sw.key}
+                                                class="dg-fmt-swatch"
+                                                style={sw.style}
+                                                data-taction="cellFill"
+                                                data-value={sw.value}
+                                                onmousedown={handleFmtMouseDown}
+                                                onclick={handleTableAction}
+                                                title={sw.title}
+                                            ></button>
+                                        </template>
                                     </div>
                                     <div
                                         class="dg-html-preview-frame dg-visual-host dg-designer-size"

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -2908,6 +2908,14 @@
                                                             class="slds-var-m-left_small"
                                                         ></lightning-button>
                                                         <lightning-button
+                                                            label={visualToggleLabel}
+                                                            icon-name="utility:richtextbulletedlist"
+                                                            variant="base"
+                                                            onclick={handleToggleHtmlVisual}
+                                                            title="Edit the document text like a rich-text editor. Your @page/style shell is preserved and reapplied when you switch back. Table layouts need Code view."
+                                                            class="slds-var-m-left_small"
+                                                        ></lightning-button>
+                                                        <lightning-button
                                                             label={htmlBodyPreviewToggleLabel}
                                                             icon-name="utility:preview"
                                                             variant="base"
@@ -2947,6 +2955,23 @@
                                                             title="Rendered preview — merge tags shown as-is"
                                                         ></div>
                                                     </template>
+                                                    <template if:true={showHtmlBodyVisual}>
+                                                        <div class="dg-visual-editor-wrap">
+                                                            <lightning-input-rich-text
+                                                                class="dg-visual-editor"
+                                                                value={visualEditorHtml}
+                                                                onchange={handleVisualEditorChange}
+                                                            ></lightning-input-rich-text>
+                                                        </div>
+                                                        <p
+                                                            class="slds-text-body_small slds-text-color_weak slds-var-m-top_xx-small"
+                                                        >
+                                                            Visual mode edits the document text — your template's page
+                                                            setup and styles are preserved and reapplied when you switch
+                                                            back to Code. Merge tags are plain text: type
+                                                            &#123;Name&#125; anywhere.
+                                                        </p>
+                                                    </template>
                                                     <div class="slds-var-m-top_x-small">
                                                         <lightning-button
                                                             variant="brand"
@@ -2954,6 +2979,20 @@
                                                             icon-name="utility:check"
                                                             onclick={handleApplyHtmlBody}
                                                             disabled={isApplyingHtmlBody}
+                                                        ></lightning-button>
+                                                        <lightning-button
+                                                            label={tagPanelToggleLabel}
+                                                            icon-name="utility:merge_field"
+                                                            onclick={toggleTagPanel}
+                                                            title="Click-to-insert merge tags: this template's fields, child loops, dates, running user, signatures, conditionals."
+                                                            class="slds-var-m-left_x-small"
+                                                        ></lightning-button>
+                                                        <lightning-button
+                                                            label={imagePanelToggleLabel}
+                                                            icon-name="utility:image"
+                                                            onclick={toggleImagePanel}
+                                                            title="Upload an image or pick one already attached — a PDF-safe <img> tag is inserted at your cursor."
+                                                            class="slds-var-m-left_x-small"
                                                         ></lightning-button>
                                                         <template if:true={isApplyingHtmlBody}>
                                                             <lightning-spinner
@@ -2971,6 +3010,113 @@
                                                             saves.
                                                         </span>
                                                     </div>
+                                                    <template if:true={showTagPanel}>
+                                                        <div class="dg-tag-panel slds-var-m-top_small">
+                                                            <template for:each={tagPaletteSections} for:item="section">
+                                                                <div key={section.key} class="dg-tag-section">
+                                                                    <div class="dg-tag-section-label">
+                                                                        {section.label}
+                                                                    </div>
+                                                                    <template if:true={section.hint}>
+                                                                        <div class="dg-tag-section-hint">
+                                                                            {section.hint}
+                                                                        </div>
+                                                                    </template>
+                                                                    <div class="dg-tag-chips">
+                                                                        <template
+                                                                            for:each={section.items}
+                                                                            for:item="tag"
+                                                                        >
+                                                                            <button
+                                                                                key={tag.key}
+                                                                                class="dg-tag-chip"
+                                                                                data-snippet={tag.snippet}
+                                                                                title={tag.title}
+                                                                                onclick={handleInsertTagSnippet}
+                                                                            >
+                                                                                {tag.label}
+                                                                            </button>
+                                                                        </template>
+                                                                    </div>
+                                                                </div>
+                                                            </template>
+                                                        </div>
+                                                    </template>
+                                                    <template if:true={showImagePanel}>
+                                                        <div class="dg-image-panel slds-var-m-top_small">
+                                                            <div class="dg-image-panel-head">
+                                                                <span class="slds-text-body_small">
+                                                                    Upload once — DocGen stores the image with this
+                                                                    template and inserts a PDF-safe
+                                                                    <code>&lt;img&gt;</code>&nbsp;tag at your cursor.
+                                                                    Click a thumbnail to insert an existing image. Use
+                                                                    PNG or JPG — SVG doesn't render in PDF output.
+                                                                </span>
+                                                                <lightning-button
+                                                                    variant="brand"
+                                                                    label="Upload Image"
+                                                                    icon-name="utility:upload"
+                                                                    onclick={triggerInsertImagePicker}
+                                                                    disabled={isUploadingInsertImage}
+                                                                ></lightning-button>
+                                                            </div>
+                                                            <input
+                                                                type="file"
+                                                                class="dg-insert-image-input"
+                                                                accept=".png,.jpg,.jpeg,.gif,.bmp"
+                                                                style="display: none"
+                                                                onchange={handleInsertImageSelected}
+                                                            />
+                                                            <template if:true={isUploadingInsertImage}>
+                                                                <div
+                                                                    class="slds-is-relative slds-var-m-top_small"
+                                                                    style="height: 30px"
+                                                                >
+                                                                    <lightning-spinner
+                                                                        alternative-text="Uploading image"
+                                                                        size="small"
+                                                                    ></lightning-spinner>
+                                                                </div>
+                                                            </template>
+                                                            <template if:true={isLoadingTemplateImages}>
+                                                                <div
+                                                                    class="slds-is-relative slds-var-m-top_small"
+                                                                    style="height: 30px"
+                                                                >
+                                                                    <lightning-spinner
+                                                                        alternative-text="Loading images"
+                                                                        size="small"
+                                                                    ></lightning-spinner>
+                                                                </div>
+                                                            </template>
+                                                            <template if:true={hasTemplateImages}>
+                                                                <div class="dg-image-grid">
+                                                                    <template for:each={templateImages} for:item="img">
+                                                                        <div
+                                                                            key={img.contentVersionId}
+                                                                            class="dg-image-thumb"
+                                                                            data-url={img.url}
+                                                                            data-name={img.fileName}
+                                                                            onclick={handleInsertExistingImage}
+                                                                            title={img.fileName}
+                                                                        >
+                                                                            <img src={img.url} alt={img.fileName} />
+                                                                            <span class="dg-image-thumb-name"
+                                                                                >{img.fileName}</span
+                                                                            >
+                                                                        </div>
+                                                                    </template>
+                                                                </div>
+                                                            </template>
+                                                            <template if:false={hasTemplateImages}>
+                                                                <p
+                                                                    class="slds-text-body_small slds-text-color_weak slds-var-m-top_x-small"
+                                                                >
+                                                                    No images attached to this template yet.
+                                                                </p>
+                                                            </template>
+                                                        </div>
+                                                    </template>
                                                 </div>
                                             </template>
                                         </template>

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1630,6 +1630,14 @@
                                 >
                                     Images
                                 </button>
+                                <button
+                                    class="dg-fmt-btn dg-panel-btn"
+                                    data-panel="hf"
+                                    onclick={handlePanelToggle}
+                                    title="Header and footer that repeat on every PDF page — with page numbers"
+                                >
+                                    Header/Footer
+                                </button>
                                 <template if:true={editTemplateOutputIsPdf}>
                                     <button
                                         class="dg-fmt-btn dg-panel-btn"
@@ -2080,6 +2088,15 @@
                                         >
                                             Header Row
                                         </button>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
+                                            data-taction="repeatHeader"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleTableAction}
+                                            title="Repeat this table's header row at the top of every PDF page it spans (toggles the {RepeatHeader} marker)"
+                                        >
+                                            Repeat Hdr
+                                        </button>
                                         <span class="dg-fmt-sep"></span>
                                         <span class="dg-fmt-label" title="Table borders">Borders</span>
                                         <button
@@ -2167,7 +2184,7 @@
                                             &#10005;
                                         </button>
                                     </div>
-                                    <template if:false={isPanelWatermark}>
+                                    <template if:true={showPanelSearch}>
                                         <input
                                             type="search"
                                             class="dg-panel-search"
@@ -2266,6 +2283,77 @@
                                         </div>
                                     </template>
 
+                                    <template if:true={isPanelHf}>
+                                        <div class="dg-image-panel">
+                                            <p class="slds-text-body_small slds-var-m-bottom_x-small">
+                                                Repeats on every PDF page. Merge tags work here too. Click a chip to
+                                                insert at your cursor; changes save with
+                                                <strong>Save as New Version</strong>.
+                                            </p>
+                                            <div class="dg-tag-chips slds-var-m-bottom_x-small">
+                                                <button
+                                                    class="dg-tag-chip"
+                                                    data-tok="pagexy"
+                                                    onclick={handleHfTokenInsert}
+                                                    title="Page counters — only work in the header/footer"
+                                                >
+                                                    Page X of Y
+                                                </button>
+                                                <button
+                                                    class="dg-tag-chip"
+                                                    data-tok="pagenum"
+                                                    onclick={handleHfTokenInsert}
+                                                >
+                                                    &#123;PageNumber&#125;
+                                                </button>
+                                                <button
+                                                    class="dg-tag-chip"
+                                                    data-tok="pagetotal"
+                                                    onclick={handleHfTokenInsert}
+                                                >
+                                                    &#123;TotalPages&#125;
+                                                </button>
+                                                <button
+                                                    class="dg-tag-chip"
+                                                    data-tok="today"
+                                                    onclick={handleHfTokenInsert}
+                                                >
+                                                    Today
+                                                </button>
+                                                <button
+                                                    class="dg-tag-chip"
+                                                    data-tok="name"
+                                                    onclick={handleHfTokenInsert}
+                                                >
+                                                    &#123;Name&#125;
+                                                </button>
+                                            </div>
+                                            <label class="slds-form-element__label">Header (top of every page)</label>
+                                            <textarea
+                                                class="dg-hf-ta dg-hf-header"
+                                                data-hf="header"
+                                                spellcheck="false"
+                                                placeholder="e.g. <div style='text-align:center'>&#123;Name&#125; — Confidential</div>"
+                                                onfocus={handleHfFocus}
+                                                oninput={handleDesignerHeaderChange}
+                                            ></textarea>
+                                            <label class="slds-form-element__label slds-var-m-top_small"
+                                                >Footer (bottom of every page)</label
+                                            >
+                                            <textarea
+                                                class="dg-hf-ta dg-hf-footer"
+                                                data-hf="footer"
+                                                spellcheck="false"
+                                                placeholder="e.g. <div style='text-align:center'>Page &#123;PageNumber&#125; of &#123;TotalPages&#125;</div>"
+                                                onfocus={handleHfFocus}
+                                                oninput={handleDesignerFooterChange}
+                                            ></textarea>
+                                            <p class="slds-text-body_small slds-text-color_weak slds-var-m-top_x-small">
+                                                With page counters the engine uses plain-text margin boxes; without
+                                                them, full HTML (including images) renders as a running band.
+                                            </p>
+                                        </div>
+                                    </template>
                                     <template if:true={isPanelWatermark}>
                                         <div class="dg-image-panel">
                                             <p class="slds-text-body_small slds-var-m-bottom_x-small">

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1595,6 +1595,14 @@
                                         >
                                         <button
                                             class="dg-fmt-btn dg-fmt-btn_word"
+                                            onmousedown={handleFmtMouseDown}
+                                            onclick={handleInsertTable}
+                                            title="Insert a 3-column table at your cursor"
+                                        >
+                                            + Table
+                                        </button>
+                                        <button
+                                            class="dg-fmt-btn dg-fmt-btn_word"
                                             data-taction="rowAfter"
                                             onmousedown={handleFmtMouseDown}
                                             onclick={handleTableAction}
@@ -1765,6 +1773,7 @@
                                                         title={blk.title}
                                                         draggable="true"
                                                         ondragstart={handleTagDragStart}
+                                                        onmousedown={handleFmtMouseDown}
                                                         onclick={handleInsertTagSnippet}
                                                     >
                                                         {blk.label}
@@ -1795,6 +1804,7 @@
                                                         title={tag.title}
                                                         draggable="true"
                                                         ondragstart={handleTagDragStart}
+                                                        onmousedown={handleFmtMouseDown}
                                                         onclick={handleInsertTagSnippet}
                                                     >
                                                         {tag.label}
@@ -1856,6 +1866,7 @@
                                                     data-name={img.fileName}
                                                     draggable="true"
                                                     ondragstart={handleImageDragStart}
+                                                    onmousedown={handleFmtMouseDown}
                                                     onclick={handleInsertExistingImage}
                                                     title={img.fileName}
                                                 >

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.html
@@ -1776,6 +1776,9 @@
                                             <div class="dg-slash-empty">{slashMenu.errorMsg}</div>
                                         </template>
                                         <div class="dg-slash-foot">
+                                            Not seeing your field? Edit your query: Edit Template &#8594; Query
+                                            Configuration.
+                                            <br />
                                             Think this should be a command?
                                             <a
                                                 href="mailto:hello@portwood.dev?subject=DocGen%20designer%20command%20idea"

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -5342,7 +5342,11 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         if (!cmd) {
             return;
         }
-        if (/^(bold|italic|underline|foreColor|hiliteColor|fontName|fontSize)$/.test(cmd)) {
+        if (
+            /^(bold|italic|underline|strikeThrough|superscript|subscript|foreColor|hiliteColor|fontName|fontSize)$/.test(
+                cmd
+            )
+        ) {
             this._expandCaretToWord();
         }
         try {

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -1267,6 +1267,14 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                         pv.style.outlineOffset = '6px';
                         pv.style.caretColor = '#7c3aed';
                         pv.style.cursor = 'text';
+                        // Merge tags render as friendly atomic pills.
+                        this._pillifyTags(pv);
+                        // Drag targets: tag chips and image thumbnails drop
+                        // exactly where the user points.
+                        pv.addEventListener('dragover', (e) => e.preventDefault());
+                        pv.addEventListener('drop', (e) => this._handleVisualDrop(e, pv));
+                        // Snapshot AFTER pillify so "unchanged" compares
+                        // like-for-like on exit.
                         this._visualEnteredDom = pv.innerHTML;
                     }
                 }
@@ -4696,6 +4704,10 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             this.showToast('Nothing to edit', 'Load or paste a template body first.', 'warning');
             return;
         }
+        this._enterVisualMode(html);
+    }
+
+    _enterVisualMode(html) {
         this._visualOriginalCode = html;
         this._visualEnteredDom = null; // captured in renderedCallback after mount
         this.showHtmlBodyPreview = false;
@@ -4704,6 +4716,51 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         // renderedCallback turns the rendered page into an editor.
         const scoped = scopeHtmlForInlinePreview(html);
         this._pendingPreviewWrite = { selector: '.dg-visual-host', html: scoped, editable: true };
+    }
+
+    /**
+     * Merge tags become atomic pills in the editable page: friendly colored
+     * chips (purple fields, green loop/section markers) that read as objects
+     * instead of code, and — because they're contenteditable=false — can only
+     * be deleted whole, never half-mangled. Walks TEXT nodes only, so tags
+     * inside attributes are untouched.
+     */
+    _pillifyTags(root) {
+        const doc = root.ownerDocument || document;
+        const walker = doc.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+        const targets = [];
+        while (walker.nextNode()) {
+            const node = walker.currentNode;
+            if (/\{[^{}]+\}/.test(node.nodeValue) && (!node.parentElement || node.parentElement.tagName !== 'STYLE')) {
+                targets.push(node);
+            }
+        }
+        for (const node of targets) {
+            const frag = doc.createDocumentFragment();
+            for (const part of node.nodeValue.split(/(\{[^{}]+\})/g)) {
+                if (/^\{[^{}]+\}$/.test(part)) {
+                    const pill = doc.createElement('span');
+                    pill.setAttribute('data-dg-tag', 'true');
+                    pill.setAttribute('contenteditable', 'false');
+                    pill.textContent = part;
+                    const isStructural = /^[#/:%@]/.test(part.charAt(1));
+                    pill.style.cssText = isStructural
+                        ? 'background:#e3f5e9;border:1px solid #9fd6b1;color:#1c7a3d;border-radius:9px;padding:0 6px;font-size:0.9em;white-space:nowrap;'
+                        : 'background:#ede7fd;border:1px solid #c9b8f5;color:#5a3fc4;border-radius:9px;padding:0 6px;font-size:0.9em;white-space:nowrap;';
+                    frag.appendChild(pill);
+                } else if (part) {
+                    frag.appendChild(doc.createTextNode(part));
+                }
+            }
+            node.parentNode.replaceChild(frag, node);
+        }
+    }
+
+    /** Pills back to plain merge-tag text (exit path). */
+    _unpillifyTags(root) {
+        for (const pill of root.querySelectorAll('[data-dg-tag]')) {
+            pill.replaceWith((root.ownerDocument || document).createTextNode(pill.textContent));
+        }
     }
 
     /** Leave visual mode — lossless when nothing changed. */
@@ -4715,11 +4772,13 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             const current = pv.innerHTML;
             if (this._visualEnteredDom !== null && current !== this._visualEnteredDom) {
                 // Extract the edited content: everything except the scoped
-                // <style> the preview pipeline injected.
+                // <style> the preview pipeline injected, with tag pills
+                // unwrapped back to plain merge-tag text.
                 const clone = pv.cloneNode(true);
                 for (const styleEl of clone.querySelectorAll('style')) {
                     styleEl.remove();
                 }
+                this._unpillifyTags(clone);
                 const edited = clone.innerHTML.trim();
                 // Swap ONLY the body content back into the original document —
                 // head/styles/@page are untouched by design.
@@ -4809,10 +4868,19 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     async toggleHtmlBodyEditor() {
         if (this.showHtmlBodyEditor) {
             this.showHtmlBodyEditor = false;
+            this.showHtmlBodyVisual = false;
+            this._visualOriginalCode = null;
+            this._visualEnteredDom = null;
             return;
         }
         this.showHtmlBodyEditor = true;
         await this._loadBodyIntoEditor();
+        // The page, not the code, is the front door: when a body exists,
+        // open straight into visual editing. Code stays one click away.
+        const body = this._lastUploadedHtmlText;
+        if (body && body.trim()) {
+            this._enterVisualMode(body);
+        }
     }
 
     /** Reload = show what's actually staged (or saved), discarding unapplied edits. */
@@ -5006,7 +5074,63 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         const pv = host && host.querySelector('.dg-pv');
         if (pv) {
             pv.insertAdjacentHTML('beforeend', markup);
+            this._pillifyTags(pv);
             this.htmlEditorDirty = true;
+        }
+    }
+
+    /** Drop a dragged tag chip / image thumbnail at the pointed-at spot. */
+    _handleVisualDrop(event, pv) {
+        event.preventDefault();
+        const text = event.dataTransfer && event.dataTransfer.getData('text/plain');
+        if (!text) {
+            return;
+        }
+        const doc = pv.ownerDocument || document;
+        const tpl = doc.createElement('template');
+        tpl.innerHTML = text;
+        this._pillifyTags(tpl.content);
+        let range = null;
+        try {
+            if (doc.caretRangeFromPoint) {
+                range = doc.caretRangeFromPoint(event.clientX, event.clientY);
+            } else if (doc.caretPositionFromPoint) {
+                const p = doc.caretPositionFromPoint(event.clientX, event.clientY);
+                if (p) {
+                    range = doc.createRange();
+                    range.setStart(p.offsetNode, p.offset);
+                }
+            }
+        } catch (e) {
+            range = null;
+        }
+        // Only honor drop points inside the page; otherwise append at the end.
+        if (range && pv.contains(range.startContainer)) {
+            range.collapse(true);
+            range.insertNode(tpl.content);
+        } else {
+            pv.appendChild(tpl.content);
+        }
+        this.htmlEditorDirty = true;
+    }
+
+    /** Tag chips and image thumbnails are draggable onto the visual page. */
+    handleTagDragStart(event) {
+        const snippet = event.currentTarget.dataset.snippet;
+        if (snippet && event.dataTransfer) {
+            event.dataTransfer.setData('text/plain', snippet);
+            event.dataTransfer.effectAllowed = 'copy';
+        }
+    }
+
+    handleImageDragStart(event) {
+        const { url, name } = event.currentTarget.dataset;
+        if (url && event.dataTransfer) {
+            event.dataTransfer.setData(
+                'text/plain',
+                '<img src="' + url + '" alt="' + (name || 'image') + '" style="width: 180px" />'
+            );
+            event.dataTransfer.effectAllowed = 'copy';
         }
     }
 

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -4,6 +4,8 @@ import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import { NavigationMixin } from 'lightning/navigation';
 import { refreshApex } from '@salesforce/apex';
 import { downloadBase64 as downloadBase64Util, parseSOQLFields, stripOuterSelectFrom } from 'c/docGenUtils';
+// HTML-first authoring: starter designs, AI prompt builder, query-shape extractor
+import { STARTERS, extractQueryShape, buildStarterHtml, buildAiPrompt } from './docGenAuthoringKit';
 
 // Apex
 import getAllTemplates from '@salesforce/apex/DocGenController.getAllTemplates';
@@ -38,6 +40,7 @@ import previewRecordData from '@salesforce/apex/DocGenController.previewRecordDa
 import saveWatermarkImage from '@salesforce/apex/DocGenController.saveWatermarkImage';
 import clearWatermarkImage from '@salesforce/apex/DocGenController.clearWatermarkImage';
 import searchDataProviders from '@salesforce/apex/DocGenController.searchDataProviders';
+import getHtmlTemplateBody from '@salesforce/apex/DocGenController.getHtmlTemplateBody';
 import validateDataProvider from '@salesforce/apex/DocGenController.validateDataProvider';
 
 // Schema
@@ -274,7 +277,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     @track newTemplateApiName = '';
     _newApiNameEdited = false;
     newTemplateCategory = '';
-    @track newTemplateType = 'Word';
+    // HTML-first: the wizard's default authoring path (starter) creates HTML templates.
+    @track newTemplateType = 'HTML';
     @track newTemplateOutputFormat = 'PDF';
     @track newTemplatePageOrientation = 'Portrait';
     @track newTemplatePageSize = 'Letter';
@@ -283,6 +287,10 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     newTemplateObject = 'Account';
     newTemplateDesc = '';
     newTemplateQuery = '';
+    // HTML-first authoring path. 'starter' (recommended) and 'ai' both create
+    // HTML templates; 'file' exposes the classic Type picker for uploads.
+    @track newAuthoringMode = 'starter';
+    @track newStarterKey = 'report';
     @track newTemplateSampleRecordId = '';
     @track sampleRecordData = null;
     isCreating = true;
@@ -340,6 +348,13 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     // Drives the "your HTML defines its own page setup" banner and hides the
     // template-level page-layout fields, which the engine ignores in this case.
     @track editHtmlBodyOwnsPageRule = false;
+    // HTML body editor (paste-back surface for LLM-generated templates)
+    @track showHtmlBodyEditor = false;
+    @track isLoadingHtmlBody = false;
+    @track isApplyingHtmlBody = false;
+    // Last HTML body text this session touched (upload, starter, or Apply) so
+    // reopening the editor doesn't need a server round-trip.
+    _lastUploadedHtmlText = null;
 
     @track currentFileId;
     @track uploadedFileName = '';
@@ -1323,6 +1338,153 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         }
         if (event.detail.value === 'HTML' || event.detail.value === 'PDF') {
             this.newTemplateOutputFormat = 'PDF';
+        }
+    }
+
+    // --- HTML-first authoring path ---
+    get isAuthoringStarter() {
+        return this.newAuthoringMode === 'starter';
+    }
+    get isAuthoringAi() {
+        return this.newAuthoringMode === 'ai';
+    }
+    get isAuthoringFile() {
+        return this.newAuthoringMode === 'file';
+    }
+
+    get authoringCards() {
+        const defs = [
+            {
+                mode: 'starter',
+                title: 'Start from a Design',
+                badge: 'Recommended',
+                icon: 'utility:brush',
+                desc: 'Pick a professional starter layout — your fields are dropped in automatically and the template renders on the first click. Creates an HTML template, the most reliable path to pixel-perfect PDFs.'
+            },
+            {
+                mode: 'ai',
+                title: 'Generate with AI',
+                badge: null,
+                icon: 'utility:einstein',
+                desc: "We assemble a ready-to-paste prompt with your fields and DocGen's tag syntax. Paste it into Claude, ChatGPT, or Copilot, then paste the HTML it returns straight into the template editor."
+            },
+            {
+                mode: 'file',
+                title: 'I Have an Existing File',
+                badge: null,
+                icon: 'utility:upload',
+                desc: 'Upload a Word, PowerPoint, Excel, fillable PDF, or HTML file you already maintain. Word documents are converted to HTML for PDF output — complex layouts may not convert exactly.'
+            }
+        ];
+        return defs.map((d) => ({
+            ...d,
+            selected: this.newAuthoringMode === d.mode,
+            cardClass:
+                this.newAuthoringMode === d.mode ? 'dg-authoring-card dg-authoring-card_selected' : 'dg-authoring-card'
+        }));
+    }
+
+    get starterCards() {
+        return STARTERS.map((s) => ({
+            ...s,
+            selected: this.newStarterKey === s.key,
+            cardClass: this.newStarterKey === s.key ? 'dg-starter-card dg-starter-card_selected' : 'dg-starter-card'
+        }));
+    }
+
+    get selectedStarterLabel() {
+        const s = STARTERS.find((x) => x.key === this.newStarterKey);
+        return s ? s.label : '';
+    }
+
+    handleAuthoringModeSelect(event) {
+        const mode = event.currentTarget.dataset.mode;
+        if (!mode || mode === this.newAuthoringMode) {
+            return;
+        }
+        this.newAuthoringMode = mode;
+        if (mode === 'starter' || mode === 'ai') {
+            this.newTemplateType = 'HTML';
+            this.newTemplateOutputFormat = 'PDF';
+        } else {
+            this.newTemplateType = 'Word';
+            this.newTemplateOutputFormat = 'PDF';
+        }
+    }
+
+    handleAuthoringModeKeydown(event) {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            this.handleAuthoringModeSelect(event);
+        }
+    }
+
+    handleStarterSelect(event) {
+        this.newStarterKey = event.currentTarget.dataset.key;
+    }
+
+    /** Word→HTML conversion expectation-setting, shown under the Type picker. */
+    get showWordConversionNote() {
+        return this.isAuthoringFile && this.newTemplateType === 'Word';
+    }
+
+    /** v1.90 HTML @page note only applies when the user brings their own HTML file. */
+    get showHtmlPageRuleNote() {
+        return this.isCreatingHtmlPdf && this.isAuthoringFile;
+    }
+
+    get aiAuthoringPrompt() {
+        const shape = extractQueryShape(this.newTemplateQuery, this.newTemplateObject);
+        return buildAiPrompt(shape, {
+            dataSourceMode: this.dataSourceMode,
+            providerFields: (this.providerFields || []).map((f) => f.name || f)
+        });
+    }
+
+    get editAiPrompt() {
+        const shape = extractQueryShape(this.editTemplateQuery, this.editTemplateObject);
+        return buildAiPrompt(shape, {
+            dataSourceMode: this.editTemplateObject === 'FlowJsonData' ? 'flow' : 'record',
+            providerFields: (this.providerFields || []).map((f) => f.name || f)
+        });
+    }
+
+    handleCopyAiPrompt() {
+        this._copyToClipboard(this.aiAuthoringPrompt, 'AI prompt copied — paste it into your AI assistant.');
+    }
+
+    handleCopyEditAiPrompt() {
+        this._copyToClipboard(this.editAiPrompt, 'AI prompt copied — paste it into your AI assistant.');
+    }
+
+    _copyToClipboard(text, successMsg) {
+        const fallback = () => {
+            const ta = document.createElement('textarea');
+            ta.value = text;
+            ta.style.position = 'fixed';
+            ta.style.opacity = '0';
+            document.body.appendChild(ta);
+            ta.select();
+            let ok = false;
+            try {
+                ok = document.execCommand('copy');
+            } catch (e) {
+                ok = false;
+            }
+            document.body.removeChild(ta);
+            if (ok) {
+                this.showToast('Copied', successMsg, 'success');
+            } else {
+                this.showToast('Copy failed', 'Select the prompt text and copy it manually.', 'warning');
+            }
+        };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(
+                () => this.showToast('Copied', successMsg, 'success'),
+                () => fallback()
+            );
+        } else {
+            fallback();
         }
     }
     handleOutputFormatChange(event) {
@@ -2739,11 +2901,20 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             fields[TEST_RECORD_FIELD.fieldApiName] = this.newTemplateSampleRecordId;
         }
 
+        // Snapshot authoring-path inputs before resetForm() clears them — the
+        // starter body is built and attached after the modal opens.
+        const authoringMode = this.newAuthoringMode;
+        const starterKey = this.newStarterKey;
+        const starterShape =
+            authoringMode === 'starter' ? extractQueryShape(this.newTemplateQuery, this.newTemplateObject) : null;
+
         try {
             const record = await createRecord({ apiName: DOCGEN_TEMPLATE_OBJECT.objectApiName, fields });
             this.createdTemplateId = record.id;
             this.isCreating = false;
-            this.showToast('Success', 'Template Record created. Please upload your document.', 'success');
+            if (authoringMode !== 'starter') {
+                this.showToast('Success', 'Template Record created. Please upload your document.', 'success');
+            }
 
             const newRow = {
                 Id: record.id,
@@ -2773,9 +2944,51 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             this.activeMainTab = 'list';
             this.activeEditTab = 'document';
             this.openEditModal(newRow, 'document');
+            if (authoringMode === 'starter') {
+                await this._applyStarterBody(record.id, starterKey, starterShape);
+            }
         } catch (error) {
             this.showToast('Error creating record', error.body ? error.body.message : error.message, 'error');
         }
+    }
+
+    /**
+     * Starter path: build the chosen design with the author's real merge
+     * fields and attach it as the template body, so the very first "Save as
+     * New Version" click produces a working v1 that renders on Generate.
+     */
+    async _applyStarterBody(templateId, starterKey, shape) {
+        try {
+            const html = buildStarterHtml(starterKey, shape);
+            const fileName = (this.selectedStarterLabelFor(starterKey) || 'Starter').replace(/[^\w]+/g, '_') + '.html';
+            const bodyResult = await saveHtmlTemplateBody({ templateId, fileName, htmlContent: html });
+            this.currentFileId = bodyResult.contentDocumentId;
+            this.uploadedContentVersionId = bodyResult.contentVersionId;
+            this.uploadedFileName = fileName;
+            this._lastUploadedHtmlText = html;
+            // Starters declare @page — same handling as an uploaded body that owns it.
+            this.editHtmlBodyOwnsPageRule = true;
+            this.editTemplatePageOrientation = null;
+            this.editTemplatePageSize = null;
+            this.editTemplatePageMargins = null;
+            this.editTemplateCustomMargins = '';
+            // Land the author inside the HTML with the draft loaded.
+            this.showHtmlBodyEditor = true;
+            this._syncHtmlBodyEditorDom(html);
+            this.showToast(
+                'Starter design attached',
+                'Review the HTML, then click "Save as New Version" to activate it. Generate Sample shows it with real data.',
+                'success'
+            );
+        } catch (err) {
+            const msg = err && err.body && err.body.message ? err.body.message : (err && err.message) || String(err);
+            this.showToast('Starter attach failed', msg, 'error');
+        }
+    }
+
+    selectedStarterLabelFor(key) {
+        const s = STARTERS.find((x) => x.key === key);
+        return s ? s.label : '';
     }
 
     // --- Row Action ---
@@ -2946,6 +3159,11 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             // Same staleness trap: the @page-ownership flag belongs to whatever
             // HTML body was last uploaded, not to this template.
             this.editHtmlBodyOwnsPageRule = false;
+            // HTML body editor state is per-template too.
+            this.showHtmlBodyEditor = false;
+            this._lastUploadedHtmlText = null;
+            this.isLoadingHtmlBody = false;
+            this.isApplyingHtmlBody = false;
 
             let cdLinks = [];
             if (row.ContentDocumentLinks) {
@@ -4205,105 +4423,180 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 htmlText = await file.text();
             }
 
-            // Extract inline data: URI images (common in Notion, ChatGPT, Apple
-            // Pages, or any rich-text-paste HTML). Blob.toPdf can't decode
-            // data URIs, so each inline image becomes its own ContentVersion
-            // with the src rewritten to /sfc/... just like zipped images.
-            const dataUriMatches = [];
-            const dataUriRe = /src\s*=\s*(["'])(data:image\/([a-zA-Z0-9+.-]+);base64,([A-Za-z0-9+/=\s]+?))\1/g;
-            let m;
-            while ((m = dataUriRe.exec(htmlText)) !== null) {
-                const dataUri = m[2];
-                let ext = m[3].toLowerCase();
-                if (ext === 'jpeg') {
-                    ext = 'jpg';
-                }
-                if (ext === 'svg+xml') {
-                    ext = 'svg';
-                }
-                const base64 = m[4].replace(/\s+/g, '');
-                dataUriMatches.push({ dataUri, ext, base64 });
-            }
-
-            // Upload each image; server returns CV Id + URL per part
-            const urlByPath = {};
-            for (let i = 0; i < imagePaths.length; i++) {
-                const base = imagePaths[i].split('/').pop() || imagePaths[i];
-                // eslint-disable-next-line no-await-in-loop
-                const imgResult = await saveHtmlTemplateImage({
-                    templateId,
-                    fileName: base,
-                    base64Content: bytesToBase64(imageBytes[i])
-                });
-                urlByPath[imagePaths[i]] = imgResult.url;
-                if (base !== imagePaths[i]) {
-                    urlByPath[base] = imgResult.url;
-                }
-            }
-
-            // Upload extracted data: URIs; key by the full data: string so the
-            // regex-replace below swaps each original URI for its CV URL.
-            const dataUriUrlMap = [];
-            for (let i = 0; i < dataUriMatches.length; i++) {
-                const d = dataUriMatches[i];
-                // eslint-disable-next-line no-await-in-loop
-                const imgResult = await saveHtmlTemplateImage({
-                    templateId,
-                    fileName: 'inline_' + (i + 1) + '.' + d.ext,
-                    base64Content: d.base64
-                });
-                dataUriUrlMap.push({ dataUri: d.dataUri, url: imgResult.url });
-            }
-
-            // Rewrite <img src="..."> references client-side
-            let rewritten = htmlText;
-            for (const path of Object.keys(urlByPath)) {
-                const url = urlByPath[path];
-                rewritten = rewritten.split('"' + path + '"').join('"' + url + '"');
-                rewritten = rewritten.split("'" + path + "'").join("'" + url + "'");
-            }
-            for (const entry of dataUriUrlMap) {
-                rewritten = rewritten.split(entry.dataUri).join(entry.url);
-            }
-            const totalImages = imagePaths.length + dataUriMatches.length;
-
-            // Save the final HTML body
-            const bodyResult = await saveHtmlTemplateBody({
-                templateId,
-                fileName: file.name,
-                htmlContent: rewritten
-            });
-
-            this.currentFileId = bodyResult.contentDocumentId;
-            this.uploadedContentVersionId = bodyResult.contentVersionId;
-            this.uploadedFileName = file.name;
-            const imgMsg =
-                totalImages > 0 ? ' (' + totalImages + ' image' + (totalImages === 1 ? '' : 's') + ' extracted)' : '';
-            // v1.90 — detect author-declared @page rule; if present, the engine suppresses
-            // its own size/margin and the template-level page fields are dead inputs. Hide
-            // them and clear in-memory values so a subsequent Save doesn't silently
-            // re-introduce conflicting values.
-            this.editHtmlBodyOwnsPageRule = this.htmlContainsPageRule(rewritten);
-            if (this.editHtmlBodyOwnsPageRule) {
-                this.editTemplatePageOrientation = null;
-                this.editTemplatePageSize = null;
-                this.editTemplatePageMargins = null;
-                this.editTemplateCustomMargins = '';
-            }
-            const pageMsg = this.editHtmlBodyOwnsPageRule
-                ? ' Your HTML defines its own @page CSS — template page-layout fields cleared.'
-                : '';
-            this.showToast(
-                'Uploaded',
-                file.name + imgMsg + '.' + pageMsg + ' Click "Save as New Version" to activate.',
-                'success'
-            );
+            await this._processAndSaveHtmlBody(templateId, htmlText, file.name, { imagePaths, imageBytes });
         } catch (err) {
             const msg = err && err.body && err.body.message ? err.body.message : (err && err.message) || String(err);
             this.showToast('Upload Failed', msg, 'error');
         } finally {
             this.isUploadingHtml = false;
             event.target.value = '';
+        }
+    }
+
+    /**
+     * Shared HTML-body pipeline (file upload, paste-back editor, starter):
+     * extract inline data: URI images, upload every image part, rewrite
+     * <img src> to CV URLs, store the body, and sync the @page-ownership
+     * state. Throws on failure — callers own the error toast.
+     */
+    async _processAndSaveHtmlBody(templateId, htmlText, fileName, zipImages) {
+        const imagePaths = (zipImages && zipImages.imagePaths) || [];
+        const imageBytes = (zipImages && zipImages.imageBytes) || [];
+
+        // Extract inline data: URI images (common in Notion, ChatGPT, Apple
+        // Pages, or any rich-text-paste HTML). Blob.toPdf can't decode
+        // data URIs, so each inline image becomes its own ContentVersion
+        // with the src rewritten to /sfc/... just like zipped images.
+        const dataUriMatches = [];
+        const dataUriRe = /src\s*=\s*(["'])(data:image\/([a-zA-Z0-9+.-]+);base64,([A-Za-z0-9+/=\s]+?))\1/g;
+        let m;
+        while ((m = dataUriRe.exec(htmlText)) !== null) {
+            const dataUri = m[2];
+            let ext = m[3].toLowerCase();
+            if (ext === 'jpeg') {
+                ext = 'jpg';
+            }
+            if (ext === 'svg+xml') {
+                ext = 'svg';
+            }
+            const base64 = m[4].replace(/\s+/g, '');
+            dataUriMatches.push({ dataUri, ext, base64 });
+        }
+
+        // Upload each image; server returns CV Id + URL per part
+        const urlByPath = {};
+        for (let i = 0; i < imagePaths.length; i++) {
+            const base = imagePaths[i].split('/').pop() || imagePaths[i];
+            // eslint-disable-next-line no-await-in-loop
+            const imgResult = await saveHtmlTemplateImage({
+                templateId,
+                fileName: base,
+                base64Content: bytesToBase64(imageBytes[i])
+            });
+            urlByPath[imagePaths[i]] = imgResult.url;
+            if (base !== imagePaths[i]) {
+                urlByPath[base] = imgResult.url;
+            }
+        }
+
+        // Upload extracted data: URIs; key by the full data: string so the
+        // regex-replace below swaps each original URI for its CV URL.
+        const dataUriUrlMap = [];
+        for (let i = 0; i < dataUriMatches.length; i++) {
+            const d = dataUriMatches[i];
+            // eslint-disable-next-line no-await-in-loop
+            const imgResult = await saveHtmlTemplateImage({
+                templateId,
+                fileName: 'inline_' + (i + 1) + '.' + d.ext,
+                base64Content: d.base64
+            });
+            dataUriUrlMap.push({ dataUri: d.dataUri, url: imgResult.url });
+        }
+
+        // Rewrite <img src="..."> references client-side
+        let rewritten = htmlText;
+        for (const path of Object.keys(urlByPath)) {
+            const url = urlByPath[path];
+            rewritten = rewritten.split('"' + path + '"').join('"' + url + '"');
+            rewritten = rewritten.split("'" + path + "'").join("'" + url + "'");
+        }
+        for (const entry of dataUriUrlMap) {
+            rewritten = rewritten.split(entry.dataUri).join(entry.url);
+        }
+        const totalImages = imagePaths.length + dataUriMatches.length;
+
+        // Save the final HTML body
+        const bodyResult = await saveHtmlTemplateBody({
+            templateId,
+            fileName,
+            htmlContent: rewritten
+        });
+
+        this.currentFileId = bodyResult.contentDocumentId;
+        this.uploadedContentVersionId = bodyResult.contentVersionId;
+        this.uploadedFileName = fileName;
+        this._lastUploadedHtmlText = rewritten;
+        const imgMsg =
+            totalImages > 0 ? ' (' + totalImages + ' image' + (totalImages === 1 ? '' : 's') + ' extracted)' : '';
+        // v1.90 — detect author-declared @page rule; if present, the engine suppresses
+        // its own size/margin and the template-level page fields are dead inputs. Hide
+        // them and clear in-memory values so a subsequent Save doesn't silently
+        // re-introduce conflicting values.
+        this.editHtmlBodyOwnsPageRule = this.htmlContainsPageRule(rewritten);
+        if (this.editHtmlBodyOwnsPageRule) {
+            this.editTemplatePageOrientation = null;
+            this.editTemplatePageSize = null;
+            this.editTemplatePageMargins = null;
+            this.editTemplateCustomMargins = '';
+        }
+        const pageMsg = this.editHtmlBodyOwnsPageRule
+            ? ' Your HTML defines its own @page CSS — template page-layout fields cleared.'
+            : '';
+        this.showToast(
+            'Uploaded',
+            fileName + imgMsg + '.' + pageMsg + ' Click "Save as New Version" to activate.',
+            'success'
+        );
+        return rewritten;
+    }
+
+    // --- HTML body editor (paste-back surface) ---
+    get htmlBodyEditorToggleLabel() {
+        return this.showHtmlBodyEditor ? 'Hide HTML Editor' : 'Edit HTML';
+    }
+
+    async toggleHtmlBodyEditor() {
+        if (this.showHtmlBodyEditor) {
+            this.showHtmlBodyEditor = false;
+            return;
+        }
+        this.showHtmlBodyEditor = true;
+        if (this._lastUploadedHtmlText != null) {
+            this._syncHtmlBodyEditorDom(this._lastUploadedHtmlText);
+            return;
+        }
+        // No body touched this session — pull the latest stored body.
+        this.isLoadingHtmlBody = true;
+        try {
+            const body = await getHtmlTemplateBody({ templateId: this.editTemplateId });
+            this._lastUploadedHtmlText = body || '';
+            this._syncHtmlBodyEditorDom(this._lastUploadedHtmlText);
+        } catch (err) {
+            const msg = err && err.body && err.body.message ? err.body.message : (err && err.message) || String(err);
+            this.showToast('Could not load HTML body', msg, 'error');
+            this._syncHtmlBodyEditorDom('');
+        } finally {
+            this.isLoadingHtmlBody = false;
+        }
+    }
+
+    /** Native textarea doesn't track LWC state — set the DOM after render. */
+    _syncHtmlBodyEditorDom(text) {
+        // eslint-disable-next-line @lwc/lwc/no-async-operation
+        setTimeout(() => {
+            const ta = this.template.querySelector('.dg-html-body-editor');
+            if (ta) {
+                ta.value = text || '';
+            }
+        }, 120);
+    }
+
+    async handleApplyHtmlBody() {
+        const ta = this.template.querySelector('.dg-html-body-editor');
+        const text = ta ? ta.value : '';
+        if (!text || !text.trim()) {
+            this.showToast('Nothing to apply', 'Paste or edit HTML in the editor first.', 'warning');
+            return;
+        }
+        this.isApplyingHtmlBody = true;
+        try {
+            const base = (this.uploadedFileName || 'template.html').replace(/\.(html?|zip)$/i, '');
+            await this._processAndSaveHtmlBody(this.editTemplateId, text, base + '.html', null);
+        } catch (err) {
+            const msg = err && err.body && err.body.message ? err.body.message : (err && err.message) || String(err);
+            this.showToast('Apply failed', msg, 'error');
+        } finally {
+            this.isApplyingHtmlBody = false;
         }
     }
 
@@ -4334,7 +4627,11 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         this.newTemplateCategory = '';
         // Excel leaves Output Format = 'Native'; without this reset the next
         // wizard open shows Type=Excel with a forced-invalid 'PDF' format.
-        this.newTemplateType = 'Word';
+        // HTML-first: the wizard opens on the recommended starter path, so the
+        // default Type is HTML until the user picks "I Have an Existing File".
+        this.newAuthoringMode = 'starter';
+        this.newStarterKey = 'report';
+        this.newTemplateType = 'HTML';
         this.newTemplateDesc = '';
         this.newTemplateQuery = '';
         this.newTemplateOutputFormat = 'PDF';

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -327,7 +327,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     newTemplateQuery = '';
     // HTML-first authoring path. 'starter' (recommended) and 'ai' both create
     // HTML templates; 'file' exposes the classic Type picker for uploads.
-    @track newAuthoringMode = 'starter';
+    @track newAuthoringMode = 'file';
     @track newStarterKey = 'report';
     // One-click create: auto-built query + optional company logo asset
     @track isAutoCreating = false;
@@ -4546,6 +4546,16 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             }
             if (templateBodyContentVersionId) {
                 this.showToast('Success', 'New version saved. You can now Generate to test it.', 'success');
+            } else if (this.activeMainTab === 'design') {
+                // Designer saves auto-stage any edits before reaching here, so
+                // "no new file" simply means the body didn't change — say so
+                // calmly instead of the sticky re-upload warning (that warning
+                // is for the file-upload modal where a stale body surprises).
+                this.showToast(
+                    'Saved',
+                    'Version saved — the document body is unchanged from the previous version.',
+                    'success'
+                );
             } else {
                 // Carry-forward warning (builds on #176's Version History diagnostics):
                 // a new version saved WITHOUT re-uploading a body file reuses the prior
@@ -7809,14 +7819,10 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     }
 
     async handleApplyHtmlBody() {
-        // Visual mode edits live in the rich-text editor — fold them into the
-        // code editor first so Apply stages what the user is looking at.
-        if (this.showHtmlBodyVisual) {
-            this._exitVisualMode();
-        }
-        const ta = this.template.querySelector('.dg-html-body-editor');
-        const text = ta ? ta.value : '';
-        if (!text || !text.trim()) {
+        // Serialize the CURRENT view non-destructively — Apply must never kick
+        // the author out of Visual mode.
+        const text = (this._currentDraftHtml() || '').trim();
+        if (!text) {
             this.showToast('Nothing to apply', 'Paste or edit HTML in the editor first.', 'warning');
             return;
         }
@@ -7824,6 +7830,16 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         try {
             const base = (this.uploadedFileName || 'template.html').replace(/\.(html?|zip)$/i, '');
             await this._processAndSaveHtmlBody(this.editTemplateId, text, base + '.html', null, 'editor');
+            this.htmlEditorDirty = false;
+            if (this.showHtmlBodyVisual) {
+                // Staged text is the new baseline: Source view and the
+                // visual round-trip both work from what was just staged.
+                this._visualOriginalCode = text;
+                const ta = this.template.querySelector('.dg-html-body-editor');
+                if (ta) {
+                    ta.value = text;
+                }
+            }
         } catch (err) {
             const msg = err && err.body && err.body.message ? err.body.message : (err && err.message) || String(err);
             this.showToast('Apply failed', msg, 'error');
@@ -7859,16 +7875,16 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         this.newTemplateCategory = '';
         // Excel leaves Output Format = 'Native'; without this reset the next
         // wizard open shows Type=Excel with a forced-invalid 'PDF' format.
-        // HTML-first: the wizard opens on the recommended starter path, so the
-        // default Type is HTML until the user picks "I Have an Existing File".
-        this.newAuthoringMode = 'starter';
+        // Default path is "I Have an Existing File" — most admins arrive with
+        // a document in hand; the design/AI/scratch cards sit right beside it.
+        this.newAuthoringMode = 'file';
         this.newStarterKey = 'report';
         this._logoFile = null;
         this.newTemplateLogoName = '';
         this.isAutoCreating = false;
         this.showAdvancedOptions = false;
         this.newTemplateLogoChoice = 'none';
-        this.newTemplateType = 'HTML';
+        this.newTemplateType = 'Word';
         this.newTemplateDesc = '';
         this.newTemplateQuery = '';
         this.newTemplateOutputFormat = 'PDF';

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -392,6 +392,11 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     @track showHtmlBodyVisual = false;
     _visualOriginalCode = null;
     _visualEnteredDom = null;
+    // What the caret is on ("Editing: Table cell") — answers "what am I
+    // about to color?"
+    @track selectionContextLabel = '';
+    // Canvas page setup, mirrored into the template's @page rule.
+    @track pageSetup = { size: 'Letter', orient: 'portrait', margin: '0.75' };
     // Last HTML body text this session touched (upload, starter, or Apply) so
     // reopening the editor doesn't need a server round-trip.
     _lastUploadedHtmlText = null;
@@ -1237,6 +1242,13 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
 
     // --- Wizard Logic ---
 
+    disconnectedCallback() {
+        if (this._selListenerAdded) {
+            document.removeEventListener('selectionchange', this._onSelectionChange);
+            this._selListenerAdded = false;
+        }
+    }
+
     renderedCallback() {
         // Sync native textarea DOM value with tracked property after re-render
         if (this.currentWizardStep === '2' && this.newTemplateQuery) {
@@ -1249,6 +1261,14 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             const ta = this.template.querySelector('.edit-query-textarea');
             if (ta && ta.value !== this.editTemplateQuery) {
                 ta.value = this.editTemplateQuery;
+            }
+        }
+        // Page-setup selects: LWC doesn't bind value on native <select>, so
+        // mirror state into the DOM the same way the query textareas do.
+        for (const sel of this.template.querySelectorAll('.dg-page-select')) {
+            const want = this.pageSetup[sel.dataset.field];
+            if (want != null && sel.value !== want) {
+                sel.value = want;
             }
         }
         // Inline HTML preview: the lwc:dom="manual" host only exists after the
@@ -1285,6 +1305,17 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                             }
                         });
                         pv.addEventListener('drop', (e) => this._handleVisualDrop(e, pv));
+                        // Live dirty signal while typing in the page.
+                        pv.addEventListener('input', () => {
+                            this.htmlEditorDirty = true;
+                        });
+                        // Sheet dimensions follow the page setup.
+                        this._applyCanvasDimensions();
+                        // Context label ("Editing: Table cell") follows the caret.
+                        if (!this._selListenerAdded) {
+                            document.addEventListener('selectionchange', this._onSelectionChange);
+                            this._selListenerAdded = true;
+                        }
                         // Snapshot AFTER pillify so "unchanged" compares
                         // like-for-like on exit.
                         this._visualEnteredDom = pv.innerHTML;
@@ -4556,6 +4587,11 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
      * state. Throws on failure — callers own the error toast.
      */
     async _processAndSaveHtmlBody(templateId, htmlText, fileName, zipImages, source) {
+        // GUARD: never stage editor-internal artifacts. If a preview-wrapped
+        // payload (scoped .dg-pv page), tag pills, or drop markers slip in —
+        // e.g. from a stale cached bundle's older code path — unwrap and
+        // strip them so the stored body is always clean template HTML.
+        htmlText = this._sanitizeStagedHtml(htmlText);
         const imagePaths = (zipImages && zipImages.imagePaths) || [];
         const imageBytes = (zipImages && zipImages.imageBytes) || [];
 
@@ -4663,6 +4699,60 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         return rewritten;
     }
 
+    /**
+     * Strip every editor-internal artifact from HTML about to be staged:
+     * tag pills back to plain text, drop markers gone, and — if the text is
+     * (or contains) a scoped preview page — unwrap .dg-pv and remove the
+     * injected preview <style>. Idempotent on clean input.
+     */
+    _sanitizeStagedHtml(html) {
+        if (
+            !html ||
+            (html.indexOf('data-dg-tag') === -1 &&
+                html.indexOf('dg-pv') === -1 &&
+                html.indexOf('dg-drop-marker') === -1)
+        ) {
+            return html;
+        }
+        try {
+            const tpl = document.createElement('template');
+            tpl.innerHTML = html;
+            const root = tpl.content;
+            for (const marker of root.querySelectorAll('.dg-drop-marker')) {
+                marker.remove();
+            }
+            this._unpillifyTags(root);
+            const pv = root.querySelector('div.dg-pv');
+            if (pv) {
+                // Preview-wrapped payload: keep only the page content, minus
+                // the injected scoped stylesheet.
+                for (const styleEl of pv.querySelectorAll(':scope > style')) {
+                    styleEl.remove();
+                }
+                const inner = pv.innerHTML.trim();
+                // Preserve an original shell if one wrapped the preview; else
+                // the content becomes the document body in a minimal shell.
+                const bodyRe = /(<body\b[^>]*>)[\s\S]*?(<\/body\s*>)/i;
+                const outer = html.replace(/[\s\S]*/, ''); // placeholder, replaced below
+                void outer;
+                if (bodyRe.test(html) && !/class="dg-pv"/.test(html.split(/<body\b[^>]*>/i)[0] || '')) {
+                    return html.replace(bodyRe, (m, open, close) => open + '\n' + inner + '\n' + close);
+                }
+                return (
+                    '<!DOCTYPE html>\n<html>\n<head>\n<meta charset="utf-8" />\n<style>\n@page { size: Letter portrait; margin: 0.75in; }\nbody { font-family: Helvetica, Arial, sans-serif; font-size: 10.5pt; color: #1a1a1a; }\n</style>\n</head>\n<body>\n' +
+                    inner +
+                    '\n</body>\n</html>\n'
+                );
+            }
+            // No pv wrapper — serialize the cleaned fragment back out.
+            const container = document.createElement('div');
+            container.appendChild(root.cloneNode(true));
+            return container.innerHTML;
+        } catch (e) {
+            return html;
+        }
+    }
+
     // --- HTML body editor (paste-back surface) ---
     get htmlBodyEditorToggleLabel() {
         return this.showHtmlBodyEditor ? 'Hide HTML Editor' : 'Edit HTML';
@@ -4711,6 +4801,114 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
 
     get codeSplitClass() {
         return this.showHtmlBodyVisual ? 'dg-code-split slds-hide' : 'dg-code-split';
+    }
+
+    // --- Visual | Source segmented switch (persistent header, like any editor) ---
+    get visualModeBtnClass() {
+        return this.showHtmlBodyVisual
+            ? 'dg-fmt-btn dg-fmt-btn_word dg-mode-btn dg-mode-btn_active'
+            : 'dg-fmt-btn dg-fmt-btn_word dg-mode-btn';
+    }
+
+    get sourceModeBtnClass() {
+        return this.showHtmlBodyVisual
+            ? 'dg-fmt-btn dg-fmt-btn_word dg-mode-btn'
+            : 'dg-fmt-btn dg-fmt-btn_word dg-mode-btn dg-mode-btn_active';
+    }
+
+    handleSelectVisualMode() {
+        if (!this.showHtmlBodyVisual) {
+            const ta = this.template.querySelector('.dg-html-body-editor');
+            this._enterVisualMode((ta && ta.value) || '');
+        }
+    }
+
+    handleSelectSourceMode() {
+        if (this.showHtmlBodyVisual) {
+            this._exitVisualMode();
+        }
+    }
+
+    // --- Page setup: size / orientation / margins → @page rule + canvas sheet ---
+    get pageSizeChoices() {
+        return [
+            { key: 'Letter', label: 'Letter' },
+            { key: 'Legal', label: 'Legal' },
+            { key: 'A4', label: 'A4' }
+        ];
+    }
+
+    _parsePageSetup(code) {
+        const setup = { size: 'Letter', orient: 'portrait', margin: '0.75' };
+        const m = /@page\s*\{([^}]*)\}/i.exec(code || '');
+        if (m) {
+            const body = m[1];
+            const sm = /size\s*:\s*(letter|legal|a4)\s*(portrait|landscape)?/i.exec(body);
+            if (sm) {
+                const raw = sm[1].toLowerCase();
+                setup.size = raw === 'a4' ? 'A4' : raw.charAt(0).toUpperCase() + raw.slice(1);
+                if (sm[2]) {
+                    setup.orient = sm[2].toLowerCase();
+                }
+            }
+            const mm = /margin\s*:\s*([\d.]+)\s*in/i.exec(body);
+            if (mm) {
+                setup.margin = mm[1];
+            }
+        }
+        this.pageSetup = setup;
+    }
+
+    handlePageSetupChange(event) {
+        const field = event.currentTarget.dataset.field;
+        this.pageSetup = { ...this.pageSetup, [field]: event.currentTarget.value };
+        this._applyPageSetup();
+    }
+
+    _applyPageSetup() {
+        const ta = this.template.querySelector('.dg-html-body-editor');
+        if (!ta) {
+            return;
+        }
+        const rule =
+            '@page { size: ' +
+            this.pageSetup.size +
+            ' ' +
+            this.pageSetup.orient +
+            '; margin: ' +
+            this.pageSetup.margin +
+            'in; }';
+        let code = ta.value || '';
+        if (/@page\s*\{[^}]*\}/i.test(code)) {
+            code = code.replace(/@page\s*\{[^}]*\}/i, rule);
+        } else if (/<style\b[^>]*>/i.test(code)) {
+            code = code.replace(/<style\b[^>]*>/i, (m) => m + '\n        ' + rule);
+        } else {
+            code = '<style>\n' + rule + '\n</style>\n' + code;
+        }
+        ta.value = code;
+        this._visualOriginalCode = code;
+        this.htmlEditorDirty = true;
+        this._applyCanvasDimensions();
+        this._refreshCodePreview();
+    }
+
+    /** Make the on-screen sheet match the page setup (Lucid-style canvas). */
+    _applyCanvasDimensions() {
+        const host = this.template.querySelector('.dg-visual-host');
+        const pv = host && host.querySelector('.dg-pv');
+        if (!pv) {
+            return;
+        }
+        const widths = { Letter: 816, Legal: 816, A4: 794 };
+        const heights = { Letter: 1056, Legal: 1344, A4: 1123 };
+        const w =
+            this.pageSetup.orient === 'landscape'
+                ? heights[this.pageSetup.size] || 1056
+                : widths[this.pageSetup.size] || 816;
+        const pad = Math.round(parseFloat(this.pageSetup.margin || '0.75') * 96);
+        pv.style.maxWidth = w + 'px';
+        pv.style.padding = pad + 'px';
     }
 
     // --- Format Code + Code ⇄ Preview (shared by the HTML editor and the DOCX viewer) ---
@@ -4798,6 +4996,74 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     handleFmtMouseDown(event) {
         event.preventDefault();
     }
+
+    /** Caret with no selection? Format the word under it — click, color, done. */
+    _expandCaretToWord() {
+        try {
+            const sel = window.getSelection();
+            if (!sel || !sel.rangeCount || !sel.isCollapsed || typeof sel.modify !== 'function') {
+                return;
+            }
+            const host = this.template.querySelector('.dg-visual-host');
+            const pv = host && host.querySelector('.dg-pv');
+            const anchorEl =
+                sel.anchorNode && sel.anchorNode.nodeType === 3 ? sel.anchorNode.parentElement : sel.anchorNode;
+            if (pv && anchorEl && pv.contains(anchorEl)) {
+                sel.modify('move', 'backward', 'word');
+                sel.modify('extend', 'forward', 'word');
+            }
+        } catch (e) {
+            /* best effort */
+        }
+    }
+
+    /** Toolbar breadcrumb: what element is the caret inside? */
+    _onSelectionChange = () => {
+        if (!this.showHtmlBodyVisual || this.activeMainTab !== 'design') {
+            return;
+        }
+        let node = null;
+        try {
+            const sel = window.getSelection();
+            node = sel && sel.anchorNode;
+        } catch (e) {
+            return;
+        }
+        while (node && node.nodeType === 3) {
+            node = node.parentNode;
+        }
+        const host = this.template.querySelector('.dg-visual-host');
+        const pv = host && host.querySelector('.dg-pv');
+        if (!node || !pv || !pv.contains(node)) {
+            this.selectionContextLabel = '';
+            return;
+        }
+        const names = {
+            H1: 'Title',
+            H2: 'Heading',
+            H3: 'Heading',
+            P: 'Paragraph',
+            TD: 'Table cell',
+            TH: 'Header cell',
+            LI: 'List item',
+            B: 'Bold text',
+            STRONG: 'Bold text',
+            I: 'Italic text',
+            EM: 'Italic text',
+            IMG: 'Image'
+        };
+        let label = '';
+        let el = node;
+        while (el && el !== pv) {
+            const n = names[el.tagName];
+            if (n) {
+                label = n;
+                break;
+            }
+            el = el.parentElement;
+        }
+        this.selectionContextLabel = 'Editing: ' + (label || 'Page');
+    };
 
     // --- Table tools (visual mode): operate on the cell holding the caret ---
     _selectedTableCell() {
@@ -4893,6 +5159,9 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         if (!cmd) {
             return;
         }
+        if (/^(bold|italic|underline|foreColor|hiliteColor|fontName|fontSize)$/.test(cmd)) {
+            this._expandCaretToWord();
+        }
         try {
             document.execCommand('styleWithCSS', false, 'true');
             const ok = document.execCommand(cmd, false, value);
@@ -4953,6 +5222,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             }
             return;
         }
+        this._expandCaretToWord();
         try {
             document.execCommand('styleWithCSS', false, 'true');
             if (document.execCommand(cmd, false, value)) {
@@ -4989,6 +5259,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     _enterVisualMode(html) {
         this._visualOriginalCode = html;
         this._visualEnteredDom = null; // captured in renderedCallback after mount
+        this._parsePageSetup(html);
         this.showHtmlBodyVisual = true;
         // Reuse the preview pipeline, but flag the write as editable so
         // renderedCallback turns the rendered page into an editor.
@@ -5005,11 +5276,28 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
      */
     _pillifyTags(root) {
         const doc = root.ownerDocument || document;
+        // Repair pass: flatten any pill-inside-pill layering left behind by
+        // older bundles before wrapping anything new.
+        let nested = root.querySelectorAll('[data-dg-tag] [data-dg-tag]');
+        while (nested.length) {
+            for (const inner of nested) {
+                inner.replaceWith(doc.createTextNode(inner.textContent));
+            }
+            nested = root.querySelectorAll('[data-dg-tag] [data-dg-tag]');
+        }
         const walker = doc.createTreeWalker(root, NodeFilter.SHOW_TEXT);
         const targets = [];
         while (walker.nextNode()) {
             const node = walker.currentNode;
-            if (/\{[^{}]+\}/.test(node.nodeValue) && (!node.parentElement || node.parentElement.tagName !== 'STYLE')) {
+            const parent = node.parentElement;
+            // Never wrap inside <style>, and NEVER inside an existing pill —
+            // re-pillifying pill text nests a new layer on every insert.
+            if (
+                /\{[^{}]+\}/.test(node.nodeValue) &&
+                parent &&
+                parent.tagName !== 'STYLE' &&
+                !parent.closest('[data-dg-tag]')
+            ) {
                 targets.push(node);
             }
         }
@@ -5341,10 +5629,14 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         this.showImagePanel = true;
         await this._loadBodyIntoEditor();
         this._loadTemplateImages();
-        const body = this._lastUploadedHtmlText;
-        if (body && body.trim()) {
-            this._enterVisualMode(body);
+        let body = this._lastUploadedHtmlText;
+        if (!body || !body.trim()) {
+            // Blank template: seed a clean sheet so click-and-type just works.
+            body =
+                '<!DOCTYPE html>\n<html>\n<head>\n<meta charset="utf-8" />\n<style>\n@page { size: Letter portrait; margin: 0.75in; }\nbody { font-family: Helvetica, Arial, sans-serif; font-size: 10.5pt; color: #1a1a1a; }\n</style>\n</head>\n<body>\n<p>Start typing your document here — or drag in blocks, tags, and images from the rail.</p>\n</body>\n</html>\n';
+            this._syncHtmlBodyEditorDom(body);
         }
+        this._enterVisualMode(body);
     }
 
     handleCloseDesigner() {

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -2027,7 +2027,12 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 this.newTemplateObject = STARTER_OBJECTS[this.newStarterKey] || 'Account';
             }
             if (this.dataSourceMode === 'record' && !(this.newTemplateQuery || '').trim()) {
-                this.newTemplateQuery = await this._buildDefaultQueryConfig(this.newTemplateObject);
+                // Scratch builds get the RICH query — the author picks fields
+                // from the palette, so all usable fields must be available.
+                this.newTemplateQuery = await this._buildDefaultQueryConfig(
+                    this.newTemplateObject,
+                    this.isAuthoringScratch
+                );
             }
             await this.createTemplate();
         } finally {
@@ -2035,8 +2040,10 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         }
     }
 
-    /** Sensible default query from the object's describe — refinable later. */
-    async _buildDefaultQueryConfig(objectApiName) {
+    /** Sensible default query from the object's describe — refinable later.
+     *  rich=true (Start From Scratch): pull EVERY usable field (capped at 40)
+     *  and more relationships, so the tag palette isn't a six-field diet. */
+    async _buildDefaultQueryConfig(objectApiName, rich) {
         try {
             const [fields, rels] = await Promise.all([
                 getObjectFields({ objectName: objectApiName }),
@@ -2047,6 +2054,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             (fields || []).forEach((f) => {
                 typeOf[f.value] = f.type;
             });
+            const fieldCap = rich ? 40 : 6;
             const PREF = [
                 'Name',
                 'Industry',
@@ -2067,12 +2075,12 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 /^(Id|OwnerId|CreatedById|LastModifiedById|SystemModstamp|IsDeleted|CurrencyIsoCode|Jigsaw.*|CleanStatus|PhotoUrl)$/;
             const chosen = [];
             for (const p of PREF) {
-                if (chosen.length < 6 && names.includes(p)) {
+                if (chosen.length < fieldCap && names.includes(p)) {
                     chosen.push(p);
                 }
             }
             for (const f of names) {
-                if (chosen.length >= 6) {
+                if (chosen.length >= fieldCap) {
                     break;
                 }
                 if (!chosen.includes(f) && !SKIP.test(f) && !f.endsWith('Id') && GOOD.test(typeOf[f] || '')) {
@@ -2087,10 +2095,22 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             const NOISE =
                 /Histories|Feeds|Shares|Teams|ContentDocumentLinks|ProcessInstances|ActivityHistories|Emails|Events|Tasks|Notes|Attachments|DuplicateRecord|RecordAction|TopicAssign|Vote/i;
             const picked = [];
+            const relCap = rich ? 4 : 2;
+            const childCap = rich ? 8 : 4;
             for (const rp of RELPREF) {
                 const r = (rels || []).find((x) => x.value === rp);
-                if (r && picked.length < 2) {
+                if (r && picked.length < relCap) {
                     picked.push(r);
+                }
+            }
+            if (rich) {
+                for (const r of rels || []) {
+                    if (picked.length >= relCap) {
+                        break;
+                    }
+                    if (!picked.includes(r) && !NOISE.test(r.value)) {
+                        picked.push(r);
+                    }
                 }
             }
             if (!picked.length && rels && rels.length) {
@@ -2103,6 +2123,10 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 try {
                     const cf = await getObjectFields({ objectName: r.childObjectApiName });
                     const cnames = (cf || []).map((f) => f.value);
+                    const ctypeOf = {};
+                    (cf || []).forEach((f) => {
+                        ctypeOf[f.value] = f.type;
+                    });
                     const cchosen = [];
                     for (const p of [
                         'Name',
@@ -2119,8 +2143,23 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                         'Subject',
                         'Status'
                     ]) {
-                        if (cchosen.length < 4 && cnames.includes(p)) {
+                        if (cchosen.length < childCap && cnames.includes(p)) {
                             cchosen.push(p);
+                        }
+                    }
+                    if (rich) {
+                        for (const f of cnames) {
+                            if (cchosen.length >= childCap) {
+                                break;
+                            }
+                            if (
+                                !cchosen.includes(f) &&
+                                !SKIP.test(f) &&
+                                !f.endsWith('Id') &&
+                                GOOD.test(ctypeOf[f] || '')
+                            ) {
+                                cchosen.push(f);
+                            }
                         }
                     }
                     if (cchosen.length) {

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -374,7 +374,6 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     @track isSwitchingToHtml = false;
     @track docxSnapshotInfo = null;
     // Code ⇄ Preview toggles (textarea stays mounted-but-hidden so its value survives)
-    @track showHtmlBodyPreview = false;
     @track showDocxHtmlPreview = false;
     // Tags palette (click-to-insert merge tags from the template's own schema)
     @track showTagPanel = false;
@@ -3242,7 +3241,6 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             this.docxSnapshotInfo = null;
             this.isLoadingDocxHtml = false;
             this.isSwitchingToHtml = false;
-            this.showHtmlBodyPreview = false;
             this.showDocxHtmlPreview = false;
             this.showImagePanel = false;
             this.templateImages = [];
@@ -4666,18 +4664,12 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     }
 
     // --- Format Code + Code ⇄ Preview (shared by the HTML editor and the DOCX viewer) ---
-    get htmlBodyPreviewToggleLabel() {
-        return this.showHtmlBodyPreview ? 'Show Code' : 'Preview';
-    }
-
     get docxHtmlPreviewToggleLabel() {
         return this.showDocxHtmlPreview ? 'Show Code' : 'Preview';
     }
 
     get htmlBodyEditorClass() {
-        return this.showHtmlBodyPreview || this.showHtmlBodyVisual
-            ? 'dg-html-body-editor slds-hide'
-            : 'dg-html-body-editor';
+        return this.showHtmlBodyVisual ? 'dg-html-body-editor slds-hide' : 'dg-html-body-editor';
     }
 
     get visualToggleLabel() {
@@ -4710,7 +4702,6 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     _enterVisualMode(html) {
         this._visualOriginalCode = html;
         this._visualEnteredDom = null; // captured in renderedCallback after mount
-        this.showHtmlBodyPreview = false;
         this.showHtmlBodyVisual = true;
         // Reuse the preview pipeline, but flag the write as editable so
         // renderedCallback turns the rendered page into an editor.
@@ -4825,21 +4816,12 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         }
     }
 
-    handleToggleHtmlPreview(event) {
-        const isDocx = event.currentTarget.dataset.target === 'docx';
-        if (isDocx) {
-            this.showDocxHtmlPreview = !this.showDocxHtmlPreview;
-            if (this.showDocxHtmlPreview) {
-                this._renderHtmlPreview('.dg-docx-preview', '.dg-docx-html-editor');
-            }
-        } else {
-            if (this.showHtmlBodyVisual) {
-                this._exitVisualMode();
-            }
-            this.showHtmlBodyPreview = !this.showHtmlBodyPreview;
-            if (this.showHtmlBodyPreview) {
-                this._renderHtmlPreview('.dg-body-preview', '.dg-html-body-editor');
-            }
+    // Preview exists only on the DOCX converted-HTML viewer — the HTML body
+    // editor's Visual mode IS the preview (same render, plus editing).
+    handleToggleHtmlPreview() {
+        this.showDocxHtmlPreview = !this.showDocxHtmlPreview;
+        if (this.showDocxHtmlPreview) {
+            this._renderHtmlPreview('.dg-docx-preview', '.dg-docx-html-editor');
         }
     }
 

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -17,6 +17,15 @@ import {
     buildBlockPalette
 } from './docGenAuthoringKit';
 
+// Each predesigned starter carries its natural object — the wizard's starter
+// path never asks for one (Advanced options exposes the picker for overrides).
+const STARTER_OBJECTS = {
+    report: 'Account',
+    invoice: 'Opportunity',
+    letter: 'Contact',
+    agreement: 'Account'
+};
+
 // Apex
 import getAllTemplates from '@salesforce/apex/DocGenController.getAllTemplates';
 import deleteTemplate from '@salesforce/apex/DocGenController.deleteTemplate';
@@ -311,6 +320,13 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     @track isAutoCreating = false;
     @track newTemplateLogoName = '';
     _logoFile = null;
+    // Starter/AI paths hide the power-user fields behind this toggle.
+    @track showAdvancedOptions = false;
+    // AI wizard step: assets the prompt can reference + the paste-back box.
+    @track wizardAssets = [];
+    _aiPastedHtml = null;
+    // Logo control: 'none' | asset id | 'upload'.
+    @track newTemplateLogoChoice = 'none';
     @track newTemplateSampleRecordId = '';
     @track sampleRecordData = null;
     isCreating = true;
@@ -1265,6 +1281,93 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             document.removeEventListener('selectionchange', this._onSelectionChange);
             this._selListenerAdded = false;
         }
+        if (this._docMouseListenerAdded) {
+            document.removeEventListener('mousedown', this._onDocMouseDown, true);
+            this._docMouseListenerAdded = false;
+        }
+    }
+
+    /**
+     * Yank focus and caret back from Lightning's global-search box after its
+     * "/" hotkey fired while the user was typing in the visual canvas, then
+     * insert the "/" they typed. See the key-trap comment in renderedCallback.
+     */
+    _recoverStolenSlash() {
+        // The search dialog keeps re-grabbing focus asynchronously while it
+        // opens, so a single focus() call loses the race — retry until the
+        // canvas HOLDS focus, inserting the "/" exactly once.
+        let inserted = false;
+        const attempt = (triesLeft) => {
+            try {
+                const host = this.template.querySelector('.dg-visual-host');
+                const pv = host && host.querySelector('.dg-pv');
+                if (!pv) {
+                    return;
+                }
+                pv.focus();
+                const s = window.getSelection();
+                if (this._lastCanvasRange) {
+                    s.removeAllRanges();
+                    s.addRange(this._lastCanvasRange);
+                }
+                if (this._canvasFocused && !inserted) {
+                    inserted = true;
+                    document.execCommand('insertText', false, '/');
+                    this.htmlEditorDirty = true;
+                    this._maybePillifyTyped();
+                }
+                if (triesLeft > 0) {
+                    // eslint-disable-next-line @lwc/lwc/no-async-operation
+                    setTimeout(() => {
+                        if (!this._canvasFocused) {
+                            attempt(triesLeft - 1);
+                        }
+                    }, 220);
+                }
+            } catch (e) {
+                /* best effort */
+            }
+        };
+        attempt(5);
+    }
+
+    /**
+     * Word-style "click and type": place the caret exactly where the user
+     * double-clicked. Inside existing content the browser range is used
+     * directly; in empty space below the last block, a fresh paragraph is
+     * created there so typing can start immediately.
+     */
+    _placeCaretAtPoint(e, pv) {
+        try {
+            const sel = window.getSelection();
+            let range = null;
+            if (document.caretRangeFromPoint) {
+                range = document.caretRangeFromPoint(e.clientX, e.clientY);
+            } else if (document.caretPositionFromPoint) {
+                const pos = document.caretPositionFromPoint(e.clientX, e.clientY);
+                if (pos) {
+                    range = document.createRange();
+                    range.setStart(pos.offsetNode, pos.offset);
+                }
+            }
+            const blocks = Array.from(pv.children).filter((c) => !c.matches('style'));
+            const last = blocks[blocks.length - 1];
+            const belowContent = last && e.clientY > last.getBoundingClientRect().bottom + 4;
+            if (belowContent || !range || !pv.contains(range.startContainer)) {
+                const p = document.createElement('p');
+                p.appendChild(document.createElement('br'));
+                pv.appendChild(p);
+                range = document.createRange();
+                range.setStart(p, 0);
+                this.htmlEditorDirty = true;
+            }
+            range.collapse(true);
+            sel.removeAllRanges();
+            sel.addRange(range);
+            pv.focus();
+        } catch (err) {
+            /* caret placement is best-effort */
+        }
     }
 
     renderedCallback() {
@@ -1346,16 +1449,69 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                             if (pill) {
                                 e.preventDefault();
                                 this._beginPillEdit(pill);
+                                return;
                             }
+                            // Word-style click-and-type: double-click empty page
+                            // space starts a cursor right there.
+                            this._placeCaretAtPoint(e, pv);
                         });
                         // Column resize: grab a cell's right edge and drag.
                         pv.addEventListener('mousemove', (e) => this._tableResizeHover(e, pv));
                         pv.addEventListener('mousedown', (e) => this._tableResizeStart(e, pv));
-                        // Keep keystrokes OURS: Lightning binds "/" (and more)
-                        // to global shortcuts and doesn't recognize manual-DOM
-                        // contenteditable as an editing context.
-                        pv.addEventListener('keydown', (e) => e.stopPropagation());
-                        pv.addEventListener('keypress', (e) => e.stopPropagation());
+                        // Keep keystrokes OURS: Lightning binds "/" (and more) to
+                        // global shortcuts via a capture-phase listener high in the
+                        // tree, so stopping propagation at the page is too late.
+                        // Trap at the window in capture phase — fires before
+                        // Lightning's hotkey handler — and stop only events that
+                        // originate inside the editable page. preventDefault is
+                        // NOT called, so typing itself is untouched.
+                        // Synthetic shadow retargets e.target for listeners
+                        // outside the component, so the trap can't identify the
+                        // canvas from the event — track focus from INSIDE it.
+                        pv.addEventListener('focusin', () => {
+                            this._canvasFocused = true;
+                        });
+                        pv.addEventListener('keydown', (e) => {
+                            // Track typing recency for the "/" recovery below.
+                            // Only content keys — Tab/arrows must not count, or
+                            // tabbing away right after typing would false-match.
+                            if (e.key && (e.key.length === 1 || e.key === 'Backspace' || e.key === 'Enter')) {
+                                this._lastCanvasKeyTs = Date.now();
+                            }
+                            e.stopPropagation();
+                        });
+                        // Lightning's "/" global-search hotkey preempts us
+                        // completely: its window-capture handler runs first,
+                        // preventDefaults, stops propagation (the canvas never
+                        // sees the keydown), and focuses the search box. LWS
+                        // never delivers window-capture listeners to component
+                        // code, so the ONLY reliable signal is the SYMPTOM: a
+                        // focusout to the search input (saInput) while the user
+                        // was mid-typing with no mouse involved. On that
+                        // signature, steal focus back, restore the caret, and
+                        // type the "/" the user actually pressed.
+                        pv.addEventListener('focusout', (e) => {
+                            this._canvasFocused = false;
+                            this._canvasBlurTs = Date.now();
+                            const rt = e.relatedTarget;
+                            const toSearchBox = rt && String(rt.className || '').indexOf('saInput') !== -1;
+                            const typedRecently = this._lastCanvasKeyTs && Date.now() - this._lastCanvasKeyTs < 1500;
+                            const mousedRecently = this._lastDocMouseTs && Date.now() - this._lastDocMouseTs < 150;
+                            if (toSearchBox && typedRecently && !mousedRecently) {
+                                // eslint-disable-next-line @lwc/lwc/no-async-operation
+                                setTimeout(() => this._recoverStolenSlash(), 120);
+                            }
+                        });
+                        // Distinguishes hotkey focus-theft from a deliberate
+                        // click into global search (document listeners DO fire
+                        // for component code — see _onSelectionChange).
+                        if (!this._docMouseListenerAdded) {
+                            this._onDocMouseDown = () => {
+                                this._lastDocMouseTs = Date.now();
+                            };
+                            document.addEventListener('mousedown', this._onDocMouseDown, true);
+                            this._docMouseListenerAdded = true;
+                        }
                         // Land ready-to-type: focus the page with the caret at
                         // the first text block so the cursor is never a hunt.
                         try {
@@ -1398,14 +1554,80 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     get isStep3() {
         return this.currentWizardStep === '3';
     }
+    /** Dedicated AI step: prompt + assets + paste-back, no query builder. */
+    get isStepAi() {
+        return this.currentWizardStep === 'ai';
+    }
+    get isStepAiOrLater() {
+        return this.currentWizardStep !== '1';
+    }
+    get hideWizardFooterNext() {
+        if (this.currentWizardStep === '3' || this.currentWizardStep === 'ai') {
+            return true;
+        }
+        // One place to move forward: on Step 1 the starter/AI paths advance
+        // ONLY via their in-card button; the footer Next belongs to the file
+        // path. Query refinement lives in the template's Query Configuration
+        // tab after creation, not in a parallel wizard branch.
+        return this.currentWizardStep === '1' && !this.isAuthoringFile;
+    }
+
+    // --- Step-1 declutter: starter/AI paths hide power-user fields ---
+    get showStep1AdvancedFields() {
+        return this.isAuthoringFile || this.showAdvancedOptions;
+    }
+    /** Starters bring their own object+query — hide the picker on that path. */
+    get showBaseObjectField() {
+        return this.isRecordDataSource && (!this.isAuthoringStarter || this.showAdvancedOptions);
+    }
+    get showAdvancedToggle() {
+        return !this.isAuthoringFile;
+    }
+    get advancedToggleLabel() {
+        return this.showAdvancedOptions
+            ? 'Hide advanced options'
+            : 'Advanced options (API name, category, data source)';
+    }
+    handleToggleAdvanced() {
+        this.showAdvancedOptions = !this.showAdvancedOptions;
+    }
     get isBackDisabled() {
         return this.currentWizardStep === '1';
     }
+    /** Progress ring value — the AI screen maps to the "Pick Your Data" slot. */
+    get wizardProgressStep() {
+        return this.currentWizardStep === 'ai' ? '2' : this.currentWizardStep;
+    }
 
-    handleNextStep() {
+    async handleNextStep() {
         if (this.currentWizardStep === '1') {
             if (!this.newTemplateName || !this.newTemplateType) {
                 this.showToast('Error', 'Please fill in the template name and type.', 'error');
+                return;
+            }
+            // AI path: skip the query builder entirely. Auto-build a sensible
+            // query for the prompt, load shared assets it can reference, and
+            // land on the prompt + paste screen.
+            if (this.isAuthoringAi && this.dataSourceMode === 'record') {
+                if (!this.newTemplateObject) {
+                    this.showToast('Pick an object', 'Choose the Base Object this document is about.', 'error');
+                    return;
+                }
+                this.isAutoCreating = true;
+                try {
+                    if (!(this.newTemplateQuery || '').trim()) {
+                        this.newTemplateQuery = await this._buildDefaultQueryConfig(this.newTemplateObject);
+                    }
+                    await this._loadWizardAssets();
+                } finally {
+                    this.isAutoCreating = false;
+                }
+                this.currentWizardStep = 'ai';
+                return;
+            }
+            if (this.isAuthoringAi && this.dataSourceMode === 'flow') {
+                await this._loadWizardAssets();
+                this.currentWizardStep = 'ai';
                 return;
             }
             // JSON Data (from Flow) data source: no SOQL, no provider class.
@@ -1465,7 +1687,9 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     }
 
     handlePrevStep() {
-        if (this.currentWizardStep === '3') {
+        if (this.currentWizardStep === 'ai') {
+            this.currentWizardStep = '1';
+        } else if (this.currentWizardStep === '3') {
             // JSON-flow templates skip Step 2 going forward; mirror that going back
             // so the user lands on Step 1 (where they can re-pick the data source).
             this.currentWizardStep = this.dataSourceMode === 'flow' ? '1' : '2';
@@ -1474,9 +1698,59 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         }
     }
 
+    /** Shared image assets shown on the AI step and named in the prompt. */
+    async _loadWizardAssets() {
+        try {
+            const assets = (await getAssets()) || [];
+            this.wizardAssets = assets.map((a) => ({
+                id: a.id,
+                name: a.name,
+                mergeTag: a.mergeTag || '{%asset:' + a.assetKey + '}'
+            }));
+        } catch (e) {
+            this.wizardAssets = [];
+        }
+    }
+
+    get hasWizardAssets() {
+        return (this.wizardAssets || []).length > 0;
+    }
+
+    /** Paste step is "3" after the assets step, "2" when there are no assets yet. */
+    get aiPasteStepNum() {
+        return this.hasWizardAssets ? '3' : '2';
+    }
+
+    handleAssetTagCopy(event) {
+        const tag = event.currentTarget.dataset.tag;
+        if (tag) {
+            this._copyToClipboard(tag, tag + ' copied — the AI prompt already lists it too.');
+        }
+    }
+
+    handleAiPasteChange(event) {
+        this._aiPastedHtml = event.target.value;
+    }
+
+    /** AI step finale: create the template with the pasted HTML staged as its body. */
+    async handleAiCreateFromPaste() {
+        const ta = this.template.querySelector('.dg-ai-paste');
+        if (ta) {
+            this._aiPastedHtml = ta.value;
+        }
+        this.isAutoCreating = true;
+        try {
+            await this.createTemplate();
+        } finally {
+            this.isAutoCreating = false;
+        }
+    }
+
     handleWizardTabActive() {
         this.activeMainTab = 'new_template';
         this.resetForm();
+        // Existing shared assets feed the logo picker and the AI prompt.
+        this._loadWizardAssets();
     }
 
     handleTabActive(event) {
@@ -1563,6 +1837,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     get starterCards() {
         return STARTERS.map((s) => ({
             ...s,
+            targetObject: STARTER_OBJECTS[s.key] || 'Account',
             selected: this.newStarterKey === s.key,
             cardClass: this.newStarterKey === s.key ? 'dg-starter-card dg-starter-card_selected' : 'dg-starter-card'
         }));
@@ -1597,6 +1872,50 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
 
     handleStarterSelect(event) {
         this.newStarterKey = event.currentTarget.dataset.key;
+        // Predesigned templates carry their natural object — no object picker
+        // on this path (Advanced options exposes it for power users).
+        if (!this.showAdvancedOptions) {
+            const obj = STARTER_OBJECTS[this.newStarterKey] || 'Account';
+            if (obj !== this.newTemplateObject) {
+                this.newTemplateObject = obj;
+                this.newTemplateQuery = '';
+                this.newTemplateSampleRecordId = null;
+            }
+        }
+    }
+
+    /** Logo control: pick an existing shared asset or upload a new image. */
+    get logoChoiceOptions() {
+        const opts = [{ label: 'No logo', value: 'none' }];
+        for (const a of this.wizardAssets || []) {
+            opts.push({ label: a.name + ' — ' + a.mergeTag, value: a.id });
+        }
+        opts.push({ label: 'Upload a new image…', value: 'upload' });
+        return opts;
+    }
+
+    get showLogoUpload() {
+        return this.newTemplateLogoChoice === 'upload';
+    }
+
+    handleLogoChoiceChange(event) {
+        this.newTemplateLogoChoice = event.detail.value;
+        if (this.newTemplateLogoChoice !== 'upload') {
+            this._logoFile = null;
+            this.newTemplateLogoName = '';
+        }
+    }
+
+    /** Merge tag the starter's logo slots should carry, per the user's choice. */
+    get _chosenLogoTag() {
+        const choice = this.newTemplateLogoChoice;
+        if (choice && choice !== 'none' && choice !== 'upload') {
+            const a = (this.wizardAssets || []).find((x) => x.id === choice);
+            if (a) {
+                return a.mergeTag;
+            }
+        }
+        return '{%asset:logo}';
     }
 
     handleLogoSelected(event) {
@@ -1630,6 +1949,11 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         }
         this.isAutoCreating = true;
         try {
+            // Predesigned path with the object picker hidden: the starter's
+            // natural object drives the auto-built query.
+            if (this.isAuthoringStarter && !this.showAdvancedOptions) {
+                this.newTemplateObject = STARTER_OBJECTS[this.newStarterKey] || 'Account';
+            }
             if (this.dataSourceMode === 'record' && !(this.newTemplateQuery || '').trim()) {
                 this.newTemplateQuery = await this._buildDefaultQueryConfig(this.newTemplateObject);
             }
@@ -1786,7 +2110,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         const shape = extractQueryShape(this.newTemplateQuery, this.newTemplateObject);
         return buildAiPrompt(shape, {
             dataSourceMode: this.dataSourceMode,
-            providerFields: (this.providerFields || []).map((f) => f.name || f)
+            providerFields: (this.providerFields || []).map((f) => f.name || f),
+            assets: this.wizardAssets
         });
     }
 
@@ -3256,6 +3581,9 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         const starterKey = this.newStarterKey;
         const starterShape =
             authoringMode === 'starter' ? extractQueryShape(this.newTemplateQuery, this.newTemplateObject) : null;
+        const aiPastedHtml = (this._aiPastedHtml || '').trim();
+        this._aiPastedHtml = null;
+        const chosenLogoTag = this._chosenLogoTag;
 
         try {
             const record = await createRecord({ apiName: DOCGEN_TEMPLATE_OBJECT.objectApiName, fields });
@@ -3295,13 +3623,17 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             this.openEditModal(newRow, 'document');
             if (authoringMode === 'starter') {
                 await this._ensureLogoAsset(record.id);
-                await this._applyStarterBody(record.id, starterKey, starterShape);
+                await this._applyStarterBody(record.id, starterKey, starterShape, chosenLogoTag);
                 // Land straight in the full-screen designer with the starter open.
                 this.isEditModalOpen = false;
                 await this._openDesignerSurface();
             } else if (authoringMode === 'ai') {
                 await this._ensureLogoAsset(record.id);
-                // AI path: designer opens in code view, ready for the paste-back.
+                // AI path: the wizard's paste-back becomes the staged body; if
+                // nothing was pasted, the designer opens ready for it.
+                if (aiPastedHtml) {
+                    await this._applyPastedBody(record.id, aiPastedHtml, newRow.Name);
+                }
                 this.isEditModalOpen = false;
                 await this._openDesignerSurface();
             }
@@ -3315,9 +3647,14 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
      * fields and attach it as the template body, so the very first "Save as
      * New Version" click produces a working v1 that renders on Generate.
      */
-    async _applyStarterBody(templateId, starterKey, shape) {
+    async _applyStarterBody(templateId, starterKey, shape, logoTag) {
         try {
-            const html = buildStarterHtml(starterKey, shape);
+            let html = buildStarterHtml(starterKey, shape);
+            // Starter bodies carry {%asset:logo} slots; an existing asset picked
+            // in the wizard swaps its own merge tag in.
+            if (logoTag && logoTag !== '{%asset:logo}') {
+                html = html.split('{%asset:logo}').join(logoTag);
+            }
             const fileName = (this.selectedStarterLabelFor(starterKey) || 'Starter').replace(/[^\w]+/g, '_') + '.html';
             const bodyResult = await saveHtmlTemplateBody({ templateId, fileName, htmlContent: html });
             this.currentFileId = bodyResult.contentDocumentId;
@@ -3349,6 +3686,40 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     selectedStarterLabelFor(key) {
         const s = STARTERS.find((x) => x.key === key);
         return s ? s.label : '';
+    }
+
+    /**
+     * AI path: the HTML pasted on the wizard's AI step becomes the staged
+     * template body, so the designer opens on the finished document.
+     */
+    async _applyPastedBody(templateId, html, templateName) {
+        try {
+            const fileName = (templateName || 'AI_Template').replace(/[^\w]+/g, '_') + '.html';
+            const bodyResult = await saveHtmlTemplateBody({ templateId, fileName, htmlContent: html });
+            this.currentFileId = bodyResult.contentDocumentId;
+            this.uploadedContentVersionId = bodyResult.contentVersionId;
+            this.uploadedFileName = fileName;
+            this._lastUploadedHtmlText = html;
+            this.stagedBodySource = 'editor';
+            this.htmlEditorDirty = false;
+            if (/@page\b/i.test(html)) {
+                this.editHtmlBodyOwnsPageRule = true;
+                this.editTemplatePageOrientation = null;
+                this.editTemplatePageSize = null;
+                this.editTemplatePageMargins = null;
+                this.editTemplateCustomMargins = '';
+            }
+            this.showHtmlBodyEditor = true;
+            this._syncHtmlBodyEditorDom(html);
+            this.showToast(
+                'AI design attached',
+                'Your pasted HTML is staged — review it, then "Save as New Version" activates it.',
+                'success'
+            );
+        } catch (err) {
+            const msg = err && err.body && err.body.message ? err.body.message : (err && err.message) || String(err);
+            this.showToast('Paste attach failed', msg, 'error');
+        }
     }
 
     // --- Row Action ---
@@ -5322,6 +5693,16 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             this.selectionContextLabel = '';
             return;
         }
+        // Stash the live caret so the "/" hotkey recovery can restore it after
+        // Lightning's global-search handler steals focus.
+        try {
+            const sel = window.getSelection();
+            if (sel && sel.rangeCount) {
+                this._lastCanvasRange = sel.getRangeAt(0).cloneRange();
+            }
+        } catch (e) {
+            /* best effort */
+        }
         const names = {
             H1: 'Title',
             H2: 'Heading',
@@ -6714,6 +7095,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         this._logoFile = null;
         this.newTemplateLogoName = '';
         this.isAutoCreating = false;
+        this.showAdvancedOptions = false;
+        this.newTemplateLogoChoice = 'none';
         this.newTemplateType = 'HTML';
         this.newTemplateDesc = '';
         this.newTemplateQuery = '';

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -1469,6 +1469,18 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 sel.value = want;
             }
         }
+        // Header/Footer panel textareas: sync tracked values into the DOM
+        // (LWC textareas have no value binding); skip while focused.
+        if (this.activePanel === 'hf') {
+            const hta = this.template.querySelector('.dg-hf-header');
+            if (hta && hta !== document.activeElement && hta.value !== (this.editTemplateHeaderHtml || '')) {
+                hta.value = this.editTemplateHeaderHtml || '';
+            }
+            const fta = this.template.querySelector('.dg-hf-footer');
+            if (fta && fta !== document.activeElement && fta.value !== (this.editTemplateFooterHtml || '')) {
+                fta.value = this.editTemplateFooterHtml || '';
+            }
+        }
         // Searchable panel just opened — put the cursor in its search box.
         if (this._focusPanelSearch) {
             const inp = this.template.querySelector('.dg-panel-search');
@@ -6006,6 +6018,29 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             if (table && !table.querySelector('td, th')) {
                 table.remove();
             }
+        } else if (action === 'repeatHeader') {
+            // {RepeatHeader} in the header row makes it repeat on every PDF
+            // page (the v2.9 large-table behavior). Toggle it.
+            const headerRow = (table.tHead && table.tHead.rows[0]) || table.rows[0];
+            const firstCell = headerRow && headerRow.cells[0];
+            if (firstCell) {
+                const existing = Array.from(headerRow.querySelectorAll('[data-dg-tag]')).find((pl) =>
+                    /repeatheader/i.test(pl.textContent)
+                );
+                if (existing) {
+                    existing.remove();
+                    this.showToast('Repeat header off', 'This table header no longer repeats on every page.', 'info');
+                } else {
+                    firstCell.insertBefore(document.createTextNode('{RepeatHeader}'), firstCell.firstChild);
+                    this._pillifyTags(firstCell);
+                    this.showToast(
+                        'Repeat header on',
+                        'The header row now repeats at the top of every PDF page this table spans.',
+                        'success'
+                    );
+                }
+                this.htmlEditorDirty = true;
+            }
         } else if (action === 'headerRow') {
             for (const c of row.children) {
                 c.style.background = '#1f3a5f';
@@ -6397,6 +6432,11 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                     key: 'currency',
                     label: 'Currency',
                     options: [
+                        opt(
+                            'cur_auto',
+                            "Record's currency (multi-currency orgs) — recommended",
+                            '{' + f + ':currency:auto}'
+                        ),
                         opt('currency', "User's currency — $1,234.00", '{' + f + ':currency}'),
                         cur('USD', '$1,234.56'),
                         cur('EUR', '1.234,56 €'),
@@ -6415,7 +6455,12 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                     key: 'dates',
                     label: 'Dates',
                     options: [
-                        opt('date_user', "User's locale date", '{' + f + ':date}'),
+                        opt('date_user', "Reader's locale date (auto)", '{' + f + ':date}'),
+                        opt('date_gb', 'UK locale — 17/04/2026', '{' + f + ':date:en_GB}'),
+                        opt('date_de', 'German locale — 17.04.2026', '{' + f + ':date:de_DE}'),
+                        opt('date_fr', 'French locale — 17/04/2026', '{' + f + ':date:fr_FR}'),
+                        opt('date_jp', 'Japanese locale — 2026/04/17', '{' + f + ':date:ja_JP}'),
+                        opt('date_br', 'Brazilian locale — 17/04/2026', '{' + f + ':date:pt_BR}'),
                         dt('MMMM d, yyyy', 'April 17, 2026 — US long'),
                         dt('MMM d, yyyy', 'Apr 17, 2026'),
                         dt('MM/dd/yyyy', '04/17/2026 — US'),
@@ -6434,6 +6479,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                     label: 'Numbers',
                     options: [
                         opt('number', 'Number — 1,234', '{' + f + ':number}'),
+                        opt('number_eu', 'Number EU — 1.234', '{' + f + ':number:de_DE}'),
+                        opt('percent_eu', 'Percent EU — 15,5%', '{' + f + ':percent:de_DE}'),
                         dt('#,##0.00', '1,234.50 — two decimals'),
                         dt('#,##0', '1,235 — whole'),
                         dt('0.00', '1234.50 — no thousands'),
@@ -6993,6 +7040,45 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         return (this.templates || []).filter((t) => t[F.Type] === 'HTML').map((t) => ({ label: t.Name, value: t.Id }));
     }
 
+    // --- Header / Footer panel (repeats on every PDF page) ---
+    handleDesignerHeaderChange(event) {
+        this.editTemplateHeaderHtml = event.target.value;
+        this.htmlEditorDirty = true;
+    }
+    handleDesignerFooterChange(event) {
+        this.editTemplateFooterHtml = event.target.value;
+        this.htmlEditorDirty = true;
+    }
+    handleHfFocus(event) {
+        this._lastHfFocus = event.target.dataset.hf;
+    }
+    handleHfTokenInsert(event) {
+        // Token keys, not literal tags — LWC decodes entities in attributes
+        // BEFORE expression parsing, so brace literals can't live in markup.
+        const TOKS = {
+            pagexy: 'Page {PageNumber} of {TotalPages}',
+            pagenum: '{PageNumber}',
+            pagetotal: '{TotalPages}',
+            today: '{Today:MMMM d, yyyy}',
+            name: '{Name}'
+        };
+        const tok = TOKS[event.currentTarget.dataset.tok];
+        const which = this._lastHfFocus === 'header' ? 'header' : 'footer';
+        const ta = this.template.querySelector(which === 'header' ? '.dg-hf-header' : '.dg-hf-footer');
+        if (!ta || !tok) {
+            return;
+        }
+        const st = typeof ta.selectionStart === 'number' ? ta.selectionStart : ta.value.length;
+        const en = typeof ta.selectionEnd === 'number' ? ta.selectionEnd : st;
+        ta.value = ta.value.slice(0, st) + tok + ta.value.slice(en);
+        if (which === 'header') {
+            this.editTemplateHeaderHtml = ta.value;
+        } else {
+            this.editTemplateFooterHtml = ta.value;
+        }
+        this.htmlEditorDirty = true;
+    }
+
     async handleDesignerTemplateSwitch(event) {
         const id = event.detail.value;
         if (!id || id === this.editTemplateId) {
@@ -7120,10 +7206,20 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     get isPanelWatermark() {
         return this.activePanel === 'watermark';
     }
+    get isPanelHf() {
+        return this.activePanel === 'hf';
+    }
+    get showPanelSearch() {
+        return !this.isPanelWatermark && !this.isPanelHf;
+    }
     get floatPanelTitle() {
-        return { insert: 'Insert blocks', tags: 'Merge tags', images: 'Image assets', watermark: 'Watermark' }[
-            this.activePanel
-        ];
+        return {
+            insert: 'Insert blocks',
+            tags: 'Merge tags',
+            images: 'Image assets',
+            watermark: 'Watermark',
+            hf: 'Header & Footer'
+        }[this.activePanel];
     }
     get panelSearchPlaceholder() {
         return this.activePanel === 'tags' ? 'Search fields, loops, charts…' : 'Search…';
@@ -7428,7 +7524,35 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
 
     get tagPaletteSections() {
         const shape = extractQueryShape(this.editTemplateQuery, this.editTemplateObject);
-        return buildTagPalette(shape);
+        const sections = buildTagPalette(shape);
+        // Signer form fields ({?key}) configured on the Signer Inputs tab.
+        try {
+            const cfg = (this.editFormFieldsConfig || '').trim();
+            if (cfg.startsWith('{')) {
+                const parsed = JSON.parse(cfg);
+                if (Array.isArray(parsed.formFields) && parsed.formFields.length) {
+                    sections.push({
+                        key: 'formfields',
+                        label: 'Signer form fields',
+                        hint: 'Filled in by the signer during e-signing. Configure keys under Edit Template → Signer Inputs.',
+                        items: parsed.formFields.map((ff) => ({
+                            key: 'ff_' + ff.key,
+                            label: ff.label || ff.key,
+                            snippet: '{?' + ff.key + '}',
+                            title:
+                                '{?' +
+                                ff.key +
+                                "} — the signer's answer. Add a default with {?" +
+                                ff.key +
+                                '|fallback}.'
+                        }))
+                    });
+                }
+            }
+        } catch (e) {
+            /* malformed config — skip */
+        }
+        return sections;
     }
 
     toggleTagPanel() {

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -1506,7 +1506,15 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                         });
                         // Column resize: grab a cell's right edge and drag.
                         pv.addEventListener('mousemove', (e) => this._tableResizeHover(e, pv));
-                        pv.addEventListener('mousedown', (e) => this._tableResizeStart(e, pv));
+                        pv.addEventListener('mousedown', (e) => {
+                            // Nested-contenteditable blur is unreliable — a click
+                            // outside an in-edit pill commits it explicitly, so
+                            // the user is never "caught" inside the pill.
+                            if (this._editingPill && !this._editingPill.contains(e.target) && this._finishPillEdit) {
+                                this._finishPillEdit();
+                            }
+                            this._tableResizeStart(e, pv);
+                        });
                         // Chip drops staged by the document-level drag listener
                         // execute HERE — pv listeners are the context where DOM
                         // insertion reliably works under LWS.
@@ -6381,6 +6389,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         pill.setAttribute('contenteditable', 'true');
         pill.style.borderStyle = 'dashed';
         pill.style.cursor = 'text';
+        this._editingPill = pill;
         try {
             const range = document.createRange();
             range.selectNodeContents(pill);
@@ -6391,6 +6400,10 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             /* selection best-effort */
         }
         const finish = () => {
+            if (this._editingPill !== pill) {
+                return; // already committed (blur + outside-click both fired)
+            }
+            this._editingPill = null;
             pill.removeEventListener('blur', finish);
             let t = (pill.textContent || '').trim();
             if (!t || t === '{}' || t === '{' || t === '}') {
@@ -6408,12 +6421,31 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             pill.setAttribute('contenteditable', 'false');
             pill.style.cssText = this._pillStyleFor(t);
             this.htmlEditorDirty = true;
+            // Park the caret AFTER the pill — leaving it inside means the next
+            // keystrokes grow the pill instead of typing beside it.
+            try {
+                const host = this.template.querySelector('.dg-visual-host');
+                const pv = host && host.querySelector('.dg-pv');
+                const r = document.createRange();
+                r.setStartAfter(pill);
+                r.collapse(true);
+                const s = window.getSelection();
+                s.removeAllRanges();
+                s.addRange(r);
+                if (pv) {
+                    pv.focus();
+                }
+            } catch (e) {
+                /* caret parking best-effort */
+            }
         };
+        this._finishPillEdit = finish;
         pill.addEventListener('blur', finish);
         pill.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter') {
+            if (e.key === 'Enter' || e.key === 'Escape') {
                 e.preventDefault();
-                pill.blur();
+                e.stopPropagation();
+                finish();
             }
         });
         pill.focus();

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -12,7 +12,8 @@ import {
     buildStarterHtml,
     buildAiPrompt,
     prettyPrintHtml,
-    scopeHtmlForInlinePreview
+    scopeHtmlForInlinePreview,
+    buildTagPalette
 } from './docGenAuthoringKit';
 
 // Apex
@@ -50,6 +51,7 @@ import clearWatermarkImage from '@salesforce/apex/DocGenController.clearWatermar
 import searchDataProviders from '@salesforce/apex/DocGenController.searchDataProviders';
 import getHtmlTemplateBody from '@salesforce/apex/DocGenController.getHtmlTemplateBody';
 import getConvertedHtmlSnapshot from '@salesforce/apex/DocGenController.getConvertedHtmlSnapshot';
+import listHtmlTemplateImages from '@salesforce/apex/DocGenController.listHtmlTemplateImages';
 import validateDataProvider from '@salesforce/apex/DocGenController.validateDataProvider';
 
 // Schema
@@ -374,6 +376,18 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     // Code ⇄ Preview toggles (textarea stays mounted-but-hidden so its value survives)
     @track showHtmlBodyPreview = false;
     @track showDocxHtmlPreview = false;
+    // Tags palette (click-to-insert merge tags from the template's own schema)
+    @track showTagPanel = false;
+    // Images panel (upload/insert <img> tags without knowing shepherd URLs)
+    @track showImagePanel = false;
+    @track isLoadingTemplateImages = false;
+    @track isUploadingInsertImage = false;
+    @track templateImages = [];
+    // Visual (WYSIWYG) mode — rich-text editing of the body content while the
+    // template's <style>/@page shell is preserved and reapplied on exit.
+    @track showHtmlBodyVisual = false;
+    @track visualEditorHtml = '';
+    _visualShellStyles = null;
     // Last HTML body text this session touched (upload, starter, or Apply) so
     // reopening the editor doesn't need a server round-trip.
     _lastUploadedHtmlText = null;
@@ -3207,6 +3221,14 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             this.isSwitchingToHtml = false;
             this.showHtmlBodyPreview = false;
             this.showDocxHtmlPreview = false;
+            this.showImagePanel = false;
+            this.templateImages = [];
+            this.showTagPanel = false;
+            this.showHtmlBodyVisual = false;
+            this.visualEditorHtml = '';
+            this._visualShellStyles = null;
+            this._visualOriginalCode = null;
+            this._visualEnteredHtml = null;
 
             let cdLinks = [];
             if (row.ContentDocumentLinks) {
@@ -4632,7 +4654,113 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     }
 
     get htmlBodyEditorClass() {
-        return this.showHtmlBodyPreview ? 'dg-html-body-editor slds-hide' : 'dg-html-body-editor';
+        return this.showHtmlBodyPreview || this.showHtmlBodyVisual
+            ? 'dg-html-body-editor slds-hide'
+            : 'dg-html-body-editor';
+    }
+
+    get visualToggleLabel() {
+        return this.showHtmlBodyVisual ? 'Back to Code' : 'Visual';
+    }
+
+    /**
+     * Enter/exit WYSIWYG mode. Entering splits the document: <style>/@page
+     * shell is stashed, body content goes into lightning-input-rich-text.
+     * Exiting reassembles the full document (Quill alignment classes mapped
+     * to inline CSS 2.1) back into the code editor. Table layouts can't be
+     * represented by the rich-text editor, so entering warns first.
+     */
+    async handleToggleHtmlVisual() {
+        if (this.showHtmlBodyVisual) {
+            this._exitVisualMode();
+            return;
+        }
+        const ta = this.template.querySelector('.dg-html-body-editor');
+        const html = (ta && ta.value) || '';
+        // HARD BLOCK, not a warning: the rich-text editor (Quill) strips
+        // tables and div layout, so entering visual mode on a layout-heavy
+        // template would destroy the design on exit. Never offer a path
+        // that silently mangles content.
+        if (/<table\b|display\s*:\s*table/i.test(html)) {
+            this.showToast(
+                'Visual editor not available for this layout',
+                'This template uses table-based layout, which the visual editor cannot represent without simplifying your design. Use Code + Preview here — Visual works great for letter-style templates.',
+                'warning'
+            );
+            return;
+        }
+        const styleBlocks = [];
+        let work = html.replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, (m) => {
+            styleBlocks.push(m);
+            return '';
+        });
+        const bodyMatch = work.match(/<body\b[^>]*>([\s\S]*?)<\/body\s*>/i);
+        this._visualShellStyles = styleBlocks.join('\n');
+        // Snapshots for a lossless exit: if the user just looks around and
+        // changes nothing, the code editor gets its ORIGINAL text back —
+        // no Quill-normalization round-trip.
+        this._visualOriginalCode = html;
+        this.visualEditorHtml = (bodyMatch ? bodyMatch[1] : work).trim();
+        this._visualEnteredHtml = null; // captured after Quill sanitizes, on first render
+        this.showHtmlBodyPreview = false;
+        this.showHtmlBodyVisual = true;
+        // Capture Quill's sanitized baseline once the editor renders, so
+        // "unchanged" is judged against what the user actually saw.
+        // eslint-disable-next-line @lwc/lwc/no-async-operation
+        setTimeout(() => {
+            const rte = this.template.querySelector('.dg-visual-editor');
+            if (rte && this._visualEnteredHtml === null) {
+                this._visualEnteredHtml = rte.value || '';
+            }
+        }, 400);
+    }
+
+    /** Leave visual mode — lossless when nothing changed. */
+    _exitVisualMode() {
+        const rte = this.template.querySelector('.dg-visual-editor');
+        const current = (rte && rte.value) || this.visualEditorHtml || '';
+        const unchanged = this._visualEnteredHtml !== null && current === this._visualEnteredHtml;
+        if (unchanged) {
+            const ta = this.template.querySelector('.dg-html-body-editor');
+            if (ta && this._visualOriginalCode != null) {
+                ta.value = this._visualOriginalCode;
+            }
+        } else {
+            this._applyVisualToCode();
+        }
+        this.showHtmlBodyVisual = false;
+        this._visualOriginalCode = null;
+        this._visualEnteredHtml = null;
+    }
+
+    /** Reassemble shell + rich-text content into the code editor. */
+    _applyVisualToCode() {
+        const rte = this.template.querySelector('.dg-visual-editor');
+        let inner = (rte && rte.value) || this.visualEditorHtml || '';
+        // Quill emits alignment/indent as classes — translate to inline CSS 2.1.
+        inner = inner
+            .replace(/class="ql-align-(center|right|justify)"/gi, 'style="text-align: $1"')
+            .replace(/class="ql-indent-(\d)"/gi, (m, n) => 'style="margin-left: ' + Number(n) * 24 + 'pt"');
+        const shell =
+            this._visualShellStyles && this._visualShellStyles.trim()
+                ? this._visualShellStyles
+                : '<style>\n@page { size: Letter portrait; margin: 0.75in; }\nbody { font-family: Helvetica, Arial, sans-serif; font-size: 10.5pt; color: #1a1a1a; }\n</style>';
+        const doc =
+            '<!DOCTYPE html>\n<html>\n<head>\n<meta charset="utf-8" />\n' +
+            shell +
+            '\n</head>\n<body>\n' +
+            inner +
+            '\n</body>\n</html>\n';
+        const ta = this.template.querySelector('.dg-html-body-editor');
+        if (ta) {
+            ta.value = prettyPrintHtml(doc);
+        }
+        this.htmlEditorDirty = true;
+    }
+
+    handleVisualEditorChange(event) {
+        this.visualEditorHtml = event.target.value;
+        this.htmlEditorDirty = true;
     }
 
     get docxHtmlEditorClass() {
@@ -4663,6 +4791,9 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 this._renderHtmlPreview('.dg-docx-preview', '.dg-docx-html-editor');
             }
         } else {
+            if (this.showHtmlBodyVisual) {
+                this._exitVisualMode();
+            }
             this.showHtmlBodyPreview = !this.showHtmlBodyPreview;
             if (this.showHtmlBodyPreview) {
                 this._renderHtmlPreview('.dg-body-preview', '.dg-html-body-editor');
@@ -4703,6 +4834,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
 
     /** Reload = show what's actually staged (or saved), discarding unapplied edits. */
     async handleReloadHtmlBodyEditor() {
+        // Reload means "discard my edits" — visual edits included.
+        this.showHtmlBodyVisual = false;
         await this._loadBodyIntoEditor();
     }
 
@@ -4851,7 +4984,173 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         }
     }
 
+    // --- Tags palette (Insert Tags without memorizing syntax) ---
+    get tagPanelToggleLabel() {
+        return this.showTagPanel ? 'Hide Tags' : 'Insert Tags';
+    }
+
+    get tagPaletteSections() {
+        const shape = extractQueryShape(this.editTemplateQuery, this.editTemplateObject);
+        return buildTagPalette(shape);
+    }
+
+    toggleTagPanel() {
+        this.showTagPanel = !this.showTagPanel;
+    }
+
+    handleInsertTagSnippet(event) {
+        const snippet = event.currentTarget.dataset.snippet;
+        if (!snippet) {
+            return;
+        }
+        if (this.showHtmlBodyVisual) {
+            const rte = this.template.querySelector('.dg-visual-editor');
+            this.visualEditorHtml = ((rte && rte.value) || this.visualEditorHtml || '') + snippet;
+            this.htmlEditorDirty = true;
+            this.showToast('Tag inserted', 'Added at the end of the document — move it where you need it.', 'success');
+            return;
+        }
+        if (this._insertAtEditorCursor(snippet)) {
+            this.showToast(
+                'Tag inserted',
+                snippet.length > 60 ? 'Loop table inserted at your cursor.' : snippet + ' inserted at your cursor.',
+                'success'
+            );
+        }
+    }
+
+    /** Splice text into the code textarea at the cursor (or before </body>). */
+    _insertAtEditorCursor(text) {
+        const ta = this.template.querySelector('.dg-html-body-editor');
+        if (!ta) {
+            return false;
+        }
+        let start = typeof ta.selectionStart === 'number' ? ta.selectionStart : ta.value.length;
+        let end = typeof ta.selectionEnd === 'number' ? ta.selectionEnd : start;
+        if (start === end && (start === 0 || start === ta.value.length)) {
+            const bodyClose = ta.value.search(/<\/body\s*>/i);
+            if (bodyClose > -1) {
+                start = bodyClose;
+                end = bodyClose;
+            }
+        }
+        ta.value = ta.value.slice(0, start) + text + ta.value.slice(end);
+        const pos = start + text.length;
+        try {
+            ta.focus();
+            ta.setSelectionRange(pos, pos);
+        } catch (e) {
+            /* focus/selection is best-effort */
+        }
+        this.htmlEditorDirty = true;
+        return true;
+    }
+
+    // --- Images panel (Add Image without knowing shepherd URLs) ---
+    get imagePanelToggleLabel() {
+        return this.showImagePanel ? 'Hide Images' : 'Add Image';
+    }
+
+    get hasTemplateImages() {
+        return (this.templateImages || []).length > 0;
+    }
+
+    async toggleImagePanel() {
+        this.showImagePanel = !this.showImagePanel;
+        if (this.showImagePanel) {
+            await this._loadTemplateImages();
+        }
+    }
+
+    async _loadTemplateImages() {
+        this.isLoadingTemplateImages = true;
+        try {
+            this.templateImages = (await listHtmlTemplateImages({ templateId: this.editTemplateId })) || [];
+        } catch (err) {
+            const msg = err && err.body && err.body.message ? err.body.message : (err && err.message) || String(err);
+            this.showToast('Could not load images', msg, 'error');
+            this.templateImages = [];
+        } finally {
+            this.isLoadingTemplateImages = false;
+        }
+    }
+
+    triggerInsertImagePicker() {
+        const input = this.template.querySelector('.dg-insert-image-input');
+        if (input) {
+            input.click();
+        }
+    }
+
+    async handleInsertImageSelected(event) {
+        const file = event.target.files && event.target.files[0];
+        if (!file) {
+            return;
+        }
+        // SVG excluded on purpose — the PDF engine silently drops it.
+        if (!/\.(png|jpe?g|gif|bmp)$/i.test(file.name)) {
+            this.showToast(
+                'Unsupported image',
+                'Use .png, .jpg, .gif, or .bmp — SVG does not render in PDF output.',
+                'error'
+            );
+            event.target.value = '';
+            return;
+        }
+        this.isUploadingInsertImage = true;
+        try {
+            const buffer = await file.arrayBuffer();
+            const result = await saveHtmlTemplateImage({
+                templateId: this.editTemplateId,
+                fileName: file.name,
+                base64Content: bytesToBase64(new Uint8Array(buffer))
+            });
+            this._insertImageSnippet(result.url, result.fileName);
+            await this._loadTemplateImages();
+        } catch (err) {
+            const msg = err && err.body && err.body.message ? err.body.message : (err && err.message) || String(err);
+            this.showToast('Image upload failed', msg, 'error');
+        } finally {
+            this.isUploadingInsertImage = false;
+            event.target.value = '';
+        }
+    }
+
+    handleInsertExistingImage(event) {
+        const { url, name } = event.currentTarget.dataset;
+        this._insertImageSnippet(url, name);
+    }
+
+    /** Drop a ready-made, PDF-safe <img> tag at the editor cursor. */
+    _insertImageSnippet(url, name) {
+        const snippet = '<img src="' + url + '" alt="' + (name || 'image') + '" style="width: 180px" />';
+        // Visual mode: append to the rich-text content instead of the textarea.
+        if (this.showHtmlBodyVisual) {
+            const rte = this.template.querySelector('.dg-visual-editor');
+            this.visualEditorHtml = ((rte && rte.value) || this.visualEditorHtml || '') + '<p>' + snippet + '</p>';
+            this.htmlEditorDirty = true;
+            this.showToast(
+                'Image inserted',
+                'Added at the end of the document — drag it where you want it.',
+                'success'
+            );
+            return;
+        }
+        if (this._insertAtEditorCursor(snippet)) {
+            this.showToast(
+                'Image inserted',
+                'A PDF-safe <img> tag was placed at your cursor — adjust the width, then click "Apply Editor HTML".',
+                'success'
+            );
+        }
+    }
+
     async handleApplyHtmlBody() {
+        // Visual mode edits live in the rich-text editor — fold them into the
+        // code editor first so Apply stages what the user is looking at.
+        if (this.showHtmlBodyVisual) {
+            this._exitVisualMode();
+        }
         const ta = this.template.querySelector('.dg-html-body-editor');
         const text = ta ? ta.value : '';
         if (!text || !text.trim()) {

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -4704,6 +4704,71 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         return this.htmlBodyEditorClass + ' dg-designer-size';
     }
 
+    // --- Visual-mode format bar (alignment, size, colors) ---
+    get textColorSwatches() {
+        return [
+            { key: 'c_black', value: '#1a1a1a', style: 'background: #1a1a1a', title: 'Black text' },
+            { key: 'c_navy', value: '#1f3a5f', style: 'background: #1f3a5f', title: 'Navy text' },
+            { key: 'c_gray', value: '#666666', style: 'background: #666666', title: 'Gray text' },
+            { key: 'c_blue', value: '#1b5e9e', style: 'background: #1b5e9e', title: 'Blue text' },
+            { key: 'c_green', value: '#1c7a3d', style: 'background: #1c7a3d', title: 'Green text' },
+            { key: 'c_red', value: '#b91c1c', style: 'background: #b91c1c', title: 'Red text' },
+            { key: 'c_white', value: '#ffffff', style: 'background: #ffffff; border-color: #999', title: 'White text' }
+        ];
+    }
+
+    get highlightSwatches() {
+        return [
+            {
+                key: 'h_none',
+                value: 'transparent',
+                style: 'background: #fff; border-color: #999',
+                title: 'No highlight'
+            },
+            { key: 'h_yellow', value: '#fef3c7', style: 'background: #fef3c7', title: 'Yellow highlight' },
+            { key: 'h_blue', value: '#e8f0fb', style: 'background: #e8f0fb', title: 'Blue highlight' },
+            { key: 'h_green', value: '#e3f5e9', style: 'background: #e3f5e9', title: 'Green highlight' },
+            { key: 'h_gray', value: '#f2f4f7', style: 'background: #f2f4f7', title: 'Gray highlight' },
+            { key: 'h_navy', value: '#1f3a5f', style: 'background: #1f3a5f', title: 'Navy fill (use white text)' }
+        ];
+    }
+
+    /** Keep the page's text selection alive while clicking toolbar controls. */
+    handleFmtMouseDown(event) {
+        event.preventDefault();
+    }
+
+    /**
+     * Apply formatting to the current selection in the editable page.
+     * styleWithCSS makes execCommand emit inline CSS spans — exactly the
+     * flat, Flying Saucer-safe styling the PDF engine renders.
+     */
+    handleFormatAction(event) {
+        if (!this.showHtmlBodyVisual) {
+            return;
+        }
+        const cmd = event.currentTarget.dataset.cmd;
+        const value = event.currentTarget.dataset.value || null;
+        if (!cmd) {
+            return;
+        }
+        try {
+            document.execCommand('styleWithCSS', false, 'true');
+            const ok = document.execCommand(cmd, false, value);
+            if (ok) {
+                this.htmlEditorDirty = true;
+            } else {
+                this.showToast(
+                    'Select some text first',
+                    'Highlight text in the page, then click a format button.',
+                    'info'
+                );
+            }
+        } catch (e) {
+            this.showToast('Formatting unavailable', 'This browser blocked the formatting command.', 'warning');
+        }
+    }
+
     /**
      * Enter/exit visual (in-place) editing. The template renders through the
      * SAME scoped-preview pipeline the Preview toggle uses — tables, bands,

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -6944,6 +6944,19 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         this._enterVisualMode(body);
     }
 
+    /** Designer → this template's full edit modal, no list-hunting. */
+    handleEditTemplateFromDesigner() {
+        if (this.showHtmlBodyVisual) {
+            this._exitVisualMode();
+        }
+        this.handleClosePdfPreview();
+        this.activePanel = null;
+        this._closeSlashMenu();
+        this.activeMainTab = 'list';
+        this.activeEditTab = 'document';
+        this.isEditModalOpen = true;
+    }
+
     handleCloseDesigner() {
         if (this.showHtmlBodyVisual) {
             this._exitVisualMode();

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -1507,6 +1507,10 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                         // Column resize: grab a cell's right edge and drag.
                         pv.addEventListener('mousemove', (e) => this._tableResizeHover(e, pv));
                         pv.addEventListener('mousedown', (e) => this._tableResizeStart(e, pv));
+                        // Chip drops staged by the document-level drag listener
+                        // execute HERE — pv listeners are the context where DOM
+                        // insertion reliably works under LWS.
+                        pv.addEventListener('mouseup', () => this._performPendingDropInsert());
                         // Keep keystrokes OURS: Lightning binds "/" (and more) to
                         // global shortcuts via a capture-phase listener high in the
                         // tree, so stopping propagation at the page is too late.
@@ -6187,12 +6191,10 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             const parent = node.parentElement;
             // Never wrap inside <style>, and NEVER inside an existing pill —
             // re-pillifying pill text nests a new layer on every insert.
-            if (
-                /\{[^{}]+\}/.test(node.nodeValue) &&
-                parent &&
-                parent.tagName !== 'STYLE' &&
-                !parent.closest('[data-dg-tag]')
-            ) {
+            // parent === null is a FRAGMENT-ROOT text node (bare tag snippet
+            // from a chip) — those must pillify too.
+            const blocked = parent && (parent.tagName === 'STYLE' || parent.closest('[data-dg-tag]'));
+            if (/\{[^{}]+\}/.test(node.nodeValue) && !blocked) {
                 targets.push(node);
             }
         }
@@ -6952,7 +6954,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 return;
             }
             const upto = node.nodeValue.slice(0, sel.anchorOffset);
-            const m = upto.match(/(^|[\s ])\/([\w -]{0,30})$/);
+            // Trigger keys: ` or [ — "/" belongs to Lightning global search.
+            const m = upto.match(/(^|[\s ])[`[]([\w -]{0,30})$/);
             if (!m) {
                 this._closeSlashMenu();
                 return;
@@ -7086,6 +7089,11 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     }
 
     handleInsertTagSnippet(event) {
+        // A completed mouse-drag suppresses the click that follows it.
+        if (this._suppressChipClick) {
+            this._suppressChipClick = false;
+            return;
+        }
         const snippet = event.currentTarget.dataset.snippet;
         const isBlock = event.currentTarget.dataset.kind === 'block';
         if (!snippet) {
@@ -7299,6 +7307,141 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     /** Tag chips and image thumbnails are draggable onto the visual page.
      *  Payload rides in _dragSnippet (LWS-proof); dataTransfer is set too for
      *  drops outside the canvas (e.g. into the Source textarea). */
+    // --- Mouse-driven chip drag (HTML5 DnD does not survive LWS + manual DOM) ---
+    // mousedown arms it; 7px of movement starts it (a ghost chip follows the
+    // cursor and the purple drop caret tracks the pointer); mouseup over the
+    // page inserts at that exact point. A no-movement mouseup stays a click.
+    handleChipDragMouseDown(event) {
+        // preventDefault keeps the canvas caret alive (same job the old
+        // handleFmtMouseDown did on these chips).
+        event.preventDefault();
+        const snippet = event.currentTarget.dataset.snippet;
+        if (!snippet) {
+            return;
+        }
+        this._pointerDrag = {
+            snippet,
+            label: (event.currentTarget.textContent || 'Insert').trim().slice(0, 40),
+            startX: event.clientX,
+            startY: event.clientY,
+            started: false,
+            ghost: null
+        };
+        this._onPointerDragMove = (e) => this._pointerDragMove(e);
+        this._onPointerDragUp = (e) => this._pointerDragUp(e);
+        document.addEventListener('mousemove', this._onPointerDragMove, true);
+        document.addEventListener('mouseup', this._onPointerDragUp, true);
+    }
+
+    _getVisualPv() {
+        const host = this.template.querySelector('.dg-visual-host');
+        return host && host.querySelector('.dg-pv');
+    }
+
+    _pointerDragMove(e) {
+        const d = this._pointerDrag;
+        if (!d) {
+            return;
+        }
+        if (!d.started) {
+            if (Math.abs(e.clientX - d.startX) + Math.abs(e.clientY - d.startY) < 7) {
+                return;
+            }
+            d.started = true;
+            const g = document.createElement('div');
+            g.className = 'dg-drag-ghost';
+            g.textContent = d.label;
+            document.body.appendChild(g);
+            d.ghost = g;
+        }
+        d.ghost.style.left = e.clientX + 14 + 'px';
+        d.ghost.style.top = e.clientY + 10 + 'px';
+        const pv = this._getVisualPv();
+        if (pv) {
+            const r = pv.getBoundingClientRect();
+            const over = e.clientX >= r.left && e.clientX <= r.right && e.clientY >= r.top && e.clientY <= r.bottom;
+            if (over) {
+                this._showDropMarker(e, pv);
+            } else {
+                this._hideDropMarker(pv);
+            }
+        }
+        e.preventDefault();
+    }
+
+    _pointerDragUp(e) {
+        const d = this._pointerDrag;
+        this._pointerDrag = null;
+        document.removeEventListener('mousemove', this._onPointerDragMove, true);
+        document.removeEventListener('mouseup', this._onPointerDragUp, true);
+        if (!d || !d.started) {
+            return; // plain click — the chip's onclick inserts at the caret
+        }
+        if (d.ghost) {
+            d.ghost.remove();
+        }
+        // The drag consumed this gesture — swallow the click that follows a
+        // mouseup back over the chip, or it would double-insert.
+        this._suppressChipClick = true;
+        // eslint-disable-next-line @lwc/lwc/no-async-operation
+        setTimeout(() => {
+            this._suppressChipClick = false;
+        }, 250);
+        const pv = this._getVisualPv();
+        if (!pv) {
+            return;
+        }
+        this._hideDropMarker(pv);
+        const r = pv.getBoundingClientRect();
+        const over = e.clientX >= r.left && e.clientX <= r.right && e.clientY >= r.top && e.clientY <= r.bottom;
+        if (!over) {
+            return;
+        }
+        // Document-context DOM insertion silently no-ops under LWS, so this
+        // capture-phase listener only STAGES the drop; the pv's own mouseup
+        // listener (proven context — see renderedCallback) performs it. The
+        // timeout is a safety net if that listener never fires.
+        this._pendingDropInsert = { snippet: d.snippet, x: e.clientX, y: e.clientY };
+        // eslint-disable-next-line @lwc/lwc/no-async-operation
+        setTimeout(() => this._performPendingDropInsert(), 250);
+    }
+
+    /** Executes a staged chip drop: caret to the drop point, then the same
+     *  insert the chip's click handler uses. Idempotent — first caller wins. */
+    _performPendingDropInsert() {
+        const drop = this._pendingDropInsert;
+        if (!drop) {
+            return;
+        }
+        this._pendingDropInsert = null;
+        const pv = this._getVisualPv();
+        if (!pv) {
+            return;
+        }
+        try {
+            let range = null;
+            if (document.caretRangeFromPoint) {
+                range = document.caretRangeFromPoint(drop.x, drop.y);
+            } else if (document.caretPositionFromPoint) {
+                const pos = document.caretPositionFromPoint(drop.x, drop.y);
+                if (pos) {
+                    range = document.createRange();
+                    range.setStart(pos.offsetNode, pos.offset);
+                }
+            }
+            if (range && pv.contains(range.startContainer)) {
+                range.collapse(true);
+                const s = window.getSelection();
+                s.removeAllRanges();
+                s.addRange(range);
+                pv.focus();
+            }
+        } catch (err) {
+            /* caret placement best-effort — insert falls back to append */
+        }
+        this._insertIntoVisualPage(drop.snippet);
+    }
+
     handleTagDragStart(event) {
         const snippet = event.currentTarget.dataset.snippet;
         this._dragSnippet = snippet || null;

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -6366,27 +6366,90 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         const raw = (pill.textContent || '').trim();
         const inner = raw.replace(/^\{|\}$/g, '');
         const first = inner.charAt(0);
-        let options = [];
         let field = null;
         if (first === '*' || first === '%') {
             field = inner.slice(1).split(':')[0];
         } else if (!/^[#/:@]/.test(first) && !/^(SUM|AVG|MIN|MAX|COUNT|Chart)\b/i.test(inner)) {
             field = inner.split(':')[0];
         }
+        let sections = [];
         if (field) {
-            options = [
-                { key: 'plain', label: 'Plain text', tag: '{' + field + '}' },
-                { key: 'currency', label: 'Currency ($1,234.00)', tag: '{' + field + ':currency}' },
-                { key: 'date_long', label: 'Date — April 17, 2026', tag: '{' + field + ':MMMM d, yyyy}' },
-                { key: 'date_short', label: 'Date — 04/17/2026', tag: '{' + field + ':MM/dd/yyyy}' },
-                { key: 'number', label: 'Number (1,234)', tag: '{' + field + ':number}' },
-                { key: 'percent', label: 'Percent (15.5%)', tag: '{' + field + ':percent}' },
-                { key: 'checkbox', label: 'Checkbox [X]/[ ]', tag: '{' + field + ':checkbox}' },
-                { key: 'label', label: 'Picklist label', tag: '{' + field + ':label}' },
-                { key: 'qr', label: 'QR code', tag: '{*' + field + ':qr:200}' },
-                { key: 'barcode', label: 'Barcode (Code 128)', tag: '{*' + field + ':code128:300x80}' },
-                { key: 'image', label: 'Image field', tag: '{%' + field + '}' }
-            ].map((o) => ({ ...o, active: o.tag === raw }));
+            const f = field;
+            const opt = (key, label, tag) => ({
+                key,
+                label,
+                tag,
+                cls: tag === raw ? 'dg-pill-menu-item dg-pill-menu-item_active' : 'dg-pill-menu-item'
+            });
+            const cur = (code, sample) => opt('cur_' + code, code + '  ' + sample, '{' + f + ':currency:' + code + '}');
+            const dt = (pat, sample) => opt('dt_' + pat, sample, '{' + f + ':' + pat + '}');
+            sections = [
+                {
+                    key: 'text',
+                    label: 'Text',
+                    options: [
+                        opt('plain', 'Plain text', '{' + f + '}'),
+                        opt('label', 'Picklist label', '{' + f + ':label}'),
+                        opt('checkbox', 'Checkbox [X]/[ ]', '{' + f + ':checkbox}')
+                    ]
+                },
+                {
+                    key: 'currency',
+                    label: 'Currency',
+                    options: [
+                        opt('currency', "User's currency — $1,234.00", '{' + f + ':currency}'),
+                        cur('USD', '$1,234.56'),
+                        cur('EUR', '1.234,56 €'),
+                        cur('GBP', '£1,234.56'),
+                        cur('JPY', '¥1,235'),
+                        cur('CAD', 'CA$1,234.56'),
+                        cur('AUD', 'A$1,234.56'),
+                        cur('CHF', "CHF 1'234.56"),
+                        cur('CNY', '¥1,234.56'),
+                        cur('INR', '₹1,23,456.00'),
+                        cur('BRL', 'R$ 1.234,56'),
+                        cur('MXN', 'MX$1,234.56')
+                    ]
+                },
+                {
+                    key: 'dates',
+                    label: 'Dates',
+                    options: [
+                        opt('date_user', "User's locale date", '{' + f + ':date}'),
+                        dt('MMMM d, yyyy', 'April 17, 2026 — US long'),
+                        dt('MMM d, yyyy', 'Apr 17, 2026'),
+                        dt('MM/dd/yyyy', '04/17/2026 — US'),
+                        dt('dd/MM/yyyy', '17/04/2026 — UK · EU'),
+                        dt('d MMMM yyyy', '17 April 2026 — EU long'),
+                        dt('dd.MM.yyyy', '17.04.2026 — DE · CH'),
+                        dt('yyyy-MM-dd', '2026-04-17 — ISO'),
+                        dt('yyyy年M月d日', '2026年4月17日 — JP'),
+                        dt('EEEE, MMMM d, yyyy', 'Friday, April 17, 2026'),
+                        dt('MMMM yyyy', 'April 2026 — month only'),
+                        dt('MMMM d, yyyy h:mm a', 'April 17, 2026 3:45 PM')
+                    ]
+                },
+                {
+                    key: 'numbers',
+                    label: 'Numbers',
+                    options: [
+                        opt('number', 'Number — 1,234', '{' + f + ':number}'),
+                        dt('#,##0.00', '1,234.50 — two decimals'),
+                        dt('#,##0', '1,235 — whole'),
+                        dt('0.00', '1234.50 — no thousands'),
+                        opt('percent', 'Percent — 15.5%', '{' + f + ':percent}')
+                    ]
+                },
+                {
+                    key: 'other',
+                    label: 'Codes & images',
+                    options: [
+                        opt('qr', 'QR code', '{*' + f + ':qr:200}'),
+                        opt('barcode', 'Barcode (Code 128)', '{*' + f + ':code128:300x80}'),
+                        opt('image', 'Image field', '{%' + f + '}')
+                    ]
+                }
+            ];
         }
         // Position the menu just under the pill, relative to the canvas column.
         const col = this.template.querySelector('.dg-designer-canvas-col');
@@ -6394,8 +6457,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         const rect = pill.getBoundingClientRect();
         this.pillMenu = {
             tagText: raw,
-            options,
-            hasOptions: options.length > 0,
+            sections,
+            hasOptions: sections.length > 0,
             posStyle:
                 'left: ' + Math.max(0, rect.left - colRect.left) + 'px; top: ' + (rect.bottom - colRect.top + 6) + 'px;'
         };

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -1273,8 +1273,17 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                         // Merge tags render as friendly atomic pills.
                         this._pillifyTags(pv);
                         // Drag targets: tag chips and image thumbnails drop
-                        // exactly where the user points.
-                        pv.addEventListener('dragover', (e) => e.preventDefault());
+                        // exactly where the user points — with a live insertion
+                        // marker so the drop point is never a guess.
+                        pv.addEventListener('dragover', (e) => {
+                            e.preventDefault();
+                            this._showDropMarker(e, pv);
+                        });
+                        pv.addEventListener('dragleave', (e) => {
+                            if (e.target === pv) {
+                                this._hideDropMarker(pv);
+                            }
+                        });
                         pv.addEventListener('drop', (e) => this._handleVisualDrop(e, pv));
                         // Snapshot AFTER pillify so "unchanged" compares
                         // like-for-like on exit.
@@ -4684,6 +4693,24 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
 
     handleHtmlBodyEditorInput() {
         this.htmlEditorDirty = true;
+        // Live preview beside the code — debounced so typing stays smooth.
+        clearTimeout(this._codePreviewTimer);
+        // eslint-disable-next-line @lwc/lwc/no-async-operation
+        this._codePreviewTimer = setTimeout(() => this._refreshCodePreview(), 400);
+    }
+
+    /** Re-render the side-by-side preview from the code editor's current text. */
+    _refreshCodePreview() {
+        const host = this.template.querySelector('.dg-code-preview');
+        const ta = this.template.querySelector('.dg-html-body-editor');
+        if (host && ta) {
+            // eslint-disable-next-line @lwc/lwc/no-inner-html
+            host.innerHTML = scopeHtmlForInlinePreview(ta.value || '');
+        }
+    }
+
+    get codeSplitClass() {
+        return this.showHtmlBodyVisual ? 'dg-code-split slds-hide' : 'dg-code-split';
     }
 
     // --- Format Code + Code ⇄ Preview (shared by the HTML editor and the DOCX viewer) ---
@@ -4871,7 +4898,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             const ok = document.execCommand(cmd, false, value);
             if (ok) {
                 this.htmlEditorDirty = true;
-            } else {
+            } else if (cmd !== 'undo' && cmd !== 'redo') {
                 this.showToast(
                     'Select some text first',
                     'Highlight text in the page, then click a format button.',
@@ -4880,6 +4907,59 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             }
         } catch (e) {
             this.showToast('Formatting unavailable', 'This browser blocked the formatting command.', 'warning');
+        }
+    }
+
+    /**
+     * Custom color pickers: opening the native picker steals focus, so the
+     * page selection is snapshotted on mousedown and restored before the
+     * chosen color is applied.
+     */
+    handleColorPickMouseDown() {
+        try {
+            const sel = window.getSelection();
+            this._savedFmtRange = sel && sel.rangeCount ? sel.getRangeAt(0).cloneRange() : null;
+        } catch (e) {
+            this._savedFmtRange = null;
+        }
+    }
+
+    handleColorPickChange(event) {
+        if (!this.showHtmlBodyVisual) {
+            return;
+        }
+        const cmd = event.currentTarget.dataset.cmd;
+        const value = event.currentTarget.value;
+        if (this._savedFmtRange) {
+            try {
+                const sel = window.getSelection();
+                sel.removeAllRanges();
+                sel.addRange(this._savedFmtRange);
+            } catch (e) {
+                /* selection restore is best-effort */
+            }
+        }
+        if (cmd === 'cellFill') {
+            const cell = this._selectedTableCell();
+            if (cell) {
+                cell.style.background = value;
+                this.htmlEditorDirty = true;
+            } else {
+                this.showToast(
+                    'Click inside a table cell first',
+                    'Put your cursor in a cell, then pick the fill color.',
+                    'info'
+                );
+            }
+            return;
+        }
+        try {
+            document.execCommand('styleWithCSS', false, 'true');
+            if (document.execCommand(cmd, false, value)) {
+                this.htmlEditorDirty = true;
+            }
+        } catch (e) {
+            /* ignore */
         }
     }
 
@@ -4976,6 +5056,9 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 for (const styleEl of clone.querySelectorAll('style')) {
                     styleEl.remove();
                 }
+                for (const markerEl of clone.querySelectorAll('.dg-drop-marker')) {
+                    markerEl.remove();
+                }
                 this._unpillifyTags(clone);
                 const edited = clone.innerHTML.trim();
                 // Swap ONLY the body content back into the original document —
@@ -5001,6 +5084,9 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         this.showHtmlBodyVisual = false;
         this._visualOriginalCode = null;
         this._visualEnteredDom = null;
+        // Landing back in Code view — make the side-by-side preview current.
+        // eslint-disable-next-line @lwc/lwc/no-async-operation
+        setTimeout(() => this._refreshCodePreview(), 120);
     }
 
     get docxHtmlEditorClass() {
@@ -5020,6 +5106,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         if (!isDocx) {
             // Formatting changes the text that Apply would stage — surface it.
             this.htmlEditorDirty = true;
+            this._refreshCodePreview();
         }
     }
 
@@ -5110,6 +5197,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             if (ta) {
                 ta.value = text || '';
             }
+            this._refreshCodePreview();
         }, 120);
     }
 
@@ -5334,9 +5422,57 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         }
     }
 
+    /** Purple insertion caret that tracks the pointer while dragging. */
+    _showDropMarker(event, pv) {
+        let marker = pv.querySelector('.dg-drop-marker');
+        if (!marker) {
+            marker = document.createElement('span');
+            marker.className = 'dg-drop-marker';
+            marker.setAttribute('contenteditable', 'false');
+            marker.style.cssText =
+                'position: absolute; width: 3px; background: #7c3aed; pointer-events: none; z-index: 99; border-radius: 2px; box-shadow: 0 0 4px rgba(124, 58, 237, 0.7);';
+            pv.style.position = 'relative';
+            pv.appendChild(marker);
+        }
+        let rect = null;
+        try {
+            const range = document.caretRangeFromPoint(event.clientX, event.clientY);
+            if (range && pv.contains(range.startContainer)) {
+                const rects = range.getClientRects();
+                rect = rects && rects.length ? rects[0] : null;
+                if (!rect) {
+                    const el =
+                        range.startContainer.nodeType === 3 ? range.startContainer.parentElement : range.startContainer;
+                    rect = el ? el.getBoundingClientRect() : null;
+                }
+            }
+        } catch (e) {
+            rect = null;
+        }
+        if (rect) {
+            const pvRect = pv.getBoundingClientRect();
+            marker.style.left = rect.left - pvRect.left + 'px';
+            marker.style.top = rect.top - pvRect.top + 'px';
+            marker.style.height = (rect.height || 16) + 'px';
+            marker.style.display = 'block';
+        } else {
+            marker.style.display = 'none';
+        }
+        pv.style.boxShadow = '0 0 0 3px rgba(124, 58, 237, 0.35)';
+    }
+
+    _hideDropMarker(pv) {
+        const marker = pv.querySelector('.dg-drop-marker');
+        if (marker) {
+            marker.remove();
+        }
+        pv.style.boxShadow = '';
+    }
+
     /** Drop a dragged tag chip / image thumbnail at the pointed-at spot. */
     _handleVisualDrop(event, pv) {
         event.preventDefault();
+        this._hideDropMarker(pv);
         const text = event.dataTransfer && event.dataTransfer.getData('text/plain');
         if (!text) {
             return;

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -4733,9 +4733,123 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         ];
     }
 
+    /** The PDF engine ships exactly four fonts — the picker offers exactly those. */
+    get fontChoices() {
+        return [
+            {
+                key: 'f_helv',
+                label: 'Helvetica',
+                value: 'Helvetica, Arial, sans-serif',
+                style: 'font-family: Helvetica, Arial, sans-serif',
+                title: 'Helvetica — clean sans-serif (default)'
+            },
+            {
+                key: 'f_times',
+                label: 'Times',
+                value: "'Times New Roman', Times, serif",
+                style: "font-family: 'Times New Roman', Times, serif",
+                title: 'Times — formal serif'
+            },
+            {
+                key: 'f_courier',
+                label: 'Courier',
+                value: "'Courier New', Courier, monospace",
+                style: "font-family: 'Courier New', Courier, monospace",
+                title: 'Courier — monospace, great for codes and numbers'
+            },
+            {
+                key: 'f_unicode',
+                label: 'Unicode',
+                value: "'Arial Unicode MS', Arial, sans-serif",
+                style: 'font-family: Arial, sans-serif',
+                title: 'Arial Unicode MS — widest character coverage (international text)'
+            }
+        ];
+    }
+
     /** Keep the page's text selection alive while clicking toolbar controls. */
     handleFmtMouseDown(event) {
         event.preventDefault();
+    }
+
+    // --- Table tools (visual mode): operate on the cell holding the caret ---
+    _selectedTableCell() {
+        let node = null;
+        try {
+            const sel = window.getSelection();
+            node = sel && sel.anchorNode;
+        } catch (e) {
+            node = null;
+        }
+        while (node && node.nodeType === 3) {
+            node = node.parentNode;
+        }
+        const host = this.template.querySelector('.dg-visual-host');
+        const pv = host && host.querySelector('.dg-pv');
+        if (!node || !pv || !pv.contains(node) || !node.closest) {
+            return null;
+        }
+        const cell = node.closest('td, th');
+        return cell && pv.contains(cell) ? cell : null;
+    }
+
+    handleTableAction(event) {
+        if (!this.showHtmlBodyVisual) {
+            return;
+        }
+        const action = event.currentTarget.dataset.taction;
+        const value = event.currentTarget.dataset.value || null;
+        const cell = this._selectedTableCell();
+        if (!cell) {
+            this.showToast(
+                'Click inside a table cell first',
+                'Put your cursor in the table you want to change, then use the table tools.',
+                'info'
+            );
+            return;
+        }
+        const row = cell.parentElement;
+        const table = cell.closest('table');
+        const cellIndex = Array.prototype.indexOf.call(row.children, cell);
+        if (action === 'rowAfter') {
+            const clone = row.cloneNode(true);
+            for (const c of clone.children) {
+                c.innerHTML = '&nbsp;';
+            }
+            row.insertAdjacentElement('afterend', clone);
+        } else if (action === 'rowDel') {
+            row.remove();
+            if (table && !table.querySelector('tr')) {
+                table.remove();
+            }
+        } else if (action === 'colAfter') {
+            for (const tr of table.rows) {
+                const ref = tr.children[Math.min(cellIndex, tr.children.length - 1)];
+                if (ref) {
+                    const c = ref.cloneNode(false);
+                    c.innerHTML = '&nbsp;';
+                    ref.insertAdjacentElement('afterend', c);
+                }
+            }
+        } else if (action === 'colDel') {
+            for (const tr of table.rows) {
+                if (tr.children[cellIndex]) {
+                    tr.children[cellIndex].remove();
+                }
+            }
+            if (table && !table.querySelector('td, th')) {
+                table.remove();
+            }
+        } else if (action === 'headerRow') {
+            for (const c of row.children) {
+                c.style.background = '#1f3a5f';
+                c.style.color = '#ffffff';
+                c.style.fontWeight = 'bold';
+            }
+        } else if (action === 'cellFill') {
+            cell.style.background = value === 'transparent' ? '' : value;
+        }
+        this.htmlEditorDirty = true;
     }
 
     /**

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -395,8 +395,19 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     // What the caret is on ("Editing: Table cell") — answers "what am I
     // about to color?"
     @track selectionContextLabel = '';
-    // Canvas page setup, mirrored into the template's @page rule.
-    @track pageSetup = { size: 'Letter', orient: 'portrait', margin: '0.75' };
+    // Pill inspector: click a pill → formatting menu (currency, date, QR…)
+    @track pillMenu = null;
+    _activePill = null;
+    // Canvas page setup, mirrored into the template's @page rule. Custom
+    // sizes cover everything from 3x4in nametags to poster PDFs.
+    @track pageSetup = {
+        size: 'Letter',
+        orient: 'portrait',
+        margin: '0.75',
+        customW: '8.5',
+        customH: '11',
+        customMargin: '0.75'
+    };
     // Last HTML body text this session touched (upload, starter, or Apply) so
     // reopening the editor doesn't need a server round-trip.
     _lastUploadedHtmlText = null;
@@ -1263,11 +1274,12 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 ta.value = this.editTemplateQuery;
             }
         }
-        // Page-setup selects: LWC doesn't bind value on native <select>, so
-        // mirror state into the DOM the same way the query textareas do.
-        for (const sel of this.template.querySelectorAll('.dg-page-select')) {
+        // Page-setup controls: LWC doesn't bind value on native <select>, so
+        // mirror state into the DOM the same way the query textareas do —
+        // but never clobber a control the user is currently typing in.
+        for (const sel of this.template.querySelectorAll('.dg-page-select, .dg-page-input')) {
             const want = this.pageSetup[sel.dataset.field];
-            if (want != null && sel.value !== want) {
+            if (want != null && sel.value !== want && !sel.matches(':focus')) {
                 sel.value = want;
             }
         }
@@ -1308,6 +1320,16 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                         // Live dirty signal while typing in the page.
                         pv.addEventListener('input', () => {
                             this.htmlEditorDirty = true;
+                        });
+                        // Click a pill → its formatting menu; click elsewhere closes it.
+                        pv.addEventListener('click', (e) => {
+                            const pill = e.target && e.target.closest ? e.target.closest('[data-dg-tag]') : null;
+                            if (pill) {
+                                e.preventDefault();
+                                this._openPillMenu(pill);
+                            } else {
+                                this.pillMenu = null;
+                            }
                         });
                         // Sheet dimensions follow the page setup.
                         this._applyCanvasDimensions();
@@ -4839,12 +4861,24 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     }
 
     _parsePageSetup(code) {
-        const setup = { size: 'Letter', orient: 'portrait', margin: '0.75' };
+        const setup = {
+            size: 'Letter',
+            orient: 'portrait',
+            margin: '0.75',
+            customW: '8.5',
+            customH: '11',
+            customMargin: '0.75'
+        };
         const m = /@page\s*\{([^}]*)\}/i.exec(code || '');
         if (m) {
             const body = m[1];
             const sm = /size\s*:\s*(letter|legal|a4)\s*(portrait|landscape)?/i.exec(body);
-            if (sm) {
+            const cm = /size\s*:\s*([\d.]+)\s*in\s+([\d.]+)\s*in/i.exec(body);
+            if (cm) {
+                setup.size = 'Custom';
+                setup.customW = cm[1];
+                setup.customH = cm[2];
+            } else if (sm) {
                 const raw = sm[1].toLowerCase();
                 setup.size = raw === 'a4' ? 'A4' : raw.charAt(0).toUpperCase() + raw.slice(1);
                 if (sm[2]) {
@@ -4853,10 +4887,19 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             }
             const mm = /margin\s*:\s*([\d.]+)\s*in/i.exec(body);
             if (mm) {
-                setup.margin = mm[1];
+                setup.margin = ['0.5', '0.75', '1'].includes(mm[1]) ? mm[1] : 'custom';
+                setup.customMargin = mm[1];
             }
         }
         this.pageSetup = setup;
+    }
+
+    get isCustomPageSize() {
+        return this.pageSetup.size === 'Custom';
+    }
+
+    get isCustomMargin() {
+        return this.pageSetup.margin === 'custom';
     }
 
     handlePageSetupChange(event) {
@@ -4870,14 +4913,11 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         if (!ta) {
             return;
         }
-        const rule =
-            '@page { size: ' +
-            this.pageSetup.size +
-            ' ' +
-            this.pageSetup.orient +
-            '; margin: ' +
-            this.pageSetup.margin +
-            'in; }';
+        const sizePart = this.isCustomPageSize
+            ? (parseFloat(this.pageSetup.customW) || 8.5) + 'in ' + (parseFloat(this.pageSetup.customH) || 11) + 'in'
+            : this.pageSetup.size + ' ' + this.pageSetup.orient;
+        const marginVal = this.isCustomMargin ? parseFloat(this.pageSetup.customMargin) || 0.75 : this.pageSetup.margin;
+        const rule = '@page { size: ' + sizePart + '; margin: ' + marginVal + 'in; }';
         let code = ta.value || '';
         if (/@page\s*\{[^}]*\}/i.test(code)) {
             code = code.replace(/@page\s*\{[^}]*\}/i, rule);
@@ -4902,11 +4942,19 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         }
         const widths = { Letter: 816, Legal: 816, A4: 794 };
         const heights = { Letter: 1056, Legal: 1344, A4: 1123 };
-        const w =
-            this.pageSetup.orient === 'landscape'
-                ? heights[this.pageSetup.size] || 1056
-                : widths[this.pageSetup.size] || 816;
-        const pad = Math.round(parseFloat(this.pageSetup.margin || '0.75') * 96);
+        let w;
+        if (this.isCustomPageSize) {
+            w = Math.round((parseFloat(this.pageSetup.customW) || 8.5) * 96);
+        } else {
+            w =
+                this.pageSetup.orient === 'landscape'
+                    ? heights[this.pageSetup.size] || 1056
+                    : widths[this.pageSetup.size] || 816;
+        }
+        const marginVal = this.isCustomMargin
+            ? parseFloat(this.pageSetup.customMargin) || 0.75
+            : parseFloat(this.pageSetup.margin || '0.75');
+        const pad = Math.round(marginVal * 96);
         pv.style.maxWidth = w + 'px';
         pv.style.padding = pad + 'px';
     }
@@ -5309,10 +5357,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                     pill.setAttribute('data-dg-tag', 'true');
                     pill.setAttribute('contenteditable', 'false');
                     pill.textContent = part;
-                    const isStructural = /^[#/:%@]/.test(part.charAt(1));
-                    pill.style.cssText = isStructural
-                        ? 'background:#e3f5e9;border:1px solid #9fd6b1;color:#1c7a3d;border-radius:9px;padding:0 6px;font-size:0.9em;white-space:nowrap;'
-                        : 'background:#ede7fd;border:1px solid #c9b8f5;color:#5a3fc4;border-radius:9px;padding:0 6px;font-size:0.9em;white-space:nowrap;';
+                    pill.style.cssText = this._pillStyleFor(part);
                     frag.appendChild(pill);
                 } else if (part) {
                     frag.appendChild(doc.createTextNode(part));
@@ -5320,6 +5365,81 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             }
             node.parentNode.replaceChild(frag, node);
         }
+    }
+
+    _pillStyleFor(tagText) {
+        const isStructural = /^[#/:%@*]/.test((tagText || '').charAt(1));
+        return isStructural
+            ? 'background:#e3f5e9;border:1px solid #9fd6b1;color:#1c7a3d;border-radius:9px;padding:0 6px;font-size:0.9em;white-space:nowrap;cursor:pointer;'
+            : 'background:#ede7fd;border:1px solid #c9b8f5;color:#5a3fc4;border-radius:9px;padding:0 6px;font-size:0.9em;white-space:nowrap;cursor:pointer;';
+    }
+
+    /**
+     * Pill inspector: parse the clicked pill's tag and offer one-click
+     * transformations — format suffixes, or re-render the same field as a
+     * QR code, barcode, or image.
+     */
+    _openPillMenu(pill) {
+        this._activePill = pill;
+        const raw = (pill.textContent || '').trim();
+        const inner = raw.replace(/^\{|\}$/g, '');
+        const first = inner.charAt(0);
+        let options = [];
+        let field = null;
+        if (first === '*' || first === '%') {
+            field = inner.slice(1).split(':')[0];
+        } else if (!/^[#/:@]/.test(first) && !/^(SUM|AVG|MIN|MAX|COUNT|Chart)\b/i.test(inner)) {
+            field = inner.split(':')[0];
+        }
+        if (field) {
+            options = [
+                { key: 'plain', label: 'Plain text', tag: '{' + field + '}' },
+                { key: 'currency', label: 'Currency ($1,234.00)', tag: '{' + field + ':currency}' },
+                { key: 'date_long', label: 'Date — April 17, 2026', tag: '{' + field + ':MMMM d, yyyy}' },
+                { key: 'date_short', label: 'Date — 04/17/2026', tag: '{' + field + ':MM/dd/yyyy}' },
+                { key: 'number', label: 'Number (1,234)', tag: '{' + field + ':number}' },
+                { key: 'percent', label: 'Percent (15.5%)', tag: '{' + field + ':percent}' },
+                { key: 'checkbox', label: 'Checkbox [X]/[ ]', tag: '{' + field + ':checkbox}' },
+                { key: 'label', label: 'Picklist label', tag: '{' + field + ':label}' },
+                { key: 'qr', label: 'QR code', tag: '{*' + field + ':qr:200}' },
+                { key: 'barcode', label: 'Barcode (Code 128)', tag: '{*' + field + ':code128:300x80}' },
+                { key: 'image', label: 'Image field', tag: '{%' + field + '}' }
+            ].map((o) => ({ ...o, active: o.tag === raw }));
+        }
+        // Position the menu just under the pill, relative to the canvas column.
+        const col = this.template.querySelector('.dg-designer-canvas-col');
+        const colRect = col ? col.getBoundingClientRect() : { left: 0, top: 0 };
+        const rect = pill.getBoundingClientRect();
+        this.pillMenu = {
+            tagText: raw,
+            options,
+            hasOptions: options.length > 0,
+            posStyle:
+                'left: ' + Math.max(0, rect.left - colRect.left) + 'px; top: ' + (rect.bottom - colRect.top + 6) + 'px;'
+        };
+    }
+
+    handlePillTransform(event) {
+        const tag = event.currentTarget.dataset.tag;
+        if (this._activePill && tag) {
+            this._activePill.textContent = tag;
+            this._activePill.style.cssText = this._pillStyleFor(tag);
+            this.htmlEditorDirty = true;
+        }
+        this.pillMenu = null;
+    }
+
+    handlePillRemove() {
+        if (this._activePill) {
+            this._activePill.remove();
+            this.htmlEditorDirty = true;
+        }
+        this.pillMenu = null;
+        this._activePill = null;
+    }
+
+    handlePillMenuClose() {
+        this.pillMenu = null;
     }
 
     /** Pills back to plain merge-tag text (exit path). */
@@ -5372,6 +5492,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         this.showHtmlBodyVisual = false;
         this._visualOriginalCode = null;
         this._visualEnteredDom = null;
+        this.pillMenu = null;
+        this._activePill = null;
         // Landing back in Code view — make the side-by-side preview current.
         // eslint-disable-next-line @lwc/lwc/no-async-operation
         setTimeout(() => this._refreshCodePreview(), 120);

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -383,11 +383,12 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     @track isLoadingTemplateImages = false;
     @track isUploadingInsertImage = false;
     @track templateImages = [];
-    // Visual (WYSIWYG) mode — rich-text editing of the body content while the
-    // template's <style>/@page shell is preserved and reapplied on exit.
+    // Visual mode — the scoped preview rendered contenteditable, so authors
+    // edit text in place with the real layout visible. Only the body content
+    // round-trips; head/styles/@page never do.
     @track showHtmlBodyVisual = false;
-    @track visualEditorHtml = '';
-    _visualShellStyles = null;
+    _visualOriginalCode = null;
+    _visualEnteredDom = null;
     // Last HTML body text this session touched (upload, starter, or Apply) so
     // reopening the editor doesn't need a server round-trip.
     _lastUploadedHtmlText = null;
@@ -1255,6 +1256,20 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             if (host) {
                 // eslint-disable-next-line @lwc/lwc/no-inner-html
                 host.innerHTML = this._pendingPreviewWrite.html;
+                // Visual mode: the rendered page becomes the editor.
+                if (this._pendingPreviewWrite.editable) {
+                    const pv = host.querySelector('.dg-pv');
+                    if (pv) {
+                        pv.setAttribute('contenteditable', 'true');
+                        pv.setAttribute('spellcheck', 'false');
+                        // Component CSS can't reach manual DOM — style inline.
+                        pv.style.outline = '2px dashed #b49aef';
+                        pv.style.outlineOffset = '6px';
+                        pv.style.caretColor = '#7c3aed';
+                        pv.style.cursor = 'text';
+                        this._visualEnteredDom = pv.innerHTML;
+                    }
+                }
                 this._pendingPreviewWrite = null;
             }
         }
@@ -3225,10 +3240,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             this.templateImages = [];
             this.showTagPanel = false;
             this.showHtmlBodyVisual = false;
-            this.visualEditorHtml = '';
-            this._visualShellStyles = null;
             this._visualOriginalCode = null;
-            this._visualEnteredHtml = null;
+            this._visualEnteredDom = null;
 
             let cdLinks = [];
             if (row.ContentDocumentLinks) {
@@ -4664,103 +4677,73 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     }
 
     /**
-     * Enter/exit WYSIWYG mode. Entering splits the document: <style>/@page
-     * shell is stashed, body content goes into lightning-input-rich-text.
-     * Exiting reassembles the full document (Quill alignment classes mapped
-     * to inline CSS 2.1) back into the code editor. Table layouts can't be
-     * represented by the rich-text editor, so entering warns first.
+     * Enter/exit visual (in-place) editing. The template renders through the
+     * SAME scoped-preview pipeline the Preview toggle uses — tables, bands,
+     * everything — and the rendered page is made contenteditable, so authors
+     * edit text exactly where it appears. On exit, only the edited body
+     * content is swapped back between the ORIGINAL document's <body> tags:
+     * head, styles, and @page are never round-tripped, so structure can't be
+     * mangled. Unchanged sessions restore the original code byte-for-byte.
      */
-    async handleToggleHtmlVisual() {
+    handleToggleHtmlVisual() {
         if (this.showHtmlBodyVisual) {
             this._exitVisualMode();
             return;
         }
         const ta = this.template.querySelector('.dg-html-body-editor');
         const html = (ta && ta.value) || '';
-        // HARD BLOCK, not a warning: the rich-text editor (Quill) strips
-        // tables and div layout, so entering visual mode on a layout-heavy
-        // template would destroy the design on exit. Never offer a path
-        // that silently mangles content.
-        if (/<table\b|display\s*:\s*table/i.test(html)) {
-            this.showToast(
-                'Visual editor not available for this layout',
-                'This template uses table-based layout, which the visual editor cannot represent without simplifying your design. Use Code + Preview here — Visual works great for letter-style templates.',
-                'warning'
-            );
+        if (!html.trim()) {
+            this.showToast('Nothing to edit', 'Load or paste a template body first.', 'warning');
             return;
         }
-        const styleBlocks = [];
-        let work = html.replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, (m) => {
-            styleBlocks.push(m);
-            return '';
-        });
-        const bodyMatch = work.match(/<body\b[^>]*>([\s\S]*?)<\/body\s*>/i);
-        this._visualShellStyles = styleBlocks.join('\n');
-        // Snapshots for a lossless exit: if the user just looks around and
-        // changes nothing, the code editor gets its ORIGINAL text back —
-        // no Quill-normalization round-trip.
         this._visualOriginalCode = html;
-        this.visualEditorHtml = (bodyMatch ? bodyMatch[1] : work).trim();
-        this._visualEnteredHtml = null; // captured after Quill sanitizes, on first render
+        this._visualEnteredDom = null; // captured in renderedCallback after mount
         this.showHtmlBodyPreview = false;
         this.showHtmlBodyVisual = true;
-        // Capture Quill's sanitized baseline once the editor renders, so
-        // "unchanged" is judged against what the user actually saw.
-        // eslint-disable-next-line @lwc/lwc/no-async-operation
-        setTimeout(() => {
-            const rte = this.template.querySelector('.dg-visual-editor');
-            if (rte && this._visualEnteredHtml === null) {
-                this._visualEnteredHtml = rte.value || '';
-            }
-        }, 400);
+        // Reuse the preview pipeline, but flag the write as editable so
+        // renderedCallback turns the rendered page into an editor.
+        const scoped = scopeHtmlForInlinePreview(html);
+        this._pendingPreviewWrite = { selector: '.dg-visual-host', html: scoped, editable: true };
     }
 
     /** Leave visual mode — lossless when nothing changed. */
     _exitVisualMode() {
-        const rte = this.template.querySelector('.dg-visual-editor');
-        const current = (rte && rte.value) || this.visualEditorHtml || '';
-        const unchanged = this._visualEnteredHtml !== null && current === this._visualEnteredHtml;
-        if (unchanged) {
-            const ta = this.template.querySelector('.dg-html-body-editor');
-            if (ta && this._visualOriginalCode != null) {
+        const host = this.template.querySelector('.dg-visual-host');
+        const pv = host && host.querySelector('.dg-pv');
+        const ta = this.template.querySelector('.dg-html-body-editor');
+        if (pv && ta && this._visualOriginalCode != null) {
+            const current = pv.innerHTML;
+            if (this._visualEnteredDom !== null && current !== this._visualEnteredDom) {
+                // Extract the edited content: everything except the scoped
+                // <style> the preview pipeline injected.
+                const clone = pv.cloneNode(true);
+                for (const styleEl of clone.querySelectorAll('style')) {
+                    styleEl.remove();
+                }
+                const edited = clone.innerHTML.trim();
+                // Swap ONLY the body content back into the original document —
+                // head/styles/@page are untouched by design.
+                const bodyRe = /(<body\b[^>]*>)[\s\S]*?(<\/body\s*>)/i;
+                let newCode;
+                if (bodyRe.test(this._visualOriginalCode)) {
+                    newCode = this._visualOriginalCode.replace(
+                        bodyRe,
+                        (m, open, close) => open + '\n' + edited + '\n' + close
+                    );
+                } else {
+                    // Body-fragment template (no <body> wrapper): the content IS the doc.
+                    newCode = edited;
+                }
+                ta.value = prettyPrintHtml(newCode);
+                this.htmlEditorDirty = true;
+            } else {
+                // Untouched — hand back the original text exactly.
                 ta.value = this._visualOriginalCode;
             }
-        } else {
-            this._applyVisualToCode();
         }
         this.showHtmlBodyVisual = false;
         this._visualOriginalCode = null;
-        this._visualEnteredHtml = null;
-    }
-
-    /** Reassemble shell + rich-text content into the code editor. */
-    _applyVisualToCode() {
-        const rte = this.template.querySelector('.dg-visual-editor');
-        let inner = (rte && rte.value) || this.visualEditorHtml || '';
-        // Quill emits alignment/indent as classes — translate to inline CSS 2.1.
-        inner = inner
-            .replace(/class="ql-align-(center|right|justify)"/gi, 'style="text-align: $1"')
-            .replace(/class="ql-indent-(\d)"/gi, (m, n) => 'style="margin-left: ' + Number(n) * 24 + 'pt"');
-        const shell =
-            this._visualShellStyles && this._visualShellStyles.trim()
-                ? this._visualShellStyles
-                : '<style>\n@page { size: Letter portrait; margin: 0.75in; }\nbody { font-family: Helvetica, Arial, sans-serif; font-size: 10.5pt; color: #1a1a1a; }\n</style>';
-        const doc =
-            '<!DOCTYPE html>\n<html>\n<head>\n<meta charset="utf-8" />\n' +
-            shell +
-            '\n</head>\n<body>\n' +
-            inner +
-            '\n</body>\n</html>\n';
-        const ta = this.template.querySelector('.dg-html-body-editor');
-        if (ta) {
-            ta.value = prettyPrintHtml(doc);
-        }
-        this.htmlEditorDirty = true;
-    }
-
-    handleVisualEditorChange(event) {
-        this.visualEditorHtml = event.target.value;
-        this.htmlEditorDirty = true;
+        this._visualEnteredDom = null;
     }
 
     get docxHtmlEditorClass() {
@@ -5004,9 +4987,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             return;
         }
         if (this.showHtmlBodyVisual) {
-            const rte = this.template.querySelector('.dg-visual-editor');
-            this.visualEditorHtml = ((rte && rte.value) || this.visualEditorHtml || '') + snippet;
-            this.htmlEditorDirty = true;
+            this._insertIntoVisualPage(snippet);
             this.showToast('Tag inserted', 'Added at the end of the document — move it where you need it.', 'success');
             return;
         }
@@ -5016,6 +4997,16 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 snippet.length > 60 ? 'Loop table inserted at your cursor.' : snippet + ' inserted at your cursor.',
                 'success'
             );
+        }
+    }
+
+    /** Append markup to the editable visual page (visual mode only). */
+    _insertIntoVisualPage(markup) {
+        const host = this.template.querySelector('.dg-visual-host');
+        const pv = host && host.querySelector('.dg-pv');
+        if (pv) {
+            pv.insertAdjacentHTML('beforeend', markup);
+            this.htmlEditorDirty = true;
         }
     }
 
@@ -5124,14 +5115,12 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     /** Drop a ready-made, PDF-safe <img> tag at the editor cursor. */
     _insertImageSnippet(url, name) {
         const snippet = '<img src="' + url + '" alt="' + (name || 'image') + '" style="width: 180px" />';
-        // Visual mode: append to the rich-text content instead of the textarea.
+        // Visual mode: insert into the editable rendered page directly.
         if (this.showHtmlBodyVisual) {
-            const rte = this.template.querySelector('.dg-visual-editor');
-            this.visualEditorHtml = ((rte && rte.value) || this.visualEditorHtml || '') + '<p>' + snippet + '</p>';
-            this.htmlEditorDirty = true;
+            this._insertIntoVisualPage('<p>' + snippet + '</p>');
             this.showToast(
                 'Image inserted',
-                'Added at the end of the document — drag it where you want it.',
+                'Added at the end of the document — cut/paste it where you want it, or fine-tune in Code.',
                 'success'
             );
             return;

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -1356,6 +1356,44 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     }
 
     /**
+     * Fit tables wider than the sheet (Word-conversion twips math, extra
+     * loop-tag cells) back onto the page: width 100% + table-layout fixed
+     * scales the authored column widths proportionally. The inline styles
+     * persist into the saved body, so the PDF is fixed too — flagged dirty
+     * and announced so the author knows their document was touched.
+     */
+    _fitOversizeTables(pv) {
+        try {
+            const cs = getComputedStyle(pv);
+            const contentW =
+                pv.getBoundingClientRect().width -
+                (parseFloat(cs.paddingLeft) || 0) -
+                (parseFloat(cs.paddingRight) || 0);
+            let fixed = 0;
+            for (const t of pv.querySelectorAll('table')) {
+                if (t.getBoundingClientRect().width > contentW + 1) {
+                    t.style.width = '100%';
+                    t.style.tableLayout = 'fixed';
+                    t.style.maxWidth = '100%';
+                    fixed++;
+                }
+            }
+            if (fixed) {
+                this.htmlEditorDirty = true;
+                this.showToast(
+                    'Table fit to page',
+                    fixed +
+                        (fixed === 1 ? ' table was' : ' tables were') +
+                        ' wider than the page and got scaled to fit — column proportions kept. Save as New Version keeps the fix.',
+                    'info'
+                );
+            }
+        } catch (e) {
+            /* best effort */
+        }
+    }
+
+    /**
      * Word-style "click and type": place the caret exactly where the user
      * double-clicked. Inside existing content the browser range is used
      * directly; in empty space below the last block, a fresh paragraph is
@@ -1595,6 +1633,10 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                         }
                         // Sheet dimensions follow the page setup.
                         this._applyCanvasDimensions();
+                        // Word-converted tables with absolute widths can't be
+                        // tamed by max-width alone (auto layout won't shrink
+                        // below min-content) — refit them onto the sheet.
+                        this._fitOversizeTables(pv);
                         // Context label ("Editing: Table cell") follows the caret.
                         if (!this._selListenerAdded) {
                             document.addEventListener('selectionchange', this._onSelectionChange);
@@ -6853,7 +6895,11 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             this.editTemplateOutputFormat = 'PDF';
             this.showDocxHtmlViewer = false;
             // Stage the tuned HTML as the body through the standard pipeline.
-            await this._processAndSaveHtmlBody(this.editTemplateId, text, 'converted-from-word.html', null, 'editor');
+            // Keep the Word file's identity: Sales_Quote.docx → Sales_Quote.html.
+            const htmlName =
+                ((this.uploadedFileName || this.editTemplateName || 'template').replace(/\.(docx?|html?|zip)$/i, '') ||
+                    'template') + '.html';
+            await this._processAndSaveHtmlBody(this.editTemplateId, text, htmlName, null, 'editor');
             this.showHtmlBodyEditor = true;
             this._syncHtmlBodyEditorDom(text);
             await refreshApex(this.wiredTemplatesResult);

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -1861,6 +1861,9 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     get isAuthoringFile() {
         return this.newAuthoringMode === 'file';
     }
+    get isAuthoringScratch() {
+        return this.newAuthoringMode === 'scratch';
+    }
 
     get authoringCards() {
         const defs = [
@@ -1877,6 +1880,13 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 badge: null,
                 icon: 'utility:einstein',
                 desc: "We assemble a ready-to-paste prompt with your fields and DocGen's tag syntax. Paste it into Claude, ChatGPT, or Copilot, then paste the HTML it returns straight into the template editor."
+            },
+            {
+                mode: 'scratch',
+                title: 'Start From Scratch',
+                badge: null,
+                icon: 'utility:edit',
+                desc: 'A blank page in the visual designer. Click anywhere and type, drag in blocks and merge tags, or hit ` for the insert menu — build the document your way.'
             },
             {
                 mode: 'file',
@@ -1914,7 +1924,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             return;
         }
         this.newAuthoringMode = mode;
-        if (mode === 'starter' || mode === 'ai') {
+        if (mode === 'starter' || mode === 'ai' || mode === 'scratch') {
             this.newTemplateType = 'HTML';
             this.newTemplateOutputFormat = 'PDF';
         } else {
@@ -3651,7 +3661,9 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             const record = await createRecord({ apiName: DOCGEN_TEMPLATE_OBJECT.objectApiName, fields });
             this.createdTemplateId = record.id;
             this.isCreating = false;
-            if (authoringMode !== 'starter') {
+            // Only the file path needs an upload prompt — every other mode
+            // lands directly in the designer.
+            if (authoringMode === 'file') {
                 this.showToast('Success', 'Template Record created. Please upload your document.', 'success');
             }
 
@@ -3696,6 +3708,10 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                 if (aiPastedHtml) {
                     await this._applyPastedBody(record.id, aiPastedHtml, newRow.Name);
                 }
+                this.isEditModalOpen = false;
+                await this._openDesignerSurface();
+            } else if (authoringMode === 'scratch') {
+                // Blank page — the designer seeds a clean sheet to type into.
                 this.isEditModalOpen = false;
                 await this._openDesignerSurface();
             }

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -6,7 +6,14 @@ import { NavigationMixin } from 'lightning/navigation';
 import { refreshApex } from '@salesforce/apex';
 import { downloadBase64 as downloadBase64Util, parseSOQLFields, stripOuterSelectFrom } from 'c/docGenUtils';
 // HTML-first authoring: starter designs, AI prompt builder, query-shape extractor
-import { STARTERS, extractQueryShape, buildStarterHtml, buildAiPrompt } from './docGenAuthoringKit';
+import {
+    STARTERS,
+    extractQueryShape,
+    buildStarterHtml,
+    buildAiPrompt,
+    prettyPrintHtml,
+    scopeHtmlForInlinePreview
+} from './docGenAuthoringKit';
 
 // Apex
 import getAllTemplates from '@salesforce/apex/DocGenController.getAllTemplates';
@@ -364,6 +371,9 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     @track isLoadingDocxHtml = false;
     @track isSwitchingToHtml = false;
     @track docxSnapshotInfo = null;
+    // Code ⇄ Preview toggles (textarea stays mounted-but-hidden so its value survives)
+    @track showHtmlBodyPreview = false;
+    @track showDocxHtmlPreview = false;
     // Last HTML body text this session touched (upload, starter, or Apply) so
     // reopening the editor doesn't need a server round-trip.
     _lastUploadedHtmlText = null;
@@ -1221,6 +1231,17 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             const ta = this.template.querySelector('.edit-query-textarea');
             if (ta && ta.value !== this.editTemplateQuery) {
                 ta.value = this.editTemplateQuery;
+            }
+        }
+        // Inline HTML preview: the lwc:dom="manual" host only exists after the
+        // re-render that the Preview toggle triggers, so the content write has
+        // to happen here rather than in the click handler.
+        if (this._pendingPreviewWrite) {
+            const host = this.template.querySelector(this._pendingPreviewWrite.selector);
+            if (host) {
+                // eslint-disable-next-line @lwc/lwc/no-inner-html
+                host.innerHTML = this._pendingPreviewWrite.html;
+                this._pendingPreviewWrite = null;
             }
         }
     }
@@ -3184,6 +3205,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             this.docxSnapshotInfo = null;
             this.isLoadingDocxHtml = false;
             this.isSwitchingToHtml = false;
+            this.showHtmlBodyPreview = false;
+            this.showDocxHtmlPreview = false;
 
             let cdLinks = [];
             if (row.ContentDocumentLinks) {
@@ -4597,6 +4620,76 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
 
     handleHtmlBodyEditorInput() {
         this.htmlEditorDirty = true;
+    }
+
+    // --- Format Code + Code ⇄ Preview (shared by the HTML editor and the DOCX viewer) ---
+    get htmlBodyPreviewToggleLabel() {
+        return this.showHtmlBodyPreview ? 'Show Code' : 'Preview';
+    }
+
+    get docxHtmlPreviewToggleLabel() {
+        return this.showDocxHtmlPreview ? 'Show Code' : 'Preview';
+    }
+
+    get htmlBodyEditorClass() {
+        return this.showHtmlBodyPreview ? 'dg-html-body-editor slds-hide' : 'dg-html-body-editor';
+    }
+
+    get docxHtmlEditorClass() {
+        return this.showDocxHtmlPreview
+            ? 'dg-html-body-editor dg-docx-html-editor slds-hide'
+            : 'dg-html-body-editor dg-docx-html-editor';
+    }
+
+    handleFormatHtml(event) {
+        const isDocx = event.currentTarget.dataset.target === 'docx';
+        const ta = this.template.querySelector(isDocx ? '.dg-docx-html-editor' : '.dg-html-body-editor');
+        if (!ta || !ta.value || !ta.value.trim()) {
+            this.showToast('Nothing to format', 'The editor is empty.', 'warning');
+            return;
+        }
+        ta.value = prettyPrintHtml(ta.value);
+        if (!isDocx) {
+            // Formatting changes the text that Apply would stage — surface it.
+            this.htmlEditorDirty = true;
+        }
+    }
+
+    handleToggleHtmlPreview(event) {
+        const isDocx = event.currentTarget.dataset.target === 'docx';
+        if (isDocx) {
+            this.showDocxHtmlPreview = !this.showDocxHtmlPreview;
+            if (this.showDocxHtmlPreview) {
+                this._renderHtmlPreview('.dg-docx-preview', '.dg-docx-html-editor');
+            }
+        } else {
+            this.showHtmlBodyPreview = !this.showHtmlBodyPreview;
+            if (this.showHtmlBodyPreview) {
+                this._renderHtmlPreview('.dg-body-preview', '.dg-html-body-editor');
+            }
+        }
+    }
+
+    /**
+     * Render the textarea's HTML into the inline preview div. LWS blocks
+     * iframe srcdoc/document.write, so the markup goes in via innerHTML with
+     * its CSS scoped to the preview container (see scopeHtmlForInlinePreview).
+     * Merge tags show literally — Generate Sample remains the real-data path.
+     */
+    _renderHtmlPreview(hostSelector, taSelector) {
+        const ta = this.template.querySelector(taSelector);
+        const scoped = scopeHtmlForInlinePreview((ta && ta.value) || '');
+        // The host div mounts on the NEXT render cycle (it's behind an
+        // if:true the caller just flipped) — renderedCallback completes the
+        // write once the node exists.
+        this._pendingPreviewWrite = { selector: hostSelector, html: scoped };
+        const host = this.template.querySelector(hostSelector);
+        if (host) {
+            // Already mounted (e.g. re-render of an open preview) — write now.
+            // eslint-disable-next-line @lwc/lwc/no-inner-html
+            host.innerHTML = scoped;
+            this._pendingPreviewWrite = null;
+        }
     }
 
     async toggleHtmlBodyEditor() {

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -435,6 +435,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     @track pillMenu = null;
     // Notion-style slash-command menu: type "/" in the canvas → searchable insert palette.
     @track slashMenu = null;
+    // Right-click context menu in the canvas.
+    @track ctxMenu = null;
     _slashCtx = null;
     _slashSel = 0;
     // Floating searchable panels replace the fixed right rail: 'insert' | 'tags' | 'images' | 'watermark'.
@@ -1541,6 +1543,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                             } else if (!pill) {
                                 this.pillMenu = null;
                                 this._closeSlashMenu();
+                                this.ctxMenu = null;
                             }
                         });
                         pv.addEventListener('dblclick', (e) => {
@@ -1553,6 +1556,32 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                             // Word-style click-and-type: double-click empty page
                             // space starts a cursor right there.
                             this._placeCaretAtPoint(e, pv);
+                        });
+                        // Right-click: contextual menu (pill menu on pills;
+                        // insert/format/table actions elsewhere).
+                        pv.addEventListener('contextmenu', (e) => {
+                            e.preventDefault();
+                            this._closeSlashMenu();
+                            const pill = e.target && e.target.closest ? e.target.closest('[data-dg-tag]') : null;
+                            if (pill && pill.getAttribute('contenteditable') !== 'true') {
+                                this.ctxMenu = null;
+                                this._openPillMenu(pill);
+                                return;
+                            }
+                            this.pillMenu = null;
+                            this._placeCaretAtPoint(e, pv);
+                            const col = this.template.querySelector('.dg-designer-canvas-col');
+                            const colRect = col ? col.getBoundingClientRect() : { left: 0, top: 0 };
+                            this._ctxPoint = { x: e.clientX, y: e.clientY };
+                            this.ctxMenu = {
+                                inTable: !!(e.target && e.target.closest && e.target.closest('td, th')),
+                                posStyle:
+                                    'left: ' +
+                                    Math.max(0, e.clientX - colRect.left) +
+                                    'px; top: ' +
+                                    (e.clientY - colRect.top + 4) +
+                                    'px;'
+                            };
                         });
                         // Column resize: grab a cell's right edge and drag.
                         pv.addEventListener('mousemove', (e) => this._tableResizeHover(e, pv));
@@ -6108,8 +6137,23 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         const startX = event.clientX;
         const startW = cell.getBoundingClientRect().width;
         const doc = pv.ownerDocument || document;
+        // Fixed-layout tables (all Word-converted ones after the auto-fit)
+        // read column widths from <colgroup> cols and the FIRST row — writing
+        // only the grabbed cell does nothing there. Write all three.
+        const table = cell.closest('table');
+        const colIdx = Array.prototype.indexOf.call(cell.parentElement.children, cell);
+        const colEl = table ? table.querySelectorAll('colgroup col')[colIdx] : null;
+        const firstRowCell = table && table.rows.length ? table.rows[0].children[colIdx] : null;
         const onMove = (ev) => {
-            cell.style.width = Math.max(24, startW + (ev.clientX - startX)) + 'px';
+            const w = Math.max(24, startW + (ev.clientX - startX)) + 'px';
+            cell.style.width = w;
+            if (colEl) {
+                colEl.removeAttribute('width');
+                colEl.style.width = w;
+            }
+            if (firstRowCell && firstRowCell !== cell) {
+                firstRowCell.style.width = w;
+            }
         };
         const onUp = () => {
             doc.removeEventListener('mousemove', onMove);
@@ -7040,6 +7084,94 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         return (this.templates || []).filter((t) => t[F.Type] === 'HTML').map((t) => ({ label: t.Name, value: t.Id }));
     }
 
+    // --- Right-click context menu handlers ---
+    handleCtxClose() {
+        this.ctxMenu = null;
+    }
+    handleCtxFormat(event) {
+        this.ctxMenu = null;
+        this.handleFormatAction(event);
+    }
+    handleCtxTable(event) {
+        this.ctxMenu = null;
+        this.handleTableAction(event);
+    }
+    handleCtxList(event) {
+        const ordered = event.currentTarget.dataset.kind === 'ol';
+        this.ctxMenu = null;
+        this._toggleListAtCaret(ordered);
+    }
+    handleCtxInsert() {
+        const pt = this._ctxPoint;
+        this.ctxMenu = null;
+        if (pt) {
+            this._openSlashMenuAtPoint(pt.x, pt.y);
+        }
+    }
+    handleCtxDeleteBlock() {
+        this.ctxMenu = null;
+        const blk = this._selectedBlockElement();
+        if (blk) {
+            blk.remove();
+            this.htmlEditorDirty = true;
+        }
+    }
+
+    /** Open the insert menu at an arbitrary point (right-click path — no typed
+     *  trigger, so executing an item skips trigger-text removal). */
+    _openSlashMenuAtPoint(x, y) {
+        this._slashQuery = '';
+        this._slashCtx = null;
+        this._slashSel = 0;
+        const col = this.template.querySelector('.dg-designer-canvas-col');
+        const colRect = col ? col.getBoundingClientRect() : { left: 0, top: 0 };
+        this._renderSlashMenu({ left: x, bottom: y, width: 1, height: 1 }, colRect);
+    }
+
+    /** Versions panel: load any version's body into the editor (staged only
+     *  when the author saves — loading changes nothing by itself). */
+    async handleLoadVersionIntoDesigner(event) {
+        const cvId = event.currentTarget.dataset.cvid;
+        const verName = event.currentTarget.dataset.ver;
+        if (!cvId) {
+            return;
+        }
+        try {
+            const b64 = await getContentVersionBase64({ contentVersionId: cvId });
+            const bin = atob(b64);
+            const bytes = new Uint8Array(bin.length);
+            for (let i = 0; i < bin.length; i++) {
+                bytes[i] = bin.charCodeAt(i);
+            }
+            const text = new TextDecoder('utf-8').decode(bytes);
+            if (!/</.test(text.slice(0, 500))) {
+                this.showToast(
+                    'Not an HTML body',
+                    verName +
+                        ' points at a non-HTML file (e.g. the original .docx) — download it from Edit Template instead.',
+                    'warning'
+                );
+                return;
+            }
+            this.activePanel = null;
+            if (this.showHtmlBodyVisual) {
+                this._exitVisualMode();
+            }
+            this._syncHtmlBodyEditorDom(text);
+            this._lastUploadedHtmlText = text;
+            this.htmlEditorDirty = true;
+            this._enterVisualMode(text);
+            this.showToast(
+                'Loaded ' + verName,
+                'This version is now in the editor. Nothing changed yet — Save as New Version creates a NEW version from it.',
+                'success'
+            );
+        } catch (err) {
+            const msg = err && err.body && err.body.message ? err.body.message : (err && err.message) || String(err);
+            this.showToast('Could not load version', msg, 'error');
+        }
+    }
+
     // --- Header / Footer panel (repeats on every PDF page) ---
     handleDesignerHeaderChange(event) {
         this.editTemplateHeaderHtml = event.target.value;
@@ -7209,8 +7341,11 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     get isPanelHf() {
         return this.activePanel === 'hf';
     }
+    get isPanelVersions() {
+        return this.activePanel === 'versions';
+    }
     get showPanelSearch() {
-        return !this.isPanelWatermark && !this.isPanelHf;
+        return !this.isPanelWatermark && !this.isPanelHf && !this.isPanelVersions;
     }
     get floatPanelTitle() {
         return {
@@ -7218,7 +7353,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             tags: 'Merge tags',
             images: 'Image assets',
             watermark: 'Watermark',
-            hf: 'Header & Footer'
+            hf: 'Header & Footer',
+            versions: 'Version history'
         }[this.activePanel];
     }
     get panelSearchPlaceholder() {
@@ -7232,6 +7368,9 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         this._focusPanelSearch = !!this.activePanel;
         if (this.activePanel === 'images') {
             this._loadWizardAssets();
+        }
+        if (this.activePanel === 'versions' && this.editTemplateId) {
+            this.loadVersions(this.editTemplateId);
         }
     }
     handlePanelClose() {

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -4421,6 +4421,24 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             this.showToast('Error', 'Name and Type are required.', 'error');
             return;
         }
+        // Designer: unapplied visual/source edits fold into the staged body
+        // automatically — "Save as New Version" saves what you're looking at,
+        // no separate Apply click required.
+        if (this.activeMainTab === 'design' && this.htmlEditorDirty && this.editTemplateType === 'HTML') {
+            const draft = (this._currentDraftHtml() || '').trim();
+            if (draft) {
+                try {
+                    const base = (this.uploadedFileName || 'template.html').replace(/\.(html?|zip)$/i, '');
+                    await this._processAndSaveHtmlBody(this.editTemplateId, draft, base + '.html', null, 'editor');
+                    this.htmlEditorDirty = false;
+                } catch (err) {
+                    const msg =
+                        err && err.body && err.body.message ? err.body.message : (err && err.message) || String(err);
+                    this.showToast('Could not stage your edits', msg, 'error');
+                    return;
+                }
+            }
+        }
 
         const fields = {
             Id: this.editTemplateId,
@@ -6931,22 +6949,65 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     }
 
     // --- Notion-style slash-command menu ---
-    /** Everything insertable, flattened and rankable by the "/" query. */
+    /** EVERY command, flattened and searchable by plain-language intent —
+     *  "close tag", "start loop", "money", "bold" all find their thing. */
     _slashCatalog() {
         const out = [];
         let i = 0;
+        const add = (label, group, item) => out.push({ key: 's' + i++, label, group, ...item });
+        // Plain-language loop + conditional entries, built from the real query.
+        const shape = extractQueryShape(this.editTemplateQuery, this.editTemplateObject);
+        for (const c of shape.children || []) {
+            add(`Start loop — repeat for each ${c.relationshipName}`, 'Loops', {
+                snippet: '{#' + c.relationshipName + '}',
+                keywords: 'start open begin loop repeat each every child rows for'
+            });
+            add(`Close loop — end of ${c.relationshipName}`, 'Loops', {
+                snippet: '{/' + c.relationshipName + '}',
+                keywords: 'close end stop finish loop tag slash'
+            });
+        }
+        add('Show only when… (start of if)', 'Conditionals', {
+            snippet: '{#FieldName}',
+            keywords: 'if condition conditional when show only start open hide'
+        });
+        add('Otherwise… (else)', 'Conditionals', {
+            snippet: '{:else}',
+            keywords: 'else otherwise fallback condition'
+        });
+        add('End of condition (close the if)', 'Conditionals', {
+            snippet: '{/FieldName}',
+            keywords: 'close end if condition tag finish stop'
+        });
+        // Editor commands — the format bar, searchable from the keyboard.
+        const CMDS = [
+            ['Bold text', 'bold', 'bold strong heavy thick'],
+            ['Italic text', 'italic', 'italic slant emphasis'],
+            ['Underline text', 'underline', 'underline'],
+            ['Strikethrough text', 'strikeThrough', 'strike strikethrough cross out'],
+            ['Bulleted list', 'ul', 'bullet bulleted list dots points unordered'],
+            ['Numbered list', 'ol', 'number numbered list ordered steps 123'],
+            ['Align left', 'justifyLeft', 'align left'],
+            ['Align center', 'justifyCenter', 'align center middle'],
+            ['Align right', 'justifyRight', 'align right'],
+            ['Clear formatting', 'removeFormat', 'clear remove formatting plain reset'],
+            ['Insert table (3 columns)', 'table', 'table grid columns rows insert']
+        ];
+        for (const [label, cmd, keywords] of CMDS) {
+            add(label, 'Formatting', { cmd, keywords });
+        }
         for (const sec of this.blockPaletteSections) {
             for (const it of sec.items) {
-                out.push({ key: 's' + i++, label: it.label, group: sec.label, snippet: it.snippet });
+                add(it.label, sec.label, { snippet: it.snippet, keywords: it.title || '' });
             }
         }
         for (const sec of this.tagPaletteSections) {
             for (const it of sec.items) {
-                out.push({ key: 's' + i++, label: it.label, group: sec.label, snippet: it.snippet });
+                add(it.label, sec.label, { snippet: it.snippet, keywords: (it.title || '') + ' merge tag field' });
             }
         }
         for (const a of this.wizardAssets || []) {
-            out.push({ key: 's' + i++, label: a.name, group: 'Image assets', snippet: a.mergeTag });
+            add(a.name, 'Image assets', { snippet: a.mergeTag, keywords: 'image picture logo asset photo' });
         }
         return out;
     }
@@ -6991,15 +7052,31 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             const colRect = col ? col.getBoundingClientRect() : { left: 0, top: 0 };
             this._renderSlashMenu(rect, colRect);
         } catch (e) {
-            this._closeSlashMenu();
+            // Surface failures IN the menu — console output from LWS contexts
+            // is unreliable, silent closes hide real bugs.
+            this.slashMenu = {
+                query: '',
+                hasItems: false,
+                posStyle: 'left: 40px; top: 40px;',
+                items: [],
+                errorMsg: (e && e.message) || String(e)
+            };
         }
     }
 
     _renderSlashMenu(rect, colRect) {
         const q = (this._slashQuery || '').toLowerCase().trim();
         const all = this._slashCatalog();
-        const scored = q ? all.filter((o) => (o.label + ' ' + o.group).toLowerCase().includes(q)) : all;
-        const items = scored.slice(0, 9);
+        // Every word of the query must match somewhere in label/group/keywords
+        // — so "close loop", "start loop", "end if" all find their command.
+        const terms = q.split(/\s+/).filter(Boolean);
+        const scored = terms.length
+            ? all.filter((o) => {
+                  const hay = (o.label + ' ' + o.group + ' ' + (o.keywords || '')).toLowerCase();
+                  return terms.every((t) => hay.includes(t));
+              })
+            : all;
+        const items = scored.slice(0, 10);
         if (this._slashSel >= items.length) {
             this._slashSel = Math.max(0, items.length - 1);
         }
@@ -7086,6 +7163,23 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             }
         } catch (e) {
             /* insertion falls back to caret/append */
+        }
+        // Formatting commands act at the caret instead of inserting markup.
+        if (item.cmd) {
+            if (item.cmd === 'ul' || item.cmd === 'ol') {
+                this._toggleListAtCaret(item.cmd === 'ol');
+            } else if (item.cmd === 'table') {
+                this.handleInsertTable();
+            } else {
+                try {
+                    document.execCommand('styleWithCSS', false, false);
+                } catch (e) {
+                    /* best effort */
+                }
+                document.execCommand(item.cmd, false, null);
+            }
+            this.htmlEditorDirty = true;
+            return;
         }
         this._insertIntoVisualPage(item.snippet);
     }

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -26,6 +26,18 @@ const STARTER_OBJECTS = {
     agreement: 'Account'
 };
 
+// Flexipage-style section presets — equal-width columns, Flying Saucer safe
+// (display:table/table-cell, never flex/grid).
+const SECTION_COLUMN_PRESETS = [2, 3, 4, 6, 12];
+function columnsSectionSnippet(n) {
+    let cells = '';
+    for (let i = 0; i < n; i++) {
+        cells +=
+            '<div style="display: table-cell; vertical-align: top; padding: 0 5pt"><p>Column ' + (i + 1) + '</p></div>';
+    }
+    return '\n<div style="display: table; width: 100%; table-layout: fixed; margin: 8pt 0">' + cells + '</div>\n';
+}
+
 // Apex
 import getAllTemplates from '@salesforce/apex/DocGenController.getAllTemplates';
 import deleteTemplate from '@salesforce/apex/DocGenController.deleteTemplate';
@@ -38,6 +50,7 @@ import generateDocumentParts from '@salesforce/apex/DocGenController.generateDoc
 import getContentVersionBase64 from '@salesforce/apex/DocGenController.getContentVersionBase64';
 import getLatestContentVersionId from '@salesforce/apex/DocGenController.getLatestContentVersionId';
 import generatePdf from '@salesforce/apex/DocGenController.generatePdf';
+import previewDraftPdf from '@salesforce/apex/DocGenController.previewDraftPdf';
 import generatePdfAsync from '@salesforce/apex/DocGenController.generatePdfAsync';
 import getPdfSampleGenerationStatus from '@salesforce/apex/DocGenController.getPdfSampleGenerationStatus';
 import prepareChartImages from '@salesforce/apex/DocGenChartImageController.prepareChartImages';
@@ -420,6 +433,16 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     @track selectionContextLabel = '';
     // Pill inspector: click a pill → formatting menu (currency, date, QR…)
     @track pillMenu = null;
+    // Notion-style slash-command menu: type "/" in the canvas → searchable insert palette.
+    @track slashMenu = null;
+    _slashCtx = null;
+    _slashSel = 0;
+    // Floating searchable panels replace the fixed right rail: 'insert' | 'tags' | 'images' | 'watermark'.
+    @track activePanel = null;
+    @track panelSearch = '';
+    // Live PDF preview: draft HTML → real Blob.toPdf render → blob: iframe.
+    @track pdfPreviewUrl = null;
+    @track isPdfPreviewLoading = false;
     _activePill = null;
     // Canvas page setup, mirrored into the template's @page rule. Custom
     // sizes cover everything from 3x4in nametags to poster PDFs.
@@ -1315,6 +1338,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                     document.execCommand('insertText', false, '/');
                     this.htmlEditorDirty = true;
                     this._maybePillifyTyped();
+                    this._maybeOpenSlashMenu();
                 }
                 if (triesLeft > 0) {
                     // eslint-disable-next-line @lwc/lwc/no-async-operation
@@ -1353,7 +1377,21 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             const blocks = Array.from(pv.children).filter((c) => !c.matches('style'));
             const last = blocks[blocks.length - 1];
             const belowContent = last && e.clientY > last.getBoundingClientRect().bottom + 4;
-            if (belowContent || !range || !pv.contains(range.startContainer)) {
+            // Empty container under the pointer (section column, table cell,
+            // panel div): start a paragraph inside IT, not wherever the range
+            // snapped to.
+            const under = document.elementFromPoint(e.clientX, e.clientY);
+            const container =
+                under && pv.contains(under) && under !== pv && /^(DIV|TD|TH)$/.test(under.tagName) ? under : null;
+            const rangeMissesContainer = container && (!range || !container.contains(range.startContainer));
+            if (rangeMissesContainer) {
+                const p = document.createElement('p');
+                p.appendChild(document.createElement('br'));
+                container.appendChild(p);
+                range = document.createRange();
+                range.setStart(p, 0);
+                this.htmlEditorDirty = true;
+            } else if (belowContent || !range || !pv.contains(range.startContainer)) {
                 const p = document.createElement('p');
                 p.appendChild(document.createElement('br'));
                 pv.appendChild(p);
@@ -1391,6 +1429,14 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             const want = this.pageSetup[sel.dataset.field];
             if (want != null && sel.value !== want && !sel.matches(':focus')) {
                 sel.value = want;
+            }
+        }
+        // Searchable panel just opened — put the cursor in its search box.
+        if (this._focusPanelSearch) {
+            const inp = this.template.querySelector('.dg-panel-search');
+            if (inp) {
+                inp.focus();
+                this._focusPanelSearch = false;
             }
         }
         // Inline HTML preview: the lwc:dom="manual" host only exists after the
@@ -1432,6 +1478,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                         pv.addEventListener('input', () => {
                             this.htmlEditorDirty = true;
                             this._maybePillifyTyped();
+                            // Notion-style: "/" at the caret opens the insert menu.
+                            this._maybeOpenSlashMenu();
                         });
                         // Click a pill → its formatting menu; click elsewhere closes it.
                         // Double-click a pill → edit its tag text in place.
@@ -1442,6 +1490,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                                 this._openPillMenu(pill);
                             } else if (!pill) {
                                 this.pillMenu = null;
+                                this._closeSlashMenu();
                             }
                         });
                         pv.addEventListener('dblclick', (e) => {
@@ -1472,6 +1521,10 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                             this._canvasFocused = true;
                         });
                         pv.addEventListener('keydown', (e) => {
+                            // Open slash menu drives arrows/Enter/Escape.
+                            if (this._slashMenuKeydown(e)) {
+                                return;
+                            }
                             // Track typing recency for the "/" recovery below.
                             // Only content keys — Tab/arrows must not count, or
                             // tabbing away right after typing would false-match.
@@ -1698,14 +1751,17 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         }
     }
 
-    /** Shared image assets shown on the AI step and named in the prompt. */
+    /** Shared image assets: the ONE image pipeline — wizard logo picker,
+     *  designer asset panel, slash menu, and the AI prompt all read this. */
     async _loadWizardAssets() {
         try {
             const assets = (await getAssets()) || [];
             this.wizardAssets = assets.map((a) => ({
                 id: a.id,
                 name: a.name,
-                mergeTag: a.mergeTag || '{%asset:' + a.assetKey + '}'
+                assetKey: a.assetKey,
+                mergeTag: a.mergeTag || '{%asset:' + a.assetKey + '}',
+                previewUrl: a.latestVersionCvId ? '/sfc/servlet.shepherd/version/download/' + a.latestVersionCvId : null
             }));
         } catch (e) {
             this.wizardAssets = [];
@@ -1884,26 +1940,28 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         }
     }
 
-    /** Logo control: pick an existing shared asset or upload a new image. */
+    /** Logo control: pick from the shared asset library — the one image
+     *  pipeline. New images are added under the Assets tab. */
     get logoChoiceOptions() {
         const opts = [{ label: 'No logo', value: 'none' }];
         for (const a of this.wizardAssets || []) {
             opts.push({ label: a.name + ' — ' + a.mergeTag, value: a.id });
         }
-        opts.push({ label: 'Upload a new image…', value: 'upload' });
         return opts;
     }
 
-    get showLogoUpload() {
-        return this.newTemplateLogoChoice === 'upload';
+    get hasNoAssetsYet() {
+        return !(this.wizardAssets || []).length;
+    }
+
+    /** Thumbnail of the chosen logo asset, shown under the picker. */
+    get selectedLogoPreviewUrl() {
+        const a = (this.wizardAssets || []).find((x) => x.id === this.newTemplateLogoChoice);
+        return a ? a.previewUrl : null;
     }
 
     handleLogoChoiceChange(event) {
         this.newTemplateLogoChoice = event.detail.value;
-        if (this.newTemplateLogoChoice !== 'upload') {
-            this._logoFile = null;
-            this.newTemplateLogoName = '';
-        }
     }
 
     /** Merge tag the starter's logo slots should carry, per the user's choice. */
@@ -6346,6 +6404,83 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     }
 
     /** Leave visual mode — lossless when nothing changed. */
+    /**
+     * The full document as it stands RIGHT NOW — visual-mode edits serialized
+     * non-destructively (same clone/unpillify/body-swap as exit, without
+     * leaving visual mode), source mode read straight from the textarea.
+     */
+    _currentDraftHtml() {
+        if (this.showHtmlBodyVisual) {
+            const host = this.template.querySelector('.dg-visual-host');
+            const pv = host && host.querySelector('.dg-pv');
+            if (pv && this._visualOriginalCode != null) {
+                const clone = pv.cloneNode(true);
+                for (const styleEl of clone.querySelectorAll('style')) {
+                    styleEl.remove();
+                }
+                for (const markerEl of clone.querySelectorAll('.dg-drop-marker')) {
+                    markerEl.remove();
+                }
+                this._unpillifyTags(clone);
+                const edited = clone.innerHTML.trim();
+                const bodyRe = /(<body\b[^>]*>)[\s\S]*?(<\/body\s*>)/i;
+                return bodyRe.test(this._visualOriginalCode)
+                    ? this._visualOriginalCode.replace(bodyRe, (m, open, close) => open + '\n' + edited + '\n' + close)
+                    : edited;
+            }
+        }
+        const ta = this.template.querySelector('.dg-html-body-editor');
+        return (ta && ta.value) || this._lastUploadedHtmlText || '';
+    }
+
+    // --- Live PDF preview (real Blob.toPdf output in a blob: iframe) ---
+    async handlePdfPreview() {
+        if (!this.editTemplateTestRecordId) {
+            this.showToast(
+                'Pick a sample record',
+                'PDF preview merges real data — choose a Sample Record in the toolbar first.',
+                'warning'
+            );
+            return;
+        }
+        const draftHtml = (this._currentDraftHtml() || '').trim();
+        if (!draftHtml) {
+            this.showToast('Nothing to preview', 'The editor is empty.', 'warning');
+            return;
+        }
+        this.isPdfPreviewLoading = true;
+        try {
+            const res = await previewDraftPdf({
+                templateId: this.editTemplateId,
+                recordId: this.editTemplateTestRecordId,
+                draftHtml
+            });
+            if (!res || !res.contentDocumentId) {
+                throw new Error('Preview returned no PDF.');
+            }
+            // LWS forbids blob: iframes, and shepherd URLs force a download —
+            // Salesforce's native file-preview overlay is the clean viewer.
+            this[NavigationMixin.Navigate]({
+                type: 'standard__namedPage',
+                attributes: { pageName: 'filePreview' },
+                state: { selectedRecordId: res.contentDocumentId }
+            });
+        } catch (err) {
+            const msg = err && err.body && err.body.message ? err.body.message : (err && err.message) || String(err);
+            this.showToast('PDF preview failed', msg, 'error');
+        } finally {
+            this.isPdfPreviewLoading = false;
+        }
+    }
+
+    handleClosePdfPreview() {
+        this.pdfPreviewUrl = null;
+    }
+
+    get pdfPreviewBtnLabel() {
+        return this.isPdfPreviewLoading ? 'Rendering…' : 'PDF Preview';
+    }
+
     _exitVisualMode() {
         const host = this.template.querySelector('.dg-visual-host');
         const pv = host && host.querySelector('.dg-pv');
@@ -6646,7 +6781,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         this.showTagPanel = true;
         this.showImagePanel = true;
         await this._loadBodyIntoEditor();
-        this._loadTemplateImages();
+        // Asset library feeds the Images panel + slash menu + tag pills.
+        this._loadWizardAssets();
         let body = this._lastUploadedHtmlText;
         if (!body || !body.trim()) {
             // Blank template: seed a clean sheet so click-and-type just works.
@@ -6661,6 +6797,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         if (this.showHtmlBodyVisual) {
             this._exitVisualMode();
         }
+        this.handleClosePdfPreview();
+        this.activePanel = null;
         if (this.htmlEditorDirty || this.stagedBodySource) {
             this.showToast(
                 'Heads up',
@@ -6676,7 +6814,261 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     // --- Blocks palette (drag-in layout pieces) ---
     get blockPaletteSections() {
         const shape = extractQueryShape(this.editTemplateQuery, this.editTemplateObject);
-        return buildBlockPalette(shape);
+        const sections = buildBlockPalette(shape);
+        return [
+            {
+                key: 'sections',
+                label: 'Sections',
+                hint: 'Flexipage-style equal columns — up to 12, like a page layout.',
+                items: SECTION_COLUMN_PRESETS.map((n) => ({
+                    key: 'seccols' + n,
+                    label: n + ' columns',
+                    title: n + ' equal-width columns section',
+                    snippet: columnsSectionSnippet(n)
+                }))
+            },
+            ...sections
+        ];
+    }
+
+    // --- Floating searchable panels (replace the fixed right rail) ---
+    get showFloatPanel() {
+        return !!this.activePanel;
+    }
+    get isPanelInsert() {
+        return this.activePanel === 'insert';
+    }
+    get isPanelTags() {
+        return this.activePanel === 'tags';
+    }
+    get isPanelImages() {
+        return this.activePanel === 'images';
+    }
+    get isPanelWatermark() {
+        return this.activePanel === 'watermark';
+    }
+    get floatPanelTitle() {
+        return { insert: 'Insert blocks', tags: 'Merge tags', images: 'Image assets', watermark: 'Watermark' }[
+            this.activePanel
+        ];
+    }
+    get panelSearchPlaceholder() {
+        return this.activePanel === 'tags' ? 'Search fields, loops, charts…' : 'Search…';
+    }
+
+    handlePanelToggle(event) {
+        const p = event.currentTarget.dataset.panel;
+        this.activePanel = this.activePanel === p ? null : p;
+        this.panelSearch = '';
+        this._focusPanelSearch = !!this.activePanel;
+        if (this.activePanel === 'images') {
+            this._loadWizardAssets();
+        }
+    }
+    handlePanelClose() {
+        this.activePanel = null;
+    }
+    handlePanelSearch(event) {
+        this.panelSearch = event.target.value || '';
+    }
+
+    _filterSections(sections) {
+        const q = (this.panelSearch || '').toLowerCase().trim();
+        if (!q) {
+            return sections;
+        }
+        return sections
+            .map((s) => ({
+                ...s,
+                items: s.items.filter((it) =>
+                    (it.label + ' ' + (it.title || '') + ' ' + s.label).toLowerCase().includes(q)
+                )
+            }))
+            .filter((s) => s.items.length);
+    }
+    get filteredBlockSections() {
+        return this._filterSections(this.blockPaletteSections);
+    }
+    get filteredTagSections() {
+        return this._filterSections(this.tagPaletteSections);
+    }
+    get filteredTemplateImages() {
+        const q = (this.panelSearch || '').toLowerCase().trim();
+        const imgs = this.templateImages || [];
+        return q ? imgs.filter((i) => (i.fileName || '').toLowerCase().includes(q)) : imgs;
+    }
+    get hasFilteredTemplateImages() {
+        return this.filteredTemplateImages.length > 0;
+    }
+    /** Asset library entries for the designer panel — searchable by name/key. */
+    get filteredAssets() {
+        const q = (this.panelSearch || '').toLowerCase().trim();
+        const assets = this.wizardAssets || [];
+        return q
+            ? assets.filter((a) => (a.name + ' ' + a.assetKey + ' ' + a.mergeTag).toLowerCase().includes(q))
+            : assets;
+    }
+    get hasFilteredAssets() {
+        return this.filteredAssets.length > 0;
+    }
+
+    // --- Notion-style slash-command menu ---
+    /** Everything insertable, flattened and rankable by the "/" query. */
+    _slashCatalog() {
+        const out = [];
+        let i = 0;
+        for (const sec of this.blockPaletteSections) {
+            for (const it of sec.items) {
+                out.push({ key: 's' + i++, label: it.label, group: sec.label, snippet: it.snippet });
+            }
+        }
+        for (const sec of this.tagPaletteSections) {
+            for (const it of sec.items) {
+                out.push({ key: 's' + i++, label: it.label, group: sec.label, snippet: it.snippet });
+            }
+        }
+        for (const a of this.wizardAssets || []) {
+            out.push({ key: 's' + i++, label: a.name, group: 'Image assets', snippet: a.mergeTag });
+        }
+        return out;
+    }
+
+    _maybeOpenSlashMenu() {
+        try {
+            const sel = window.getSelection();
+            if (!sel || !sel.rangeCount || !sel.isCollapsed) {
+                this._closeSlashMenu();
+                return;
+            }
+            const node = sel.anchorNode;
+            if (!node || node.nodeType !== 3) {
+                this._closeSlashMenu();
+                return;
+            }
+            const host = this.template.querySelector('.dg-visual-host');
+            const pv = host && host.querySelector('.dg-pv');
+            if (!pv || !pv.contains(node) || (node.parentElement && node.parentElement.closest('[data-dg-tag]'))) {
+                this._closeSlashMenu();
+                return;
+            }
+            const upto = node.nodeValue.slice(0, sel.anchorOffset);
+            const m = upto.match(/(^|[\s ])\/([\w -]{0,30})$/);
+            if (!m) {
+                this._closeSlashMenu();
+                return;
+            }
+            const query = m[2] || '';
+            if (!this.slashMenu || this._slashQuery !== query) {
+                this._slashSel = 0;
+            }
+            this._slashQuery = query;
+            this._slashCtx = { node, slashIndex: upto.length - query.length - 1 };
+            const range = sel.getRangeAt(0).cloneRange();
+            let rect = range.getBoundingClientRect();
+            if (!rect || (!rect.width && !rect.height)) {
+                rect = (node.parentElement || pv).getBoundingClientRect();
+            }
+            const col = this.template.querySelector('.dg-designer-canvas-col');
+            const colRect = col ? col.getBoundingClientRect() : { left: 0, top: 0 };
+            this._renderSlashMenu(rect, colRect);
+        } catch (e) {
+            this._closeSlashMenu();
+        }
+    }
+
+    _renderSlashMenu(rect, colRect) {
+        const q = (this._slashQuery || '').toLowerCase().trim();
+        const all = this._slashCatalog();
+        const scored = q ? all.filter((o) => (o.label + ' ' + o.group).toLowerCase().includes(q)) : all;
+        const items = scored.slice(0, 9);
+        if (this._slashSel >= items.length) {
+            this._slashSel = Math.max(0, items.length - 1);
+        }
+        const posStyle = rect
+            ? 'left: ' + Math.max(0, rect.left - colRect.left) + 'px; top: ' + (rect.bottom - colRect.top + 6) + 'px;'
+            : this.slashMenu
+              ? this.slashMenu.posStyle
+              : '';
+        this.slashMenu = {
+            query: this._slashQuery,
+            hasItems: items.length > 0,
+            posStyle,
+            items: items.map((o, idx) => ({
+                ...o,
+                itemClass: idx === this._slashSel ? 'dg-slash-item dg-slash-item_active' : 'dg-slash-item'
+            }))
+        };
+    }
+
+    _closeSlashMenu() {
+        if (this.slashMenu) {
+            this.slashMenu = null;
+            this._slashCtx = null;
+            this._slashSel = 0;
+        }
+    }
+
+    /** Keyboard driving for the open slash menu; returns true when consumed. */
+    _slashMenuKeydown(e) {
+        if (!this.slashMenu) {
+            return false;
+        }
+        if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+            e.preventDefault();
+            const n = this.slashMenu.items.length;
+            if (n) {
+                this._slashSel = (this._slashSel + (e.key === 'ArrowDown' ? 1 : n - 1)) % n;
+                this._renderSlashMenu(null, null);
+            }
+            return true;
+        }
+        if (e.key === 'Enter' || e.key === 'Tab') {
+            e.preventDefault();
+            this._executeSlashItem(this.slashMenu.items[this._slashSel]);
+            return true;
+        }
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            this._closeSlashMenu();
+            return true;
+        }
+        return false;
+    }
+
+    handleSlashItemClick(event) {
+        const key = event.currentTarget.dataset.key;
+        const item = this.slashMenu && this.slashMenu.items.find((o) => o.key === key);
+        this._executeSlashItem(item);
+    }
+
+    handleSlashMenuClose() {
+        this._closeSlashMenu();
+    }
+
+    /** Remove the typed "/query" trigger text, then insert the chosen thing there. */
+    _executeSlashItem(item) {
+        const ctx = this._slashCtx;
+        this._closeSlashMenu();
+        if (!item) {
+            return;
+        }
+        try {
+            if (ctx && ctx.node && ctx.node.parentNode) {
+                const sel = window.getSelection();
+                const end =
+                    sel && sel.rangeCount && sel.anchorNode === ctx.node ? sel.anchorOffset : ctx.node.nodeValue.length;
+                const r = document.createRange();
+                r.setStart(ctx.node, Math.max(0, ctx.slashIndex));
+                r.setEnd(ctx.node, Math.min(end, ctx.node.nodeValue.length));
+                r.deleteContents();
+                const s = window.getSelection();
+                s.removeAllRanges();
+                s.addRange(r);
+            }
+        } catch (e) {
+            /* insertion falls back to caret/append */
+        }
+        this._insertIntoVisualPage(item.snippet);
     }
 
     // --- Tags palette (Insert Tags without memorizing syntax) ---
@@ -6861,7 +7253,18 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     _handleVisualDrop(event, pv) {
         event.preventDefault();
         this._hideDropMarker(pv);
-        const text = event.dataTransfer && event.dataTransfer.getData('text/plain');
+        // Internal chip/thumbnail drags carry their payload in component state
+        // (_dragSnippet) — dataTransfer doesn't survive LWS reliably. External
+        // drops (text dragged from elsewhere) still read dataTransfer.
+        let text = this._dragSnippet;
+        this._dragSnippet = null;
+        if (!text) {
+            try {
+                text = event.dataTransfer && event.dataTransfer.getData('text/plain');
+            } catch (e) {
+                text = null;
+            }
+        }
         if (!text) {
             return;
         }
@@ -6893,23 +7296,33 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         this.htmlEditorDirty = true;
     }
 
-    /** Tag chips and image thumbnails are draggable onto the visual page. */
+    /** Tag chips and image thumbnails are draggable onto the visual page.
+     *  Payload rides in _dragSnippet (LWS-proof); dataTransfer is set too for
+     *  drops outside the canvas (e.g. into the Source textarea). */
     handleTagDragStart(event) {
         const snippet = event.currentTarget.dataset.snippet;
+        this._dragSnippet = snippet || null;
         if (snippet && event.dataTransfer) {
-            event.dataTransfer.setData('text/plain', snippet);
-            event.dataTransfer.effectAllowed = 'copy';
+            try {
+                event.dataTransfer.setData('text/plain', snippet);
+                event.dataTransfer.effectAllowed = 'copy';
+            } catch (e) {
+                /* dataTransfer best-effort */
+            }
         }
     }
 
     handleImageDragStart(event) {
         const { url, name } = event.currentTarget.dataset;
-        if (url && event.dataTransfer) {
-            event.dataTransfer.setData(
-                'text/plain',
-                '<img src="' + url + '" alt="' + (name || 'image') + '" style="width: 180px" />'
-            );
-            event.dataTransfer.effectAllowed = 'copy';
+        const snippet = url ? '<img src="' + url + '" alt="' + (name || 'image') + '" style="width: 180px" />' : null;
+        this._dragSnippet = snippet;
+        if (snippet && event.dataTransfer) {
+            try {
+                event.dataTransfer.setData('text/plain', snippet);
+                event.dataTransfer.effectAllowed = 'copy';
+            } catch (e) {
+                /* dataTransfer best-effort */
+            }
         }
     }
 

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -53,6 +53,9 @@ import searchDataProviders from '@salesforce/apex/DocGenController.searchDataPro
 import getHtmlTemplateBody from '@salesforce/apex/DocGenController.getHtmlTemplateBody';
 import getConvertedHtmlSnapshot from '@salesforce/apex/DocGenController.getConvertedHtmlSnapshot';
 import listHtmlTemplateImages from '@salesforce/apex/DocGenController.listHtmlTemplateImages';
+import getAssets from '@salesforce/apex/DocGenController.getAssets';
+import createAsset from '@salesforce/apex/DocGenController.createAsset';
+import addAssetVersion from '@salesforce/apex/DocGenController.addAssetVersion';
 import validateDataProvider from '@salesforce/apex/DocGenController.validateDataProvider';
 
 // Schema
@@ -304,6 +307,10 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     // HTML templates; 'file' exposes the classic Type picker for uploads.
     @track newAuthoringMode = 'starter';
     @track newStarterKey = 'report';
+    // One-click create: auto-built query + optional company logo asset
+    @track isAutoCreating = false;
+    @track newTemplateLogoName = '';
+    _logoFile = null;
     @track newTemplateSampleRecordId = '';
     @track sampleRecordData = null;
     isCreating = true;
@@ -1344,6 +1351,27 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                         // Column resize: grab a cell's right edge and drag.
                         pv.addEventListener('mousemove', (e) => this._tableResizeHover(e, pv));
                         pv.addEventListener('mousedown', (e) => this._tableResizeStart(e, pv));
+                        // Keep keystrokes OURS: Lightning binds "/" (and more)
+                        // to global shortcuts and doesn't recognize manual-DOM
+                        // contenteditable as an editing context.
+                        pv.addEventListener('keydown', (e) => e.stopPropagation());
+                        pv.addEventListener('keypress', (e) => e.stopPropagation());
+                        // Land ready-to-type: focus the page with the caret at
+                        // the first text block so the cursor is never a hunt.
+                        try {
+                            pv.focus();
+                            const first = pv.querySelector('p, h1, h2, h3, li, td');
+                            if (first) {
+                                const r = document.createRange();
+                                r.selectNodeContents(first);
+                                r.collapse(true);
+                                const s = window.getSelection();
+                                s.removeAllRanges();
+                                s.addRange(r);
+                            }
+                        } catch (e) {
+                            /* focus best-effort */
+                        }
                         // Sheet dimensions follow the page setup.
                         this._applyCanvasDimensions();
                         // Context label ("Editing: Table cell") follows the caret.
@@ -1569,6 +1597,179 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
 
     handleStarterSelect(event) {
         this.newStarterKey = event.currentTarget.dataset.key;
+    }
+
+    handleLogoSelected(event) {
+        const file = event.target.files && event.target.files[0];
+        if (!file) {
+            return;
+        }
+        if (!/\.(png|jpe?g)$/i.test(file.name)) {
+            this.showToast('Unsupported logo', 'Use a .png or .jpg image.', 'error');
+            event.target.value = '';
+            return;
+        }
+        this._logoFile = file;
+        this.newTemplateLogoName = file.name;
+    }
+
+    /**
+     * The fluid path: name it, pick a design, click once. A sensible Query
+     * Config is auto-built from the object's describe (top fields + up to
+     * two child relationships), the template is created, the starter body
+     * attached, and the designer opens on the finished document.
+     */
+    async handleCreateAndDesign() {
+        if (!this.newTemplateName) {
+            this.showToast('Name it first', 'Give the template a name, then create.', 'error');
+            return;
+        }
+        if (this.dataSourceMode === 'record' && !this.newTemplateObject) {
+            this.showToast('Pick an object', 'Choose the Base Object this document is about.', 'error');
+            return;
+        }
+        this.isAutoCreating = true;
+        try {
+            if (this.dataSourceMode === 'record' && !(this.newTemplateQuery || '').trim()) {
+                this.newTemplateQuery = await this._buildDefaultQueryConfig(this.newTemplateObject);
+            }
+            await this.createTemplate();
+        } finally {
+            this.isAutoCreating = false;
+        }
+    }
+
+    /** Sensible default query from the object's describe — refinable later. */
+    async _buildDefaultQueryConfig(objectApiName) {
+        try {
+            const [fields, rels] = await Promise.all([
+                getObjectFields({ objectName: objectApiName }),
+                getChildRelationships({ objectName: objectApiName })
+            ]);
+            const names = (fields || []).map((f) => f.value);
+            const typeOf = {};
+            (fields || []).forEach((f) => {
+                typeOf[f.value] = f.type;
+            });
+            const PREF = [
+                'Name',
+                'Industry',
+                'Phone',
+                'Email',
+                'Website',
+                'Amount',
+                'StageName',
+                'CloseDate',
+                'Status',
+                'Title',
+                'Type',
+                'Description'
+            ];
+            const GOOD =
+                /^(STRING|CURRENCY|DOUBLE|INTEGER|PERCENT|DATE|DATETIME|EMAIL|PHONE|URL|PICKLIST|TEXTAREA|BOOLEAN)$/;
+            const SKIP =
+                /^(Id|OwnerId|CreatedById|LastModifiedById|SystemModstamp|IsDeleted|CurrencyIsoCode|Jigsaw.*|CleanStatus|PhotoUrl)$/;
+            const chosen = [];
+            for (const p of PREF) {
+                if (chosen.length < 6 && names.includes(p)) {
+                    chosen.push(p);
+                }
+            }
+            for (const f of names) {
+                if (chosen.length >= 6) {
+                    break;
+                }
+                if (!chosen.includes(f) && !SKIP.test(f) && !f.endsWith('Id') && GOOD.test(typeOf[f] || '')) {
+                    chosen.push(f);
+                }
+            }
+            if (!chosen.length) {
+                chosen.push('Name');
+            }
+            const parts = [chosen.join(', ')];
+            const RELPREF = ['Contacts', 'Opportunities', 'OpportunityLineItems', 'OrderItems', 'Cases', 'Assets'];
+            const NOISE =
+                /Histories|Feeds|Shares|Teams|ContentDocumentLinks|ProcessInstances|ActivityHistories|Emails|Events|Tasks|Notes|Attachments|DuplicateRecord|RecordAction|TopicAssign|Vote/i;
+            const picked = [];
+            for (const rp of RELPREF) {
+                const r = (rels || []).find((x) => x.value === rp);
+                if (r && picked.length < 2) {
+                    picked.push(r);
+                }
+            }
+            if (!picked.length && rels && rels.length) {
+                const r = rels.find((x) => !NOISE.test(x.value));
+                if (r) {
+                    picked.push(r);
+                }
+            }
+            for (const r of picked) {
+                try {
+                    const cf = await getObjectFields({ objectName: r.childObjectApiName });
+                    const cnames = (cf || []).map((f) => f.value);
+                    const cchosen = [];
+                    for (const p of [
+                        'Name',
+                        'FirstName',
+                        'LastName',
+                        'Email',
+                        'Title',
+                        'StageName',
+                        'Amount',
+                        'CloseDate',
+                        'Quantity',
+                        'UnitPrice',
+                        'TotalPrice',
+                        'Subject',
+                        'Status'
+                    ]) {
+                        if (cchosen.length < 4 && cnames.includes(p)) {
+                            cchosen.push(p);
+                        }
+                    }
+                    if (cchosen.length) {
+                        parts.push('(SELECT ' + cchosen.join(', ') + ' FROM ' + r.value + ')');
+                    }
+                } catch (e) {
+                    /* skip relationship */
+                }
+            }
+            return parts.join(', ');
+        } catch (e) {
+            return 'Name';
+        }
+    }
+
+    /** Wizard logo → the shared {%asset:logo} asset every template can use. */
+    async _ensureLogoAsset(templateId) {
+        if (!this._logoFile) {
+            return;
+        }
+        try {
+            const buffer = await this._logoFile.arrayBuffer();
+            const cvRes = await saveHtmlTemplateImage({
+                templateId,
+                fileName: this._logoFile.name,
+                base64Content: bytesToBase64(new Uint8Array(buffer))
+            });
+            const assets = (await getAssets()) || [];
+            let logo = assets.find((a) => a.assetKey === 'logo');
+            if (!logo) {
+                logo = await createAsset({ name: 'Company Logo', assetKey: 'logo' });
+            }
+            await addAssetVersion({ assetId: logo.id, contentVersionId: cvRes.contentVersionId });
+            this.showToast(
+                'Logo saved',
+                'Stored as the shared asset {%asset:logo} — your starter header uses it, and every future template can too.',
+                'success'
+            );
+        } catch (err) {
+            const msg = err && err.body && err.body.message ? err.body.message : (err && err.message) || String(err);
+            this.showToast('Logo not saved', msg + ' — you can add it later under Assets.', 'warning');
+        } finally {
+            this._logoFile = null;
+            this.newTemplateLogoName = '';
+        }
     }
 
     /** Word→HTML conversion expectation-setting, shown under the Type picker. */
@@ -3093,11 +3294,13 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             this.activeEditTab = 'document';
             this.openEditModal(newRow, 'document');
             if (authoringMode === 'starter') {
+                await this._ensureLogoAsset(record.id);
                 await this._applyStarterBody(record.id, starterKey, starterShape);
                 // Land straight in the full-screen designer with the starter open.
                 this.isEditModalOpen = false;
                 await this._openDesignerSurface();
             } else if (authoringMode === 'ai') {
+                await this._ensureLogoAsset(record.id);
                 // AI path: designer opens in code view, ready for the paste-back.
                 this.isEditModalOpen = false;
                 await this._openDesignerSurface();
@@ -6152,6 +6355,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         const tpl = doc.createElement('template');
         tpl.innerHTML = markup;
         this._pillifyTags(tpl.content);
+        // Capture BEFORE insertion — insertNode empties the fragment.
+        const firstEl = tpl.content.firstElementChild;
         let inserted = false;
         try {
             const sel = window.getSelection();
@@ -6170,6 +6375,14 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         }
         if (!inserted) {
             pv.appendChild(tpl.content);
+        }
+        // Never make the user hunt for what they just added.
+        if (firstEl && firstEl.scrollIntoView) {
+            try {
+                firstEl.scrollIntoView({ block: 'center', behavior: 'smooth' });
+            } catch (e) {
+                /* best effort */
+            }
         }
         this.htmlEditorDirty = true;
     }
@@ -6498,6 +6711,9 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         // default Type is HTML until the user picks "I Have an Existing File".
         this.newAuthoringMode = 'starter';
         this.newStarterKey = 'report';
+        this._logoFile = null;
+        this.newTemplateLogoName = '';
+        this.isAutoCreating = false;
         this.newTemplateType = 'HTML';
         this.newTemplateDesc = '';
         this.newTemplateQuery = '';

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -5307,6 +5307,66 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         doc.addEventListener('mouseup', onUp);
     }
 
+    /**
+     * Turn the caret's paragraph into a list item (or back). Enter inside a
+     * list adds items natively; toggling a list item lifts it back out as a
+     * paragraph. Inside a table cell the list wraps the cell's content.
+     */
+    _toggleListAtCaret(ordered) {
+        const blk = this._selectedBlockElement();
+        if (!blk) {
+            this.showToast(
+                'Click into some text first',
+                'Put your cursor in a paragraph, then click the list button.',
+                'info'
+            );
+            return;
+        }
+        const doc = blk.ownerDocument || document;
+        const placeCaret = (el) => {
+            try {
+                const r = doc.createRange();
+                r.selectNodeContents(el);
+                r.collapse(false);
+                const sel = window.getSelection();
+                sel.removeAllRanges();
+                sel.addRange(r);
+            } catch (e) {
+                /* best effort */
+            }
+        };
+        if (blk.tagName === 'LI') {
+            // Toggle OFF: lift this item out of the list as a paragraph.
+            const list = blk.parentElement;
+            const p = doc.createElement('p');
+            p.innerHTML = blk.innerHTML;
+            list.insertAdjacentElement('afterend', p);
+            blk.remove();
+            if (list && !list.querySelector('li')) {
+                list.remove();
+            }
+            placeCaret(p);
+        } else if (blk.tagName === 'TD' || blk.tagName === 'TH') {
+            const list = doc.createElement(ordered ? 'ol' : 'ul');
+            list.style.margin = '2pt 0 2pt 14pt';
+            const li = doc.createElement('li');
+            li.innerHTML = blk.innerHTML && blk.innerHTML.trim() !== '&nbsp;' ? blk.innerHTML : 'List item';
+            list.appendChild(li);
+            blk.innerHTML = '';
+            blk.appendChild(list);
+            placeCaret(li);
+        } else {
+            const list = doc.createElement(ordered ? 'ol' : 'ul');
+            list.style.margin = '6pt 0 6pt 18pt';
+            const li = doc.createElement('li');
+            li.innerHTML = blk.innerHTML || 'List item';
+            list.appendChild(li);
+            blk.replaceWith(list);
+            placeCaret(li);
+        }
+        this.htmlEditorDirty = true;
+    }
+
     /** The block element (p, heading, list item, div, td) holding the caret. */
     _selectedBlockElement() {
         let node = null;
@@ -5340,6 +5400,12 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         const cmd = event.currentTarget.dataset.cmd;
         const value = event.currentTarget.dataset.value || null;
         if (!cmd) {
+            return;
+        }
+        // Lists via DOM surgery — LWS quietly breaks execCommand's list
+        // commands, and this way numbers/bullets always render.
+        if (cmd === 'insertUnorderedList' || cmd === 'insertOrderedList') {
+            this._toggleListAtCaret(cmd === 'insertOrderedList');
             return;
         }
         if (

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -1341,6 +1341,9 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                                 this._beginPillEdit(pill);
                             }
                         });
+                        // Column resize: grab a cell's right edge and drag.
+                        pv.addEventListener('mousemove', (e) => this._tableResizeHover(e, pv));
+                        pv.addEventListener('mousedown', (e) => this._tableResizeStart(e, pv));
                         // Sheet dimensions follow the page setup.
                         this._applyCanvasDimensions();
                         // Context label ("Editing: Table cell") follows the caret.
@@ -4828,6 +4831,11 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         if (host && ta) {
             // eslint-disable-next-line @lwc/lwc/no-inner-html
             host.innerHTML = scopeHtmlForInlinePreview(ta.value || '');
+            const pv = host.querySelector('.dg-pv');
+            if (pv) {
+                // The preview sheet mirrors the page setup too.
+                this._applyCanvasDimensions(pv);
+            }
         }
     }
 
@@ -4944,29 +4952,44 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     }
 
     /** Make the on-screen sheet match the page setup (Lucid-style canvas). */
-    _applyCanvasDimensions() {
-        const host = this.template.querySelector('.dg-visual-host');
-        const pv = host && host.querySelector('.dg-pv');
-        if (!pv) {
+    _applyCanvasDimensions(targetPv) {
+        const pvs = [];
+        if (targetPv) {
+            pvs.push(targetPv);
+        } else {
+            for (const hostSel of ['.dg-visual-host', '.dg-code-preview']) {
+                const host = this.template.querySelector(hostSel);
+                const pv = host && host.querySelector('.dg-pv');
+                if (pv) {
+                    pvs.push(pv);
+                }
+            }
+        }
+        if (!pvs.length) {
             return;
         }
         const widths = { Letter: 816, Legal: 816, A4: 794 };
         const heights = { Letter: 1056, Legal: 1344, A4: 1123 };
         let w;
+        let h;
         if (this.isCustomPageSize) {
             w = Math.round((parseFloat(this.pageSetup.customW) || 8.5) * 96);
+            h = Math.round((parseFloat(this.pageSetup.customH) || 11) * 96);
         } else {
-            w =
-                this.pageSetup.orient === 'landscape'
-                    ? heights[this.pageSetup.size] || 1056
-                    : widths[this.pageSetup.size] || 816;
+            const landscape = this.pageSetup.orient === 'landscape';
+            w = landscape ? heights[this.pageSetup.size] || 1056 : widths[this.pageSetup.size] || 816;
+            h = landscape ? widths[this.pageSetup.size] || 816 : heights[this.pageSetup.size] || 1056;
         }
         const marginVal = this.isCustomMargin
             ? parseFloat(this.pageSetup.customMargin) || 0.75
             : parseFloat(this.pageSetup.margin || '0.75');
         const pad = Math.round(marginVal * 96);
-        pv.style.maxWidth = w + 'px';
-        pv.style.padding = pad + 'px';
+        for (const pv of pvs) {
+            pv.style.maxWidth = w + 'px';
+            pv.style.width = w + 'px';
+            pv.style.minHeight = h + 'px';
+            pv.style.padding = pad + 'px';
+        }
     }
 
     // --- Format Code + Code ⇄ Preview (shared by the HTML editor and the DOCX viewer) ---
@@ -5238,6 +5261,50 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             }
         }
         this.htmlEditorDirty = true;
+    }
+
+    // --- Column drag-resize (grab a cell's right edge) ---
+    _resizeEdgeCell(event, pv) {
+        const cell = event.target && event.target.closest ? event.target.closest('td, th') : null;
+        if (!cell || !pv.contains(cell)) {
+            return null;
+        }
+        const rect = cell.getBoundingClientRect();
+        return event.clientX >= rect.right - 5 && event.clientX <= rect.right + 5 ? cell : null;
+    }
+
+    _tableResizeHover(event, pv) {
+        if (this._colResizing) {
+            return;
+        }
+        const cell = this._resizeEdgeCell(event, pv);
+        const hovered = event.target && event.target.closest ? event.target.closest('td, th') : null;
+        if (hovered) {
+            hovered.style.cursor = cell ? 'col-resize' : '';
+        }
+    }
+
+    _tableResizeStart(event, pv) {
+        const cell = this._resizeEdgeCell(event, pv);
+        if (!cell) {
+            return;
+        }
+        event.preventDefault();
+        this._colResizing = true;
+        const startX = event.clientX;
+        const startW = cell.getBoundingClientRect().width;
+        const doc = pv.ownerDocument || document;
+        const onMove = (ev) => {
+            cell.style.width = Math.max(24, startW + (ev.clientX - startX)) + 'px';
+        };
+        const onUp = () => {
+            doc.removeEventListener('mousemove', onMove);
+            doc.removeEventListener('mouseup', onUp);
+            this._colResizing = false;
+            this.htmlEditorDirty = true;
+        };
+        doc.addEventListener('mousemove', onMove);
+        doc.addEventListener('mouseup', onUp);
     }
 
     /** The block element (p, heading, list item, div, td) holding the caret. */
@@ -6000,15 +6067,83 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         }
     }
 
-    /** Append markup to the editable visual page (visual mode only). */
+    /**
+     * Insert markup into the editable visual page — at the caret when there
+     * is one (chips keep it alive via mousedown-preventDefault), otherwise
+     * appended at the end.
+     */
     _insertIntoVisualPage(markup) {
         const host = this.template.querySelector('.dg-visual-host');
         const pv = host && host.querySelector('.dg-pv');
-        if (pv) {
-            pv.insertAdjacentHTML('beforeend', markup);
-            this._pillifyTags(pv);
-            this.htmlEditorDirty = true;
+        if (!pv) {
+            return;
         }
+        const doc = pv.ownerDocument || document;
+        const tpl = doc.createElement('template');
+        tpl.innerHTML = markup;
+        this._pillifyTags(tpl.content);
+        let inserted = false;
+        try {
+            const sel = window.getSelection();
+            if (sel && sel.rangeCount) {
+                const range = sel.getRangeAt(0);
+                let node = range.startContainer;
+                const el = node.nodeType === 3 ? node.parentElement : node;
+                if (el && pv.contains(el) && !el.closest('[data-dg-tag]')) {
+                    range.collapse(true);
+                    range.insertNode(tpl.content);
+                    inserted = true;
+                }
+            }
+        } catch (e) {
+            inserted = false;
+        }
+        if (!inserted) {
+            pv.appendChild(tpl.content);
+        }
+        this.htmlEditorDirty = true;
+    }
+
+    /** Table group's "+ Table": a styled 3-column data table at the caret. */
+    handleInsertTable() {
+        const th = 'background: #1f3a5f; color: #ffffff; text-align: left; padding: 5pt 7pt; font-size: 9.5pt';
+        const cell = 'padding: 5pt 7pt; border-bottom: 0.75pt solid #dddddd';
+        const snippet =
+            '\n<table style="width: 100%; border-collapse: collapse">' +
+            '<thead><tr>' +
+            '<th style="' +
+            th +
+            '">Column 1</th><th style="' +
+            th +
+            '">Column 2</th><th style="' +
+            th +
+            '">Column 3</th>' +
+            '</tr></thead><tbody>' +
+            '<tr><td style="' +
+            cell +
+            '">&nbsp;</td><td style="' +
+            cell +
+            '">&nbsp;</td><td style="' +
+            cell +
+            '">&nbsp;</td></tr>' +
+            '<tr><td style="' +
+            cell +
+            '">&nbsp;</td><td style="' +
+            cell +
+            '">&nbsp;</td><td style="' +
+            cell +
+            '">&nbsp;</td></tr>' +
+            '</tbody></table>\n';
+        if (this.showHtmlBodyVisual) {
+            this._insertIntoVisualPage(snippet);
+        } else {
+            this._insertAtEditorCursor(snippet);
+        }
+        this.showToast(
+            'Table added',
+            'Drag a cell edge to resize columns; use the Table tools for rows, columns, and borders.',
+            'success'
+        );
     }
 
     /** Purple insertion caret that tracks the pointer while dragging. */

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -6869,6 +6869,40 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         return this.editTemplateName || 'Template Designer';
     }
 
+    /** Switch templates without leaving the designer. */
+    get designerTemplateOptions() {
+        return (this.templates || []).filter((t) => t[F.Type] === 'HTML').map((t) => ({ label: t.Name, value: t.Id }));
+    }
+
+    async handleDesignerTemplateSwitch(event) {
+        const id = event.detail.value;
+        if (!id || id === this.editTemplateId) {
+            return;
+        }
+        if (this.htmlEditorDirty) {
+            const ok = await LightningConfirm.open({
+                message: 'Switch templates? Unapplied edits in this editor will be discarded — staged bodies are kept.',
+                label: 'Switch template',
+                theme: 'warning'
+            });
+            if (!ok) {
+                // Re-render snaps the picker back to the current template.
+                this.editTemplateId = this.editTemplateId; // eslint-disable-line no-self-assign
+                return;
+            }
+        }
+        const row = (this.templates || []).find((t) => t.Id === id);
+        if (!row) {
+            return;
+        }
+        if (this.showHtmlBodyVisual) {
+            this._exitVisualMode();
+        }
+        this.handleClosePdfPreview();
+        this.activePanel = null;
+        await this.openDesignerForRow(row);
+    }
+
     /** Row action / modal button → full-screen designer for HTML templates. */
     async openDesignerForRow(row) {
         this.openEditModal(row, 'document');

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -1317,18 +1317,28 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
                             }
                         });
                         pv.addEventListener('drop', (e) => this._handleVisualDrop(e, pv));
-                        // Live dirty signal while typing in the page.
+                        // Live dirty signal while typing in the page — and
+                        // type-to-pill: a completed {tag} snaps into a pill.
                         pv.addEventListener('input', () => {
                             this.htmlEditorDirty = true;
+                            this._maybePillifyTyped();
                         });
                         // Click a pill → its formatting menu; click elsewhere closes it.
+                        // Double-click a pill → edit its tag text in place.
                         pv.addEventListener('click', (e) => {
+                            const pill = e.target && e.target.closest ? e.target.closest('[data-dg-tag]') : null;
+                            if (pill && pill.getAttribute('contenteditable') !== 'true') {
+                                e.preventDefault();
+                                this._openPillMenu(pill);
+                            } else if (!pill) {
+                                this.pillMenu = null;
+                            }
+                        });
+                        pv.addEventListener('dblclick', (e) => {
                             const pill = e.target && e.target.closest ? e.target.closest('[data-dg-tag]') : null;
                             if (pill) {
                                 e.preventDefault();
-                                this._openPillMenu(pill);
-                            } else {
-                                this.pillMenu = null;
+                                this._beginPillEdit(pill);
                             }
                         });
                         // Sheet dimensions follow the page setup.
@@ -5142,6 +5152,19 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         const value = event.currentTarget.dataset.value || null;
         const cell = this._selectedTableCell();
         if (!cell) {
+            // Fill works everywhere: outside a table it colors the block the
+            // caret is in (paragraph, heading, list item, div panel).
+            if (action === 'cellFill') {
+                const blk = this._selectedBlockElement();
+                if (blk) {
+                    blk.style.background = value === 'transparent' ? '' : value;
+                    if (value !== 'transparent' && !blk.style.padding) {
+                        blk.style.padding = '6pt 8pt';
+                    }
+                    this.htmlEditorDirty = true;
+                    return;
+                }
+            }
             this.showToast(
                 'Click inside a table cell first',
                 'Put your cursor in the table you want to change, then use the table tools.',
@@ -5189,8 +5212,53 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             }
         } else if (action === 'cellFill') {
             cell.style.background = value === 'transparent' ? '' : value;
+        } else if (action === 'bordersAll') {
+            table.style.borderCollapse = 'collapse';
+            table.style.border = '1pt solid #444444';
+            for (const c of table.querySelectorAll('td, th')) {
+                c.style.border = '0.75pt solid #999999';
+            }
+        } else if (action === 'bordersOutline') {
+            table.style.borderCollapse = 'collapse';
+            table.style.border = '1pt solid #444444';
+            for (const c of table.querySelectorAll('td, th')) {
+                c.style.border = 'none';
+            }
+        } else if (action === 'bordersRows') {
+            table.style.borderCollapse = 'collapse';
+            table.style.border = 'none';
+            for (const c of table.querySelectorAll('td, th')) {
+                c.style.border = 'none';
+                c.style.borderBottom = '0.75pt solid #cccccc';
+            }
+        } else if (action === 'bordersNone') {
+            table.style.border = 'none';
+            for (const c of table.querySelectorAll('td, th')) {
+                c.style.border = 'none';
+            }
         }
         this.htmlEditorDirty = true;
+    }
+
+    /** The block element (p, heading, list item, div, td) holding the caret. */
+    _selectedBlockElement() {
+        let node = null;
+        try {
+            const sel = window.getSelection();
+            node = sel && sel.anchorNode;
+        } catch (e) {
+            return null;
+        }
+        while (node && node.nodeType === 3) {
+            node = node.parentNode;
+        }
+        const host = this.template.querySelector('.dg-visual-host');
+        const pv = host && host.querySelector('.dg-pv');
+        if (!node || !pv || !pv.contains(node) || !node.closest) {
+            return null;
+        }
+        const blk = node.closest('p, h1, h2, h3, h4, li, div, td, th');
+        return blk && pv.contains(blk) && blk !== pv ? blk : null;
     }
 
     /**
@@ -5440,6 +5508,113 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
 
     handlePillMenuClose() {
         this.pillMenu = null;
+    }
+
+    handlePillEdit() {
+        if (this._activePill) {
+            this._beginPillEdit(this._activePill);
+        }
+        this.pillMenu = null;
+    }
+
+    /**
+     * Edit a pill's tag text in place (loop names, conditionals, modifiers —
+     * anything). Enter or clicking away commits; braces are auto-completed;
+     * an emptied pill removes itself.
+     */
+    _beginPillEdit(pill) {
+        this.pillMenu = null;
+        pill.setAttribute('contenteditable', 'true');
+        pill.style.borderStyle = 'dashed';
+        pill.style.cursor = 'text';
+        try {
+            const range = document.createRange();
+            range.selectNodeContents(pill);
+            const sel = window.getSelection();
+            sel.removeAllRanges();
+            sel.addRange(range);
+        } catch (e) {
+            /* selection best-effort */
+        }
+        const finish = () => {
+            pill.removeEventListener('blur', finish);
+            let t = (pill.textContent || '').trim();
+            if (!t || t === '{}' || t === '{' || t === '}') {
+                pill.remove();
+                this.htmlEditorDirty = true;
+                return;
+            }
+            if (!t.startsWith('{')) {
+                t = '{' + t;
+            }
+            if (!t.endsWith('}')) {
+                t = t + '}';
+            }
+            pill.textContent = t;
+            pill.setAttribute('contenteditable', 'false');
+            pill.style.cssText = this._pillStyleFor(t);
+            this.htmlEditorDirty = true;
+        };
+        pill.addEventListener('blur', finish);
+        pill.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                pill.blur();
+            }
+        });
+        pill.focus();
+    }
+
+    /**
+     * Type-to-pill: when typing in the page completes a {tag} in a plain
+     * text node, snap it into a pill and put the caret right after it.
+     */
+    _maybePillifyTyped() {
+        try {
+            const sel = window.getSelection();
+            if (!sel || !sel.rangeCount || !sel.isCollapsed) {
+                return;
+            }
+            const node = sel.anchorNode;
+            if (!node || node.nodeType !== 3) {
+                return;
+            }
+            const parent = node.parentElement;
+            if (!parent || parent.tagName === 'STYLE' || parent.closest('[data-dg-tag]')) {
+                return;
+            }
+            const host = this.template.querySelector('.dg-visual-host');
+            const pv = host && host.querySelector('.dg-pv');
+            if (!pv || !pv.contains(node) || !/\{[^{}]+\}/.test(node.nodeValue)) {
+                return;
+            }
+            const doc = node.ownerDocument || document;
+            const frag = doc.createDocumentFragment();
+            let lastPill = null;
+            for (const part of node.nodeValue.split(/(\{[^{}]+\})/g)) {
+                if (/^\{[^{}]+\}$/.test(part)) {
+                    const pillEl = doc.createElement('span');
+                    pillEl.setAttribute('data-dg-tag', 'true');
+                    pillEl.setAttribute('contenteditable', 'false');
+                    pillEl.textContent = part;
+                    pillEl.style.cssText = this._pillStyleFor(part);
+                    frag.appendChild(pillEl);
+                    lastPill = pillEl;
+                } else if (part) {
+                    frag.appendChild(doc.createTextNode(part));
+                }
+            }
+            node.parentNode.replaceChild(frag, node);
+            if (lastPill) {
+                const r = doc.createRange();
+                r.setStartAfter(lastPill);
+                r.collapse(true);
+                sel.removeAllRanges();
+                sel.addRange(r);
+            }
+        } catch (e) {
+            /* best effort */
+        }
     }
 
     /** Pills back to plain merge-tag text (exit path). */

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -1,5 +1,6 @@
 import { LightningElement, track, wire } from 'lwc';
-import { createRecord } from 'lightning/uiRecordApi';
+import { createRecord, updateRecord } from 'lightning/uiRecordApi';
+import LightningConfirm from 'lightning/confirm';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import { NavigationMixin } from 'lightning/navigation';
 import { refreshApex } from '@salesforce/apex';
@@ -41,6 +42,7 @@ import saveWatermarkImage from '@salesforce/apex/DocGenController.saveWatermarkI
 import clearWatermarkImage from '@salesforce/apex/DocGenController.clearWatermarkImage';
 import searchDataProviders from '@salesforce/apex/DocGenController.searchDataProviders';
 import getHtmlTemplateBody from '@salesforce/apex/DocGenController.getHtmlTemplateBody';
+import getConvertedHtmlSnapshot from '@salesforce/apex/DocGenController.getConvertedHtmlSnapshot';
 import validateDataProvider from '@salesforce/apex/DocGenController.validateDataProvider';
 
 // Schema
@@ -352,6 +354,16 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     @track showHtmlBodyEditor = false;
     @track isLoadingHtmlBody = false;
     @track isApplyingHtmlBody = false;
+    // What "Save as New Version" will save: 'file' | 'editor' | 'starter' | null
+    // (null = nothing staged this session; the stored body remains active).
+    @track stagedBodySource = null;
+    // True when the textarea has been typed in since the last stage/reload.
+    @track htmlEditorDirty = false;
+    // DOCX→HTML transparency viewer (Word templates, PDF output)
+    @track showDocxHtmlViewer = false;
+    @track isLoadingDocxHtml = false;
+    @track isSwitchingToHtml = false;
+    @track docxSnapshotInfo = null;
     // Last HTML body text this session touched (upload, starter, or Apply) so
     // reopening the editor doesn't need a server round-trip.
     _lastUploadedHtmlText = null;
@@ -2966,6 +2978,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             this.uploadedContentVersionId = bodyResult.contentVersionId;
             this.uploadedFileName = fileName;
             this._lastUploadedHtmlText = html;
+            this.stagedBodySource = 'starter';
+            this.htmlEditorDirty = false;
             // Starters declare @page — same handling as an uploaded body that owns it.
             this.editHtmlBodyOwnsPageRule = true;
             this.editTemplatePageOrientation = null;
@@ -3164,6 +3178,12 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             this._lastUploadedHtmlText = null;
             this.isLoadingHtmlBody = false;
             this.isApplyingHtmlBody = false;
+            this.stagedBodySource = null;
+            this.htmlEditorDirty = false;
+            this.showDocxHtmlViewer = false;
+            this.docxSnapshotInfo = null;
+            this.isLoadingDocxHtml = false;
+            this.isSwitchingToHtml = false;
 
             let cdLinks = [];
             if (row.ContentDocumentLinks) {
@@ -4439,7 +4459,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
      * <img src> to CV URLs, store the body, and sync the @page-ownership
      * state. Throws on failure — callers own the error toast.
      */
-    async _processAndSaveHtmlBody(templateId, htmlText, fileName, zipImages) {
+    async _processAndSaveHtmlBody(templateId, htmlText, fileName, zipImages, source) {
         const imagePaths = (zipImages && zipImages.imagePaths) || [];
         const imageBytes = (zipImages && zipImages.imageBytes) || [];
 
@@ -4516,6 +4536,13 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         this.uploadedContentVersionId = bodyResult.contentVersionId;
         this.uploadedFileName = fileName;
         this._lastUploadedHtmlText = rewritten;
+        this.stagedBodySource = source || 'file';
+        this.htmlEditorDirty = false;
+        // Keep the editor in lockstep with whatever just got staged — a file
+        // upload while the editor is open must not leave stale HTML showing.
+        if (this.showHtmlBodyEditor) {
+            this._syncHtmlBodyEditorDom(rewritten);
+        }
         const imgMsg =
             totalImages > 0 ? ' (' + totalImages + ' image' + (totalImages === 1 ? '' : 's') + ' extracted)' : '';
         // v1.90 — detect author-declared @page rule; if present, the engine suppresses
@@ -4533,7 +4560,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             ? ' Your HTML defines its own @page CSS — template page-layout fields cleared.'
             : '';
         this.showToast(
-            'Uploaded',
+            source === 'editor' ? 'Editor HTML staged' : 'Uploaded',
             fileName + imgMsg + '.' + pageMsg + ' Click "Save as New Version" to activate.',
             'success'
         );
@@ -4545,14 +4572,52 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         return this.showHtmlBodyEditor ? 'Hide HTML Editor' : 'Edit HTML';
     }
 
+    /** One-line answer to "what will Save as New Version actually save?" */
+    get htmlEditorStatusText() {
+        if (this.htmlEditorDirty) {
+            return 'Unapplied edits — click "Apply Editor HTML" to stage them, or Reload to discard.';
+        }
+        if (this.stagedBodySource === 'editor') {
+            return 'Staged: your editor HTML — "Save as New Version" saves it.';
+        }
+        if (this.stagedBodySource === 'starter') {
+            return 'Staged: starter design (' + this.uploadedFileName + ') — "Save as New Version" saves it.';
+        }
+        if (this.stagedBodySource === 'file') {
+            return (
+                'Staged: uploaded file "' + this.uploadedFileName + '" (shown below) — "Save as New Version" saves it.'
+            );
+        }
+        return 'Showing the current saved body — nothing staged yet.';
+    }
+
+    get htmlEditorStatusClass() {
+        return this.htmlEditorDirty ? 'dg-html-editor-status dg-html-editor-status_dirty' : 'dg-html-editor-status';
+    }
+
+    handleHtmlBodyEditorInput() {
+        this.htmlEditorDirty = true;
+    }
+
     async toggleHtmlBodyEditor() {
         if (this.showHtmlBodyEditor) {
             this.showHtmlBodyEditor = false;
             return;
         }
         this.showHtmlBodyEditor = true;
+        await this._loadBodyIntoEditor();
+    }
+
+    /** Reload = show what's actually staged (or saved), discarding unapplied edits. */
+    async handleReloadHtmlBodyEditor() {
+        await this._loadBodyIntoEditor();
+    }
+
+    /** Fill the editor with the staged body, falling back to the stored one. */
+    async _loadBodyIntoEditor() {
         if (this._lastUploadedHtmlText != null) {
             this._syncHtmlBodyEditorDom(this._lastUploadedHtmlText);
+            this.htmlEditorDirty = false;
             return;
         }
         // No body touched this session — pull the latest stored body.
@@ -4561,6 +4626,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             const body = await getHtmlTemplateBody({ templateId: this.editTemplateId });
             this._lastUploadedHtmlText = body || '';
             this._syncHtmlBodyEditorDom(this._lastUploadedHtmlText);
+            this.htmlEditorDirty = false;
         } catch (err) {
             const msg = err && err.body && err.body.message ? err.body.message : (err && err.message) || String(err);
             this.showToast('Could not load HTML body', msg, 'error');
@@ -4581,6 +4647,117 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         }, 120);
     }
 
+    // --- DOCX→HTML transparency viewer (Word templates, PDF output) ---
+    get showDocxConvertedHtmlSection() {
+        return this.editTemplateType === 'Word' && this.editTemplateOutputFormat === 'PDF';
+    }
+
+    get docxHtmlViewerToggleLabel() {
+        return this.showDocxHtmlViewer ? 'Hide Converted HTML' : 'View Converted HTML';
+    }
+
+    get docxViewerStatusText() {
+        const info = this.docxSnapshotInfo;
+        if (!info) {
+            return 'Loading conversion snapshot…';
+        }
+        if (info.status === 'NoActiveVersion') {
+            return 'No active version yet — upload a Word file and "Save as New Version" first.';
+        }
+        if (!info.html) {
+            const st = info.status || 'Pending';
+            return (
+                'Conversion snapshot not baked yet (status: ' + st + '). Re-save the version, then reopen this viewer.'
+            );
+        }
+        return (
+            'Converted HTML from ' +
+            (info.versionName || 'the active version') +
+            ' — this is exactly what the PDF engine renders from your Word file.'
+        );
+    }
+
+    async toggleDocxHtmlViewer() {
+        if (this.showDocxHtmlViewer) {
+            this.showDocxHtmlViewer = false;
+            return;
+        }
+        this.showDocxHtmlViewer = true;
+        this.isLoadingDocxHtml = true;
+        this.docxSnapshotInfo = null;
+        try {
+            const info = await getConvertedHtmlSnapshot({ templateId: this.editTemplateId });
+            this.docxSnapshotInfo = info || { html: null, status: 'Unknown' };
+            this._syncDocxHtmlViewerDom((info && info.html) || '');
+        } catch (err) {
+            const msg = err && err.body && err.body.message ? err.body.message : (err && err.message) || String(err);
+            this.showToast('Could not load converted HTML', msg, 'error');
+            this.docxSnapshotInfo = { html: null, status: 'Error' };
+            this._syncDocxHtmlViewerDom('');
+        } finally {
+            this.isLoadingDocxHtml = false;
+        }
+    }
+
+    _syncDocxHtmlViewerDom(text) {
+        // eslint-disable-next-line @lwc/lwc/no-async-operation
+        setTimeout(() => {
+            const ta = this.template.querySelector('.dg-docx-html-editor');
+            if (ta) {
+                ta.value = text || '';
+            }
+        }, 120);
+    }
+
+    /**
+     * One-way ramp from Word to HTML: the (possibly fine-tuned) converted
+     * HTML becomes the template's real body and Type flips to HTML, so edits
+     * stick instead of being clobbered by the next DOCX re-decomposition.
+     */
+    async handleSwitchToHtmlTemplate() {
+        const ta = this.template.querySelector('.dg-docx-html-editor');
+        const text = ta ? ta.value : '';
+        if (!text || !text.trim()) {
+            this.showToast('Nothing to convert', 'The converted-HTML view is empty.', 'warning');
+            return;
+        }
+        const proceed = await LightningConfirm.open({
+            message:
+                "This makes the HTML shown (including your edits) the template's real body and changes the template Type from Word to HTML. " +
+                'The Word file stays in Version History, but future edits happen in the HTML editor. Continue?',
+            label: 'Switch to HTML Template',
+            theme: 'warning'
+        });
+        if (!proceed) {
+            return;
+        }
+        this.isSwitchingToHtml = true;
+        try {
+            const fields = { Id: this.editTemplateId };
+            fields[TYPE_FIELD.fieldApiName] = 'HTML';
+            fields[OUTPUT_FORMAT_FIELD.fieldApiName] = 'PDF';
+            await updateRecord({ fields });
+            this.editTemplateType = 'HTML';
+            this.editTemplateOutputFormat = 'PDF';
+            this.showDocxHtmlViewer = false;
+            // Stage the tuned HTML as the body through the standard pipeline.
+            await this._processAndSaveHtmlBody(this.editTemplateId, text, 'converted-from-word.html', null, 'editor');
+            this.showHtmlBodyEditor = true;
+            this._syncHtmlBodyEditorDom(text);
+            await refreshApex(this.wiredTemplatesResult);
+            this.showToast(
+                'Now an HTML template',
+                'Your converted HTML is staged — review it in the editor and click "Save as New Version" to activate.',
+                'success'
+            );
+        } catch (err) {
+            const msg = err && err.body && err.body.message ? err.body.message : (err && err.message) || String(err);
+            this.showToast('Switch failed', msg, 'error');
+        } finally {
+            this.isSwitchingToHtml = false;
+        }
+    }
+
     async handleApplyHtmlBody() {
         const ta = this.template.querySelector('.dg-html-body-editor');
         const text = ta ? ta.value : '';
@@ -4591,7 +4768,7 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         this.isApplyingHtmlBody = true;
         try {
             const base = (this.uploadedFileName || 'template.html').replace(/\.(html?|zip)$/i, '');
-            await this._processAndSaveHtmlBody(this.editTemplateId, text, base + '.html', null);
+            await this._processAndSaveHtmlBody(this.editTemplateId, text, base + '.html', null, 'editor');
         } catch (err) {
             const msg = err && err.body && err.body.message ? err.body.message : (err && err.message) || String(err);
             this.showToast('Apply failed', msg, 'error');

--- a/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAdmin.js
@@ -13,7 +13,8 @@ import {
     buildAiPrompt,
     prettyPrintHtml,
     scopeHtmlForInlinePreview,
-    buildTagPalette
+    buildTagPalette,
+    buildBlockPalette
 } from './docGenAuthoringKit';
 
 // Apex
@@ -193,6 +194,7 @@ const COLUMNS = [
             rowActions: [
                 { label: 'View', name: 'view' },
                 { label: 'Edit', name: 'edit' },
+                { label: 'Design', name: 'design' },
                 { label: 'Clone', name: 'clone' },
                 { label: 'Export', name: 'export' },
                 { label: 'Delete', name: 'delete' }
@@ -377,6 +379,8 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
     @track showDocxHtmlPreview = false;
     // Tags palette (click-to-insert merge tags from the template's own schema)
     @track showTagPanel = false;
+    // Blocks palette (drag-in layout pieces: columns, tables, bands, breaks…)
+    @track showBlockPanel = false;
     // Images panel (upload/insert <img> tags without knowing shepherd URLs)
     @track showImagePanel = false;
     @track isLoadingTemplateImages = false;
@@ -3015,6 +3019,13 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             this.openEditModal(newRow, 'document');
             if (authoringMode === 'starter') {
                 await this._applyStarterBody(record.id, starterKey, starterShape);
+                // Land straight in the full-screen designer with the starter open.
+                this.isEditModalOpen = false;
+                await this._openDesignerSurface();
+            } else if (authoringMode === 'ai') {
+                // AI path: designer opens in code view, ready for the paste-back.
+                this.isEditModalOpen = false;
+                await this._openDesignerSurface();
             }
         } catch (error) {
             this.showToast('Error creating record', error.body ? error.body.message : error.message, 'error');
@@ -3078,6 +3089,18 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
             }
         } else if (actionName === 'edit') {
             this.openEditModal(row, 'details');
+        } else if (actionName === 'design') {
+            if (row[F.Type] === 'HTML') {
+                this.openDesignerForRow(row);
+            } else {
+                this.showToast(
+                    'Designer is for HTML templates',
+                    row[F.Type] === 'Word'
+                        ? 'Open Edit → Document & History → View Converted HTML, and use "Switch to HTML Template" to bring this Word template into the designer.'
+                        : 'This template type is file-based — use Edit to manage its document.',
+                    'info'
+                );
+            }
         } else if (actionName === 'view') {
             this.openEditModal(row, 'tags');
         } else if (actionName === 'clone') {
@@ -4676,6 +4699,11 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         return this.showHtmlBodyVisual ? 'Back to Code' : 'Visual';
     }
 
+    /** Designer canvas: same editor classes plus the full-height variant. */
+    get designerEditorClass() {
+        return this.htmlBodyEditorClass + ' dg-designer-size';
+    }
+
     /**
      * Enter/exit visual (in-place) editing. The template renders through the
      * SAME scoped-preview pipeline the Preview toggle uses — tables, bands,
@@ -5017,6 +5045,63 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
         }
     }
 
+    // --- Designer tab (full-screen editing surface) ---
+    get designerHasTemplate() {
+        return !!this.editTemplateId && this.editTemplateType === 'HTML';
+    }
+
+    get designerTitle() {
+        return this.editTemplateName || 'Template Designer';
+    }
+
+    /** Row action / modal button → full-screen designer for HTML templates. */
+    async openDesignerForRow(row) {
+        this.openEditModal(row, 'document');
+        this.isEditModalOpen = false;
+        await this._openDesignerSurface();
+    }
+
+    async handleOpenDesignerFromModal() {
+        this.isEditModalOpen = false;
+        await this._openDesignerSurface();
+    }
+
+    async _openDesignerSurface() {
+        this.activeMainTab = 'design';
+        this.showHtmlBodyEditor = true;
+        this.showBlockPanel = true;
+        this.showTagPanel = true;
+        this.showImagePanel = true;
+        await this._loadBodyIntoEditor();
+        this._loadTemplateImages();
+        const body = this._lastUploadedHtmlText;
+        if (body && body.trim()) {
+            this._enterVisualMode(body);
+        }
+    }
+
+    handleCloseDesigner() {
+        if (this.showHtmlBodyVisual) {
+            this._exitVisualMode();
+        }
+        if (this.htmlEditorDirty || this.stagedBodySource) {
+            this.showToast(
+                'Heads up',
+                this.stagedBodySource
+                    ? 'Your staged body is kept — reopen the designer or the template editor to Save as New Version.'
+                    : 'Unapplied editor changes were left un-staged.',
+                'info'
+            );
+        }
+        this.activeMainTab = 'list';
+    }
+
+    // --- Blocks palette (drag-in layout pieces) ---
+    get blockPaletteSections() {
+        const shape = extractQueryShape(this.editTemplateQuery, this.editTemplateObject);
+        return buildBlockPalette(shape);
+    }
+
     // --- Tags palette (Insert Tags without memorizing syntax) ---
     get tagPanelToggleLabel() {
         return this.showTagPanel ? 'Hide Tags' : 'Insert Tags';
@@ -5033,18 +5118,27 @@ export default class DocGenAdmin extends NavigationMixin(LightningElement) {
 
     handleInsertTagSnippet(event) {
         const snippet = event.currentTarget.dataset.snippet;
+        const isBlock = event.currentTarget.dataset.kind === 'block';
         if (!snippet) {
             return;
         }
         if (this.showHtmlBodyVisual) {
             this._insertIntoVisualPage(snippet);
-            this.showToast('Tag inserted', 'Added at the end of the document — move it where you need it.', 'success');
+            this.showToast(
+                isBlock ? 'Block added' : 'Tag inserted',
+                isBlock
+                    ? 'Added at the end of the document — click into it to edit, or drag chips from the rail to drop them exactly where you point.'
+                    : 'Added at the end of the document — move it where you need it.',
+                'success'
+            );
             return;
         }
         if (this._insertAtEditorCursor(snippet)) {
             this.showToast(
-                'Tag inserted',
-                snippet.length > 60 ? 'Loop table inserted at your cursor.' : snippet + ' inserted at your cursor.',
+                isBlock ? 'Block added' : 'Tag inserted',
+                snippet.length > 60
+                    ? (isBlock ? 'Block' : 'Loop table') + ' inserted at your cursor.'
+                    : snippet + ' inserted at your cursor.',
                 'success'
             );
         }

--- a/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
@@ -587,7 +587,12 @@ export function scopeHtmlForInlinePreview(html) {
         'border-top: 2px dashed #a9b2c0; border-bottom: 2px dashed #a9b2c0; position: relative; }\n' +
         ".dg-pv [style*='page-break-before']::after, .dg-pv [style*='page-break-after']::after { " +
         "content: 'PAGE BREAK — new page starts here'; position: absolute; left: 0; right: 0; top: 8px; " +
-        'text-align: center; font-size: 10px; letter-spacing: 2px; color: #7a8598; }';
+        'text-align: center; font-size: 10px; letter-spacing: 2px; color: #7a8598; }\n' +
+        // SLDS globally resets list-style to none — restore real bullets and
+        // numbers inside the page (matches how the PDF engine renders them).
+        '.dg-pv ul { list-style: disc outside !important; padding-left: 18pt; }\n' +
+        '.dg-pv ol { list-style: decimal outside !important; padding-left: 18pt; }\n' +
+        '.dg-pv li { list-style: inherit !important; }';
     return '<div class="dg-pv"><style>' + baseline + css + '</style>' + content + '</div>';
 }
 

--- a/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
@@ -575,11 +575,19 @@ export function scopeHtmlForInlinePreview(html) {
 
     // Baseline "paper sheet" look, injected with the content because
     // component CSS can't reach lwc:dom="manual" children. Declared first so
-    // the template's own (scoped) rules win any conflicts.
+    // the template's own (scoped) rules win any conflicts. Page-break
+    // elements render as a visible Word-style page seam — editor-only
+    // styling that lives in this injected sheet and never touches saved HTML.
     const baseline =
         '.dg-pv { background: #fff; max-width: 850px; margin: 0 auto; padding: 48px 56px; ' +
         'box-shadow: 0 2px 12px rgba(0, 0, 0, 0.18); font-family: Helvetica, Arial, sans-serif; ' +
-        'font-size: 10.5pt; color: #1a1a1a; min-height: 380px; box-sizing: border-box; }';
+        'font-size: 10.5pt; color: #1a1a1a; min-height: 380px; box-sizing: border-box; }\n' +
+        ".dg-pv [style*='page-break-before'], .dg-pv [style*='page-break-after'] { display: block; " +
+        'height: 30px !important; font-size: 0 !important; margin: 18px 0; background: #e8eaed; ' +
+        'border-top: 2px dashed #a9b2c0; border-bottom: 2px dashed #a9b2c0; position: relative; }\n' +
+        ".dg-pv [style*='page-break-before']::after, .dg-pv [style*='page-break-after']::after { " +
+        "content: 'PAGE BREAK — new page starts here'; position: absolute; left: 0; right: 0; top: 8px; " +
+        'text-align: center; font-size: 10px; letter-spacing: 2px; color: #7a8598; }';
     return '<div class="dg-pv"><style>' + baseline + css + '</style>' + content + '</div>';
 }
 
@@ -717,6 +725,27 @@ export function buildBlockPalette(shape) {
                     snippet:
                         '\n<p style="margin: 6pt 0">Your text here — mix in fields from Insert Tags anywhere.</p>\n',
                     title: 'Plain text block'
+                },
+                {
+                    key: 'blk_ul',
+                    label: 'Bulleted list',
+                    snippet:
+                        '\n<ul style="margin: 6pt 0 6pt 18pt"><li>First item</li><li>Second item</li><li>Third item</li></ul>\n',
+                    title: 'Bullet points — Enter adds items while editing'
+                },
+                {
+                    key: 'blk_ol',
+                    label: 'Numbered list',
+                    snippet:
+                        '\n<ol style="margin: 6pt 0 6pt 18pt"><li>First step</li><li>Second step</li><li>Third step</li></ol>\n',
+                    title: 'Numbered steps'
+                },
+                {
+                    key: 'blk_quote',
+                    label: 'Indented quote',
+                    snippet:
+                        '\n<div style="margin: 8pt 0 8pt 18pt; padding-left: 10pt; border-left: 3pt solid #cccccc; color: #555555; font-style: italic">Quoted or emphasized text.</div>\n',
+                    title: 'Left-ruled italic block for quotes and emphasis'
                 },
                 {
                     key: 'blk_panel',

--- a/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
@@ -840,6 +840,33 @@ export function buildTagPalette(shape) {
                 });
             }
         }
+        // Charts: one click per bucketable field — {Chart:...} renders a
+        // pure-Apex PNG in PDF output; swap :bar for column/pie/donut/
+        // stacked/clustered/line/area.
+        for (const f of child.fields || []) {
+            if (f !== 'Id' && !f.includes('.')) {
+                aggregateItems.push({
+                    key: rel + '_chart_' + f,
+                    label: 'Chart: ' + humanizeField(f),
+                    snippet:
+                        '{Chart:' +
+                        rel +
+                        ':' +
+                        f +
+                        ':bar:title=' +
+                        humanizeField(rel) +
+                        ' by ' +
+                        humanizeField(f) +
+                        '}',
+                    title:
+                        'Bar chart of ' +
+                        humanizeField(rel) +
+                        ' bucketed by ' +
+                        humanizeField(f) +
+                        ' — change :bar to column, pie, donut, stacked, clustered, line, or area. Goes OUTSIDE the loop.'
+                });
+            }
+        }
         aggregateItems.push({
             key: rel + '_count',
             label: 'Count of ' + humanizeField(rel),
@@ -932,6 +959,57 @@ export function buildTagPalette(shape) {
                 label: 'Signature (Company rep)',
                 snippet: '{@Signature_Company_Representative:2:Full}',
                 title: 'Second signer, order 2'
+            }
+        ]
+    });
+
+    // Barcodes & QR — {*Field:qr} / {*Field:code128}, the only two types.
+    const codeishFields = [...(shape.baseFields || [])].filter(
+        (f) => /(number|code|sku|url|website)$/i.test(f) || /^name$/i.test(f)
+    );
+    sections.push({
+        key: 'barcodes',
+        label: 'Barcodes & QR',
+        hint: 'Code 128 and QR only. Keep QR values under ~120 characters for 1-inch prints.',
+        items: [
+            ...codeishFields.map((f) => ({
+                key: 'qr_' + f,
+                label: 'QR: ' + humanizeField(f),
+                snippet: '{*' + f + ':qr:200}',
+                title: '200px QR code of ' + humanizeField(f)
+            })),
+            {
+                key: 'qr_any',
+                label: 'QR code (any field)',
+                snippet: '{*FieldName:qr:200}',
+                title: 'Swap FieldName for one of your fields'
+            },
+            {
+                key: 'bc_any',
+                label: 'Barcode (Code 128)',
+                snippet: '{*FieldName:code128:300x80}',
+                title: 'Swap FieldName; renders a 300×80px Code 128 barcode'
+            }
+        ]
+    });
+
+    // Image tags — record image fields and org-wide shared assets.
+    sections.push({
+        key: 'imgtags',
+        label: 'Image Tags',
+        hint: 'Record images and shared assets (see the Assets tab).',
+        items: [
+            {
+                key: 'img_field',
+                label: 'Record image field',
+                snippet: '{%ImageFieldName}',
+                title: 'Renders the image stored in a field — swap ImageFieldName for your image field'
+            },
+            {
+                key: 'img_asset',
+                label: 'Shared asset (logo)',
+                snippet: '{%asset:logo}',
+                title: 'Org-wide shared asset by key — great for logos reused across templates'
             }
         ]
     });

--- a/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
@@ -427,7 +427,7 @@ export function buildAiPrompt(shape, options) {
     );
     lines.push('- Conditional: {#SomeField} shown when truthy {:else} otherwise {/SomeField}.');
     lines.push(
-        '- Aggregates: {SUM:Rel.Field}, plus AVG/MIN/MAX/COUNT — format suffixes apply, e.g. {SUM:Lines.Amount:currency}.'
+        '- Aggregates (grand totals across a child list, place OUTSIDE the loop): {SUM:Rel.Field}, {AVG:Rel.Field}, {MIN:Rel.Field}, {MAX:Rel.Field}, {COUNT:Rel} or {COUNT:Rel.Field}. All accept format suffixes: {SUM:Lines.Amount:currency}, {SUM:Lines.Amount:currency:EUR:de_DE} (ISO + locale), {SUM:Lines.Amount:currency:auto} (record currency), {COUNT:Lines:number}. The aggregated field must be in the Query Config, but does NOT need to be a rendered column.'
     );
     lines.push(
         '- Built-ins: {Today:MMMM d, yyyy}, {Now:yyyy-MM-dd HH:mm}, and running-user tags {RunningUser.Name}, {RunningUser.Email}, {RunningUser.Title}.'

--- a/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
@@ -194,6 +194,7 @@ function buildReport(shape) {
         .join('\n');
     const inner = `    <table>
         <tr>
+            <td style="width: 120pt; vertical-align: middle">{%asset:logo}</td>
             <td>
                 <h1>{Name}</h1>
                 <div class="meta">${humanizeField(shape.object)} Report</div>
@@ -218,6 +219,7 @@ ${sections}
 function buildLetter(shape) {
     const inner = `    <table>
         <tr>
+            <td style="width: 110pt; vertical-align: middle">{%asset:logo}</td>
             <td>
                 <h1 style="font-size: 14pt">Your Company Name</h1>
                 <div class="meta">123 Your Street &#8226; Your City, ST 00000 &#8226; (555) 555-0100</div>
@@ -281,6 +283,7 @@ function buildInvoice(shape) {
             : '';
     const inner = `    <table>
         <tr>
+            <td style="width: 110pt; vertical-align: middle">{%asset:logo}</td>
             <td>
                 <h1>INVOICE</h1>
                 <div class="meta">Your Company Name</div>

--- a/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
@@ -603,7 +603,12 @@ export function scopeHtmlForInlinePreview(html) {
         // numbers inside the page (matches how the PDF engine renders them).
         '.dg-pv ul { list-style: disc outside !important; padding-left: 18pt; }\n' +
         '.dg-pv ol { list-style: decimal outside !important; padding-left: 18pt; }\n' +
-        '.dg-pv li { list-style: inherit !important; }';
+        '.dg-pv li { list-style: inherit !important; }\n' +
+        // Converted DOCX tables often carry absolute widths wider than the
+        // page (extra loop-tag cells, twips math) — keep them ON the sheet so
+        // their edges stay reachable for column drag-resize.
+        '.dg-pv table { max-width: 100% !important; }\n' +
+        '.dg-pv td, .dg-pv th { overflow-wrap: break-word; }';
     return '<div class="dg-pv"><style>' + baseline + css + '</style>' + content + '</div>';
 }
 

--- a/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
@@ -460,6 +460,14 @@ export function buildAiPrompt(shape, options) {
             );
         }
     }
+    const assets = opts.assets || [];
+    if (assets.length) {
+        lines.push('');
+        lines.push('SHARED IMAGE ASSETS (already stored in Salesforce — reference by tag, do NOT invent image URLs):');
+        for (const a of assets) {
+            lines.push(`  - ${a.mergeTag} — ${a.name}. Place as e.g. <td style="width:120pt">${a.mergeTag}</td>.`);
+        }
+    }
     lines.push('');
     lines.push('WHAT I WANT THIS DOCUMENT TO BE:');
     lines.push(

--- a/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
@@ -129,7 +129,7 @@ function detailRows(fields) {
 
 // Loop tags must open in the first cell and close in the last so container
 // auto-expansion repeats the whole <tr> per child row.
-function childLoopTable(child) {
+export function childLoopTable(child) {
     const rel = child.relationshipName;
     const fields = child.fields.length ? child.fields : ['Name'];
     const headCells = fields
@@ -576,4 +576,158 @@ export function scopeHtmlForInlinePreview(html) {
         'box-shadow: 0 2px 12px rgba(0, 0, 0, 0.18); font-family: Helvetica, Arial, sans-serif; ' +
         'font-size: 10.5pt; color: #1a1a1a; min-height: 380px; box-sizing: border-box; }';
     return '<div class="dg-pv"><style>' + baseline + css + '</style>' + content + '</div>';
+}
+
+// ---------------------------------------------------------------------------
+// Tag palette (Insert Tags panel)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the click-to-insert tag palette from the template's actual Query
+ * Config shape: its record fields, its child relationships (with a
+ * ready-made loop table), plus the universal built-ins, signature tags,
+ * conditionals, and aggregates.
+ */
+export function buildTagPalette(shape) {
+    const sections = [];
+    const tagFor = (f) => (isMoneyField(f) ? '{' + f + ':currency}' : '{' + f + '}');
+
+    const fieldItems = [...(shape.baseFields || []), ...(shape.parentFields || [])].map((f) => ({
+        key: 'f_' + f,
+        label: humanizeField(f),
+        snippet: tagFor(f),
+        title: 'Insert ' + tagFor(f)
+    }));
+    if (fieldItems.length) {
+        sections.push({
+            key: 'fields',
+            label: 'Record Fields',
+            hint: 'From this template’s Query Config — click to insert at your cursor.',
+            items: fieldItems
+        });
+    }
+
+    for (const child of shape.children || []) {
+        const rel = child.relationshipName;
+        sections.push({
+            key: 'rel_' + rel,
+            label: humanizeField(rel) + ' — child loop',
+            hint: 'Child fields only resolve inside the {#' + rel + '}…{/' + rel + '} loop.',
+            items: [
+                {
+                    key: rel + '_table',
+                    label: 'Loop table (all fields)',
+                    snippet: '\n' + childLoopTable(child) + '\n',
+                    title: 'A table that repeats one row per ' + rel + ' record'
+                },
+                {
+                    key: rel + '_loop',
+                    label: 'Inline loop block',
+                    snippet: '{#' + rel + '} … {/' + rel + '}',
+                    title: 'Repeats its contents once per ' + rel + ' record'
+                },
+                ...(child.fields || []).map((f) => ({
+                    key: rel + '_' + f,
+                    label: humanizeField(f),
+                    snippet: tagFor(f),
+                    title: tagFor(f) + ' — place inside the {#' + rel + '} loop'
+                }))
+            ]
+        });
+    }
+
+    sections.push({
+        key: 'builtins',
+        label: 'Built-ins',
+        hint: 'Work on every template, no configuration.',
+        items: [
+            { key: 'today_long', label: 'Today (long)', snippet: '{Today:MMMM d, yyyy}', title: 'April 17, 2026' },
+            { key: 'today_num', label: 'Today (numeric)', snippet: '{Today:MM/dd/yyyy}', title: '04/17/2026' },
+            { key: 'now', label: 'Now (timestamp)', snippet: '{Now:yyyy-MM-dd HH:mm}', title: 'Current date-time' },
+            {
+                key: 'ru_name',
+                label: 'Running user',
+                snippet: '{RunningUser.Name}',
+                title: 'Whoever generates the document'
+            },
+            {
+                key: 'ru_title',
+                label: 'Running user title',
+                snippet: '{RunningUser.Title}',
+                title: '{RunningUser.Title}'
+            },
+            {
+                key: 'ru_email',
+                label: 'Running user email',
+                snippet: '{RunningUser.Email}',
+                title: '{RunningUser.Email}'
+            }
+        ]
+    });
+
+    sections.push({
+        key: 'sig',
+        label: 'E-Signature',
+        hint: 'Role + order + type. Roles are free-form — Buyer, Seller, Witness…',
+        items: [
+            {
+                key: 'sig_full',
+                label: 'Signature (Customer)',
+                snippet: '{@Signature_Customer:1:Full}',
+                title: 'Full signature stamp'
+            },
+            {
+                key: 'sig_date',
+                label: 'Signed date (Customer)',
+                snippet: '{@Signature_Customer:1:Date}',
+                title: 'Auto-filled when signed'
+            },
+            {
+                key: 'sig_init',
+                label: 'Initials (Customer)',
+                snippet: '{@Signature_Customer:1:Initials}',
+                title: 'Initials stamp'
+            },
+            {
+                key: 'sig_rep',
+                label: 'Signature (Company rep)',
+                snippet: '{@Signature_Company_Representative:2:Full}',
+                title: 'Second signer, order 2'
+            }
+        ]
+    });
+
+    sections.push({
+        key: 'logic',
+        label: 'Conditionals & Aggregates',
+        hint: 'Replace FieldName / Relationship.Field with yours.',
+        items: [
+            {
+                key: 'ifelse',
+                label: 'If / else block',
+                snippet: '{#FieldName}shown when set{:else}shown when empty{/FieldName}',
+                title: 'Conditional content'
+            },
+            {
+                key: 'sum',
+                label: 'SUM of child field',
+                snippet: '{SUM:Relationship.Field:currency}',
+                title: 'Total across child records'
+            },
+            {
+                key: 'count',
+                label: 'COUNT of children',
+                snippet: '{COUNT:Relationship.Id}',
+                title: 'Number of child records'
+            },
+            {
+                key: 'checkbox',
+                label: 'Checkbox render',
+                snippet: '{FieldName:checkbox}',
+                title: '[X] when true, [ ] when false'
+            }
+        ]
+    });
+
+    return sections;
 }

--- a/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
@@ -466,3 +466,114 @@ export function buildAiPrompt(shape, options) {
     lines.push('3. Use only the merge tags listed in DATA SHAPE (plus {Today}/{RunningUser.*} built-ins).');
     return lines.join('\n');
 }
+
+// ---------------------------------------------------------------------------
+// HTML pretty-printer (Format Code button)
+// ---------------------------------------------------------------------------
+
+const VOID_TAGS = /^(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)$/i;
+
+/**
+ * Conservative HTML formatter for the template editors. Only inserts
+ * whitespace BETWEEN adjacent tags (never inside text runs), so merge tags
+ * and inline text spacing are untouched. <style>/<script>/<pre>/<textarea>
+ * blocks pass through verbatim.
+ */
+export function prettyPrintHtml(html) {
+    if (!html || typeof html !== 'string') {
+        return html;
+    }
+    const protectedBlocks = [];
+    let work = html.replace(/<(style|script|pre|textarea)\b[\s\S]*?<\/\1\s*>/gi, (m) => {
+        protectedBlocks.push(m);
+        return '@@DGBLK' + (protectedBlocks.length - 1) + '@@';
+    });
+    // Break only where two tags touch (optionally separated by pure whitespace),
+    // and around protected-block placeholders so they land on their own line.
+    work = work
+        .replace(/>\s*</g, '>\n<')
+        .replace(/(@@DGBLK\d+@@)\s*</g, '$1\n<')
+        .replace(/>\s*(@@DGBLK\d+@@)/g, '>\n$1');
+    const lines = work.split('\n');
+    const out = [];
+    let depth = 0;
+    for (const raw of lines) {
+        const line = raw.trim();
+        if (!line) {
+            continue;
+        }
+        const isClosing = /^<\//.test(line);
+        if (isClosing) {
+            depth = Math.max(0, depth - 1);
+        }
+        out.push('    '.repeat(depth) + line);
+        const openMatch = line.match(/^<([a-zA-Z][\w-]*)/);
+        if (openMatch && !isClosing) {
+            const tag = openMatch[1];
+            const selfClosed = /\/>\s*$/.test(line) || VOID_TAGS.test(tag);
+            const closedSameLine = new RegExp('</' + tag + '\\s*>\\s*$', 'i').test(line);
+            if (!selfClosed && !closedSameLine) {
+                depth++;
+            }
+        }
+    }
+    return out.join('\n').replace(/@@DGBLK(\d+)@@/g, (m, i) => protectedBlocks[Number(i)]);
+}
+
+// ---------------------------------------------------------------------------
+// Inline preview (Code ⇄ Preview toggle)
+// ---------------------------------------------------------------------------
+
+/**
+ * Prepare template HTML for INLINE rendering inside the admin UI.
+ *
+ * Lightning Web Security blocks iframe srcdoc/document.write, so the preview
+ * renders straight into a lwc:dom="manual" div. To keep the template's CSS
+ * from leaking into the admin page, every selector is prefixed with the
+ * .dg-pv scope class (html/body selectors are remapped to the scope itself),
+ * @page rules are dropped (meaningless inline), and scripts/event handlers
+ * are stripped. Merge tags render as-is — this is a layout preview, not a
+ * data merge.
+ */
+export function scopeHtmlForInlinePreview(html) {
+    let work = (html || '').replace(/<script\b[\s\S]*?<\/script\s*>/gi, '').replace(/<link\b[^>]*>/gi, '');
+    const styles = [];
+    work = work.replace(/<style\b[^>]*>([\s\S]*?)<\/style\s*>/gi, (m, css) => {
+        styles.push(css);
+        return '';
+    });
+    const bodyMatch = work.match(/<body\b[^>]*>([\s\S]*?)<\/body\s*>/i);
+    let content = bodyMatch ? bodyMatch[1] : work.replace(/<\/?(?:!DOCTYPE|html|head|body|meta|title)\b[^>]*>/gi, '');
+    // Strip inline event handlers (on*="...") — static preview only.
+    content = content.replace(/\son\w+\s*=\s*(["'])[\s\S]*?\1/gi, '');
+
+    let css = styles.join('\n').replace(/@page\b[^{]*{[^}]*}/gi, '');
+    // Prefix every selector with the scope class. Handles the flat CSS 2.1
+    // rules templates use; at-rule headers (@media etc.) pass through and
+    // their inner rules get scoped by the same pass.
+    css = css.replace(/(^|})([^{}@]+){/g, (m, brace, selectors) => {
+        const scoped = selectors
+            .split(',')
+            .map((s) => {
+                const sel = s.trim();
+                if (!sel) {
+                    return sel;
+                }
+                if (/^(html|body)$/i.test(sel)) {
+                    return '.dg-pv';
+                }
+                return '.dg-pv ' + sel.replace(/^(html|body)\s+/i, '');
+            })
+            .join(', ');
+        return brace + '\n' + scoped + ' {';
+    });
+
+    // Baseline "paper sheet" look, injected with the content because
+    // component CSS can't reach lwc:dom="manual" children. Declared first so
+    // the template's own (scoped) rules win any conflicts.
+    const baseline =
+        '.dg-pv { background: #fff; max-width: 850px; margin: 0 auto; padding: 48px 56px; ' +
+        'box-shadow: 0 2px 12px rgba(0, 0, 0, 0.18); font-family: Helvetica, Arial, sans-serif; ' +
+        'font-size: 10.5pt; color: #1a1a1a; min-height: 380px; box-sizing: border-box; }';
+    return '<div class="dg-pv"><style>' + baseline + css + '</style>' + content + '</div>';
+}

--- a/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
@@ -35,6 +35,11 @@ export function isMoneyField(apiName) {
     return /amount|total|price|cost|revenue|budget/i.test(apiName || '');
 }
 
+/** Quantity-shaped field name → summable, but no currency symbol. */
+export function isQuantityField(apiName) {
+    return /qty|quantity|hours|units|weight|points|score|seats|licenses/i.test(apiName || '');
+}
+
 /**
  * Normalize any Query_Config__c flavor into one simple shape.
  * Never throws — falls back to a Name-only shape so the starter/prompt
@@ -609,10 +614,52 @@ export function buildTagPalette(shape) {
 
     for (const child of shape.children || []) {
         const rel = child.relationshipName;
+        // Aggregates generated from the loop's OWN fields — no placeholder
+        // editing. Money fields get SUM/AVG with :currency, quantity-shaped
+        // fields plain SUM, and every loop gets a record count.
+        const aggregateItems = [];
+        for (const f of child.fields || []) {
+            if (isMoneyField(f)) {
+                aggregateItems.push(
+                    {
+                        key: rel + '_sum_' + f,
+                        label: 'Total ' + humanizeField(f),
+                        snippet: '{SUM:' + rel + '.' + f + ':currency}',
+                        title:
+                            'Sum of ' +
+                            humanizeField(f) +
+                            ' across all ' +
+                            humanizeField(rel) +
+                            ' — goes OUTSIDE the loop'
+                    },
+                    {
+                        key: rel + '_avg_' + f,
+                        label: 'Average ' + humanizeField(f),
+                        snippet: '{AVG:' + rel + '.' + f + ':currency}',
+                        title: 'Average ' + humanizeField(f) + ' — goes OUTSIDE the loop'
+                    }
+                );
+            } else if (isQuantityField(f)) {
+                aggregateItems.push({
+                    key: rel + '_sum_' + f,
+                    label: 'Total ' + humanizeField(f),
+                    snippet: '{SUM:' + rel + '.' + f + '}',
+                    title:
+                        'Sum of ' + humanizeField(f) + ' across all ' + humanizeField(rel) + ' — goes OUTSIDE the loop'
+                });
+            }
+        }
+        aggregateItems.push({
+            key: rel + '_count',
+            label: 'Count of ' + humanizeField(rel),
+            snippet: '{COUNT:' + rel + '.Id}',
+            title: 'Number of ' + humanizeField(rel) + ' records — goes OUTSIDE the loop'
+        });
         sections.push({
             key: 'rel_' + rel,
             label: humanizeField(rel) + ' — child loop',
-            hint: 'Child fields only resolve inside the {#' + rel + '}…{/' + rel + '} loop.',
+            hint:
+                'Child fields only resolve inside the {#' + rel + '}…{/' + rel + '} loop. Totals/counts go outside it.',
             items: [
                 {
                     key: rel + '_table',
@@ -631,7 +678,8 @@ export function buildTagPalette(shape) {
                     label: humanizeField(f),
                     snippet: tagFor(f),
                     title: tagFor(f) + ' — place inside the {#' + rel + '} loop'
-                }))
+                })),
+                ...aggregateItems
             ]
         });
     }
@@ -697,36 +745,44 @@ export function buildTagPalette(shape) {
         ]
     });
 
-    sections.push({
-        key: 'logic',
-        label: 'Conditionals & Aggregates',
-        hint: 'Replace FieldName / Relationship.Field with yours.',
-        items: [
-            {
-                key: 'ifelse',
-                label: 'If / else block',
-                snippet: '{#FieldName}shown when set{:else}shown when empty{/FieldName}',
-                title: 'Conditional content'
-            },
+    // Real aggregates live in each relationship's own section, built from its
+    // actual fields. Generic placeholders only appear as a fallback when the
+    // Query Config has no child relationships to build from.
+    const logicItems = [
+        {
+            key: 'ifelse',
+            label: 'If / else block',
+            snippet: '{#FieldName}shown when set{:else}shown when empty{/FieldName}',
+            title: 'Conditional content — swap FieldName for one of yours'
+        },
+        {
+            key: 'checkbox',
+            label: 'Checkbox render',
+            snippet: '{FieldName:checkbox}',
+            title: '[X] when true, [ ] when false'
+        }
+    ];
+    if (!(shape.children || []).length) {
+        logicItems.push(
             {
                 key: 'sum',
                 label: 'SUM of child field',
                 snippet: '{SUM:Relationship.Field:currency}',
-                title: 'Total across child records'
+                title: 'Total across child records — add a child relationship to your Query Config for ready-made totals'
             },
             {
                 key: 'count',
                 label: 'COUNT of children',
                 snippet: '{COUNT:Relationship.Id}',
                 title: 'Number of child records'
-            },
-            {
-                key: 'checkbox',
-                label: 'Checkbox render',
-                snippet: '{FieldName:checkbox}',
-                title: '[X] when true, [ ] when false'
             }
-        ]
+        );
+    }
+    sections.push({
+        key: 'logic',
+        label: 'Conditionals',
+        hint: 'Swap FieldName for one of your fields.',
+        items: logicItems
     });
 
     return sections;

--- a/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
@@ -1,0 +1,468 @@
+/**
+ * Authoring kit for the HTML-first template creation wizard.
+ *
+ * Three exports drive the "Start from a Design" and "Generate with AI" paths:
+ *  - extractQueryShape(queryConfig, baseObject) — normalizes V1 SOQL strings,
+ *    V3 node trees, and V4 provider configs into one { object, baseFields,
+ *    parentFields, children } shape the builders consume.
+ *  - buildStarterHtml(starterKey, shape) — renders a complete, CSS 2.1-safe
+ *    HTML template body with the author's real merge fields injected, ready
+ *    to save as v1 and generate on first click.
+ *  - buildAiPrompt(shape, options) — assembles a copy-paste LLM prompt with
+ *    the full DocGen tag cheat sheet, the Flying Saucer rendering constraints,
+ *    and the template's actual schema.
+ *
+ * Every starter obeys the Flying Saucer envelope: CSS 2.1 only (no flex/grid/
+ * calc/variables/gradients), table-based layout, solid colors, @page in the
+ * source so the engine defers to it.
+ */
+import { parseSOQLFields } from 'c/docGenUtils';
+
+/** 'Total_Amount__c' → 'Total Amount'; 'Owner.Name' → 'Owner Name'; 'FirstName' → 'First Name' */
+export function humanizeField(apiName) {
+    return (apiName || '')
+        .replace(/__c$/i, '')
+        .replace(/__r\./gi, ' ')
+        .replace(/\./g, ' ')
+        .replace(/_/g, ' ')
+        .replace(/([a-z])([A-Z])/g, '$1 $2')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+/** Money-shaped field name → render with :currency and right-align. */
+export function isMoneyField(apiName) {
+    return /amount|total|price|cost|revenue|budget/i.test(apiName || '');
+}
+
+/**
+ * Normalize any Query_Config__c flavor into one simple shape.
+ * Never throws — falls back to a Name-only shape so the starter/prompt
+ * builders always have something render-worthy.
+ */
+export function extractQueryShape(queryConfig, baseObject) {
+    const shape = {
+        object: baseObject || 'Record',
+        baseFields: [],
+        parentFields: [],
+        children: [],
+        provider: null
+    };
+    const q = (queryConfig || '').trim();
+    if (!q) {
+        shape.baseFields = ['Name'];
+        return shape;
+    }
+    try {
+        if (q.startsWith('{')) {
+            const cfg = JSON.parse(q);
+            if (cfg.v === 4 && cfg.provider) {
+                shape.provider = cfg.provider;
+                shape.baseFields = ['Name'];
+                return shape;
+            }
+            if (cfg.v === 3 && Array.isArray(cfg.nodes)) {
+                const root = cfg.nodes.find((n) => !n.parentNode) || {};
+                shape.baseFields = [...(root.fields || [])];
+                shape.parentFields = [...(root.parentFields || [])];
+                const collectKids = (parentId) => {
+                    for (const k of cfg.nodes.filter((n) => n.parentNode === parentId)) {
+                        shape.children.push({
+                            relationshipName: k.alias || k.relationshipName,
+                            fields: [...(k.fields || []), ...(k.parentFields || [])]
+                        });
+                        // Grandchildren flatten into the list too — starters render
+                        // top-level child sections only, but the AI prompt lists all.
+                        collectKids(k.id);
+                    }
+                };
+                collectKids(root.id);
+            }
+        } else {
+            const parsed = parseSOQLFields(q);
+            shape.baseFields = parsed.baseFields || [];
+            shape.parentFields = parsed.parentFields || [];
+            const flatten = (subs) => {
+                for (const sq of subs || []) {
+                    shape.children.push({ relationshipName: sq.relationshipName, fields: sq.fields || [] });
+                    flatten(sq.children);
+                }
+            };
+            flatten(parsed.subqueries);
+        }
+    } catch (e) {
+        // eslint-disable-line no-unused-vars
+        // Unparseable config — keep going with a minimal shape.
+    }
+    if (shape.baseFields.length === 0 && shape.parentFields.length === 0) {
+        shape.baseFields = ['Name'];
+    }
+    return shape;
+}
+
+// ---------------------------------------------------------------------------
+// Shared HTML fragments
+// ---------------------------------------------------------------------------
+
+const BASE_CSS = `
+        @page { size: Letter portrait; margin: 0.75in; }
+        body { font-family: Helvetica, Arial, sans-serif; font-size: 10.5pt; color: #1a1a1a; margin: 0; }
+        h1 { font-size: 20pt; margin: 0 0 2pt 0; color: #1f3a5f; }
+        h2 { font-size: 13pt; margin: 18pt 0 6pt 0; color: #1f3a5f; border-bottom: 2pt solid #1f3a5f; padding-bottom: 3pt; }
+        table { width: 100%; border-collapse: collapse; border-spacing: 0; }
+        td, th { padding: 5pt 7pt; vertical-align: top; }
+        .meta { color: #666666; font-size: 9pt; }
+        .label-cell { width: 35%; font-weight: bold; color: #444444; background: #f2f4f7; border-bottom: 1pt solid #ffffff; }
+        .value-cell { border-bottom: 1pt solid #eeeeee; }
+        .data-table th { background: #1f3a5f; color: #ffffff; text-align: left; font-size: 9.5pt; }
+        .data-table td { border-bottom: 0.75pt solid #dddddd; }
+        .footer-note { margin-top: 24pt; padding-top: 6pt; border-top: 1pt solid #cccccc; color: #888888; font-size: 8.5pt; }`;
+
+function detailRows(fields) {
+    return fields
+        .map((f) => {
+            const tag = isMoneyField(f) ? `{${f}:currency}` : `{${f}}`;
+            return `            <tr>\n                <td class="label-cell">${humanizeField(f)}</td>\n                <td class="value-cell">${tag}</td>\n            </tr>`;
+        })
+        .join('\n');
+}
+
+// Loop tags must open in the first cell and close in the last so container
+// auto-expansion repeats the whole <tr> per child row.
+function childLoopTable(child) {
+    const rel = child.relationshipName;
+    const fields = child.fields.length ? child.fields : ['Name'];
+    const headCells = fields
+        .map((f) => {
+            const align = isMoneyField(f) ? ' style="text-align: right"' : '';
+            return `                    <th${align}>${humanizeField(f)}</th>`;
+        })
+        .join('\n');
+    const cells = fields
+        .map((f, i) => {
+            const money = isMoneyField(f);
+            let inner = money ? `{${f}:currency}` : `{${f}}`;
+            if (i === 0) inner = `{#${rel}}` + inner;
+            if (i === fields.length - 1) inner = inner + `{/${rel}}`;
+            const align = money ? ' style="text-align: right"' : '';
+            return `                    <td${align}>${inner}</td>`;
+        })
+        .join('\n');
+    return `        <table class="data-table">
+            <thead>
+                <tr>
+${headCells}
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+${cells}
+                </tr>
+            </tbody>
+        </table>`;
+}
+
+function docShell(title, bodyInner, extraCss) {
+    return `<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>${title}</title>
+    <style>${BASE_CSS}${extraCss || ''}
+    </style>
+</head>
+<body>
+${bodyInner}
+</body>
+</html>
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Starters
+// ---------------------------------------------------------------------------
+
+function buildReport(shape) {
+    const detailFields = [...shape.baseFields, ...shape.parentFields];
+    const sections = shape.children
+        .map((c) => `\n    <h2>${humanizeField(c.relationshipName)}</h2>\n${childLoopTable(c)}`)
+        .join('\n');
+    const inner = `    <table>
+        <tr>
+            <td>
+                <h1>{Name}</h1>
+                <div class="meta">${humanizeField(shape.object)} Report</div>
+            </td>
+            <td style="text-align: right" class="meta">
+                Prepared by {RunningUser.Name}<br />
+                {Today:MMMM d, yyyy}
+            </td>
+        </tr>
+    </table>
+
+    <h2>Details</h2>
+    <table>
+${detailRows(detailFields)}
+    </table>
+${sections}
+
+    <div class="footer-note">Generated with Portwood DocGen &#8226; {Today:MM/dd/yyyy}</div>`;
+    return docShell('Record Report', inner);
+}
+
+function buildLetter(shape) {
+    const inner = `    <table>
+        <tr>
+            <td>
+                <h1 style="font-size: 14pt">Your Company Name</h1>
+                <div class="meta">123 Your Street &#8226; Your City, ST 00000 &#8226; (555) 555-0100</div>
+            </td>
+            <td style="text-align: right" class="meta">{Today:MMMM d, yyyy}</td>
+        </tr>
+    </table>
+
+    <p style="margin-top: 28pt">{Name}</p>
+
+    <p style="margin-top: 18pt">Dear {Name},</p>
+
+    <p>
+        Replace this paragraph with your letter body. Any field from your Query Config drops in with a merge
+        tag &#8212; for example, this record is {Name}. Format dates and money with suffixes like
+        &#123;CloseDate:MMMM d, yyyy&#125; and &#123;Amount:currency&#125;.
+    </p>
+
+    <p>
+        A second paragraph of your letter. Conditional blocks let you include text only when a field has a
+        value, and loops repeat a block for every child record.
+    </p>
+
+    <p style="margin-top: 30pt">
+        Sincerely,<br /><br /><br />
+        {RunningUser.Name}<br />
+        <span class="meta">{RunningUser.Title}</span>
+    </p>`;
+    return docShell('Business Letter', inner);
+}
+
+function buildInvoice(shape) {
+    const child = shape.children[0];
+    const rel = child ? child.relationshipName : null;
+    const sumField = child ? child.fields.find(isMoneyField) : null;
+    const lineTable = child
+        ? childLoopTable(child)
+        : `        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Description</th>
+                    <th style="text-align: right">Amount</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Add a child relationship in your Query Config to loop line items here.</td>
+                    <td style="text-align: right">&#8212;</td>
+                </tr>
+            </tbody>
+        </table>`;
+    const totalRow =
+        rel && sumField
+            ? `\n    <table style="margin-top: 8pt">
+        <tr>
+            <td style="width: 70%"></td>
+            <td class="label-cell" style="text-align: right">Total</td>
+            <td class="value-cell" style="text-align: right; font-weight: bold">{SUM:${rel}.${sumField}:currency}</td>
+        </tr>
+    </table>`
+            : '';
+    const inner = `    <table>
+        <tr>
+            <td>
+                <h1>INVOICE</h1>
+                <div class="meta">Your Company Name</div>
+            </td>
+            <td style="text-align: right" class="meta">
+                Date: {Today:MM/dd/yyyy}<br />
+                Reference: {Name}
+            </td>
+        </tr>
+    </table>
+
+    <h2>Billed To</h2>
+    <table>
+${detailRows([...shape.baseFields, ...shape.parentFields])}
+    </table>
+
+    <h2>Line Items</h2>
+${lineTable}${totalRow}
+
+    <div class="footer-note">Payment due within 30 days &#8226; Generated {Today:MMMM d, yyyy} by {RunningUser.Name}</div>`;
+    return docShell('Invoice', inner);
+}
+
+function buildAgreement(shape) {
+    const inner = `    <h1 style="text-align: center">Agreement</h1>
+    <p class="meta" style="text-align: center">Effective {Today:MMMM d, yyyy}</p>
+
+    <p style="margin-top: 20pt">
+        This Agreement is entered into between <strong>Your Company Name</strong> ("Company") and
+        <strong>{Name}</strong> ("Customer").
+    </p>
+
+    <h2>1. Scope</h2>
+    <p>Describe the goods or services covered by this agreement. Merge any field from your Query Config, e.g. {Name}.</p>
+
+    <h2>2. Term</h2>
+    <p>This agreement begins on {Today:MMMM d, yyyy} and continues until terminated by either party.</p>
+
+    <h2>3. Signatures</h2>
+    <p>Signed and agreed by the parties below.</p>
+
+    <table style="margin-top: 30pt">
+        <tr>
+            <td style="width: 48%">
+                {@Signature_Customer:1:Full}
+                <div style="border-top: 1pt solid #333333; margin-top: 4pt; padding-top: 3pt" class="meta">
+                    Customer &#8226; Date: {@Signature_Customer:1:Date}
+                </div>
+            </td>
+            <td style="width: 4%"></td>
+            <td style="width: 48%">
+                {@Signature_Company_Representative:2:Full}
+                <div style="border-top: 1pt solid #333333; margin-top: 4pt; padding-top: 3pt" class="meta">
+                    Company Representative &#8226; Date: {@Signature_Company_Representative:2:Date}
+                </div>
+            </td>
+        </tr>
+    </table>`;
+    return docShell('Agreement', inner);
+}
+
+export const STARTERS = [
+    {
+        key: 'report',
+        label: 'Record Report',
+        icon: 'utility:summarydetail',
+        description:
+            'Title band, a details table of your fields, and a table per child relationship. The safe default for any object.'
+    },
+    {
+        key: 'invoice',
+        label: 'Invoice / Line Items',
+        icon: 'utility:money',
+        description:
+            'Billed-to block plus a line-item loop table from your first child relationship, with an automatic total row.'
+    },
+    {
+        key: 'letter',
+        label: 'Business Letter',
+        icon: 'utility:email',
+        description: 'Letterhead, date, salutation, and body copy with merge fields — signed by the running user.'
+    },
+    {
+        key: 'agreement',
+        label: 'Agreement (Signature-ready)',
+        icon: 'utility:signature',
+        description: 'Numbered terms with a two-party e-signature block wired to DocGen signature tags.'
+    }
+];
+
+const BUILDERS = { report: buildReport, invoice: buildInvoice, letter: buildLetter, agreement: buildAgreement };
+
+export function buildStarterHtml(starterKey, shape) {
+    const builder = BUILDERS[starterKey] || buildReport;
+    return builder(shape);
+}
+
+// ---------------------------------------------------------------------------
+// AI prompt
+// ---------------------------------------------------------------------------
+
+/**
+ * Assemble a self-contained LLM prompt: rendering constraints + tag syntax +
+ * this template's actual schema. Works pasted into any assistant.
+ */
+export function buildAiPrompt(shape, options) {
+    const opts = options || {};
+    const lines = [];
+    lines.push(
+        'You are writing an HTML document template for Portwood DocGen, a native Salesforce document-generation package. The template is a single self-contained HTML file. DocGen replaces {merge tags} with Salesforce record data, then renders the HTML to PDF with the Flying Saucer engine.'
+    );
+    lines.push('');
+    lines.push('HARD RENDERING CONSTRAINTS (Flying Saucer = CSS 2.1 plus a small CSS 3 subset):');
+    lines.push('- Layout with <table>/<tr>/<td>, or <div> with display:table / table-row / table-cell.');
+    lines.push(
+        '- NEVER use: flexbox, grid, gap, calc(), CSS variables, linear-gradient or any gradient, position:sticky, transforms. They are silently ignored and the layout collapses.'
+    );
+    lines.push('- Solid colors only. No web fonts — stick to Helvetica/Arial/Times/Georgia/Courier.');
+    lines.push(
+        "- No <svg> and no JavaScript — they are dropped. Images must be <img> with regular src URLs; don't invent image URLs."
+    );
+    lines.push(
+        '- Avoid child selectors involving tbody (e.g. table > tbody > tr) — they silently fail. Use classes on cells instead.'
+    );
+    lines.push(
+        '- Declare the page setup with an @page rule in a <style> block, e.g. @page { size: Letter portrait; margin: 0.75in; }'
+    );
+    lines.push(
+        '- Every {...} pair is treated as a merge tag: unknown names render as empty text, and an unclosed { fails the merge. For literal braces use &#123; and &#125;.'
+    );
+    lines.push('');
+    lines.push('DOCGEN MERGE TAG SYNTAX:');
+    lines.push(
+        '- Field: {FieldName} — e.g. {Name}, {Status__c}. Parent lookups dot through: {Account.Name}, {Owner.Profile.Name}. Null renders as empty string.'
+    );
+    lines.push(
+        '- Format suffixes: {CloseDate:MMMM d, yyyy} (Java SimpleDateFormat), {CloseDate:date} (user locale), {Amount:currency}, {Amount:currency:EUR}, {Qty:number}, {Qty:#,##0.00}, {Rate:percent}, {IsActive:checkbox} ([X]/[ ]), {Status__c:label} (picklist label).'
+    );
+    lines.push(
+        '- Child loop: {#RelationshipName} ... {/RelationshipName} repeats the block per child record; child fields are bare inside the loop. If the tags sit inside a table row, the whole <tr> repeats — put {#Rel} in the first cell and {/Rel} in the last cell of the data row. Use a real <thead> for column headers. Nested loops are supported.'
+    );
+    lines.push('- Conditional: {#SomeField} shown when truthy {:else} otherwise {/SomeField}.');
+    lines.push(
+        '- Aggregates: {SUM:Rel.Field}, plus AVG/MIN/MAX/COUNT — format suffixes apply, e.g. {SUM:Lines.Amount:currency}.'
+    );
+    lines.push(
+        '- Built-ins: {Today:MMMM d, yyyy}, {Now:yyyy-MM-dd HH:mm}, and running-user tags {RunningUser.Name}, {RunningUser.Email}, {RunningUser.Title}.'
+    );
+    lines.push(
+        '- E-signature placeholders (only if asked for a signable document): {@Signature_RoleName:1:Full}, {@Signature_RoleName:1:Date}.'
+    );
+    lines.push('');
+    lines.push('DATA SHAPE — use ONLY these fields (any other tag renders empty):');
+    if (opts.dataSourceMode === 'flow') {
+        lines.push(
+            '- Data arrives at runtime as JSON from a Salesforce Flow. Describe your JSON keys to me here, then use them as {key} tags. Lists loop with {#listKey}...{/listKey}.'
+        );
+    } else if (shape.provider) {
+        lines.push(`- Data comes from the Apex provider class ${shape.provider}. Fields available:`);
+        for (const f of opts.providerFields || []) {
+            lines.push(`  - {${f}}`);
+        }
+        if (!(opts.providerFields || []).length) {
+            lines.push('  - (list your provider field names here before pasting)');
+        }
+    } else {
+        lines.push(`- Base object: ${shape.object}`);
+        for (const f of [...shape.baseFields, ...shape.parentFields]) {
+            lines.push(`  - {${f}}${f.includes('.') ? ' (parent lookup)' : ''}`);
+        }
+        for (const c of shape.children) {
+            lines.push(
+                `- Child relationship {#${c.relationshipName}}...{/${c.relationshipName}} with fields: ${c.fields.map((f) => '{' + f + '}').join(', ')}`
+            );
+        }
+    }
+    lines.push('');
+    lines.push('WHAT I WANT THIS DOCUMENT TO BE:');
+    lines.push(
+        '<<DESCRIBE YOUR DOCUMENT HERE: purpose, sections, tone, branding colors. Example: "A two-page account summary: header with account name and logo placeholder, key details table, then a table of open opportunities with a total row.">>'
+    );
+    lines.push('');
+    lines.push('OUTPUT REQUIREMENTS:');
+    lines.push(
+        '1. Return ONE complete self-contained HTML file (<!DOCTYPE html> ... </html>) with all CSS inline in a single <style> block. No commentary, no markdown fences.'
+    );
+    lines.push('2. Professional print-ready design within the CSS 2.1 constraints above.');
+    lines.push('3. Use only the merge tags listed in DATA SHAPE (plus {Today}/{RunningUser.*} built-ins).');
+    return lines.join('\n');
+}

--- a/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
@@ -934,7 +934,7 @@ export function buildTagPalette(shape) {
         aggregateItems.push({
             key: rel + '_count',
             label: 'Count of ' + humanizeField(rel),
-            snippet: '{COUNT:' + rel + '.Id}',
+            snippet: '{COUNT:' + rel + '}',
             title: 'Number of ' + humanizeField(rel) + ' records — goes OUTSIDE the loop'
         });
         sections.push({
@@ -1240,7 +1240,7 @@ export function buildTagPalette(shape) {
             {
                 key: 'count',
                 label: 'COUNT of children',
-                snippet: '{COUNT:Relationship.Id}',
+                snippet: '{COUNT:Relationship}',
                 title: 'Number of child records'
             }
         );

--- a/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
@@ -593,6 +593,197 @@ export function scopeHtmlForInlinePreview(html) {
  * ready-made loop table), plus the universal built-ins, signature tags,
  * conditionals, and aggregates.
  */
+/**
+ * Ready-made layout blocks for the visual builder. Every snippet is
+ * self-contained (inline styles only — no dependence on the template's CSS)
+ * and Flying Saucer-safe: table-based columns, solid colors, CSS 2.1 only.
+ */
+export function buildBlockPalette(shape) {
+    const td = 'vertical-align: top; padding: 0 8pt 0 0';
+    const cell = 'padding: 5pt 7pt; border-bottom: 0.75pt solid #dddddd';
+    const th = 'background: #1f3a5f; color: #ffffff; text-align: left; padding: 5pt 7pt; font-size: 9.5pt';
+
+    const sections = [
+        {
+            key: 'blk_layout',
+            label: 'Layout',
+            hint: 'Table-based — the only layout the PDF engine renders reliably.',
+            items: [
+                {
+                    key: 'blk_2col',
+                    label: 'Two columns',
+                    snippet:
+                        '\n<table style="width: 100%; border-collapse: collapse"><tr>' +
+                        '<td style="width: 50%; ' +
+                        td +
+                        '"><p>Left column</p></td>' +
+                        '<td style="width: 50%; vertical-align: top; padding: 0 0 0 8pt"><p>Right column</p></td>' +
+                        '</tr></table>\n',
+                    title: '50/50 side-by-side content'
+                },
+                {
+                    key: 'blk_3col',
+                    label: 'Three columns',
+                    snippet:
+                        '\n<table style="width: 100%; border-collapse: collapse"><tr>' +
+                        '<td style="width: 33%; ' +
+                        td +
+                        '"><p>First</p></td>' +
+                        '<td style="width: 34%; ' +
+                        td +
+                        '"><p>Second</p></td>' +
+                        '<td style="width: 33%; vertical-align: top"><p>Third</p></td>' +
+                        '</tr></table>\n',
+                    title: 'Three equal columns'
+                },
+                {
+                    key: 'blk_table',
+                    label: 'Data table',
+                    snippet:
+                        '\n<table style="width: 100%; border-collapse: collapse">' +
+                        '<thead><tr>' +
+                        '<th style="' +
+                        th +
+                        '">Column 1</th><th style="' +
+                        th +
+                        '">Column 2</th><th style="' +
+                        th +
+                        '">Column 3</th>' +
+                        '</tr></thead><tbody>' +
+                        '<tr><td style="' +
+                        cell +
+                        '">&nbsp;</td><td style="' +
+                        cell +
+                        '">&nbsp;</td><td style="' +
+                        cell +
+                        '">&nbsp;</td></tr>' +
+                        '<tr><td style="' +
+                        cell +
+                        '">&nbsp;</td><td style="' +
+                        cell +
+                        '">&nbsp;</td><td style="' +
+                        cell +
+                        '">&nbsp;</td></tr>' +
+                        '</tbody></table>\n',
+                    title: 'Styled 3-column table shell — add your own rows and fields'
+                },
+                {
+                    key: 'blk_divider',
+                    label: 'Divider line',
+                    snippet:
+                        '\n<div style="border-top: 1pt solid #cccccc; margin: 14pt 0; font-size: 0">&nbsp;</div>\n',
+                    title: 'Horizontal rule'
+                },
+                {
+                    key: 'blk_spacer',
+                    label: 'Spacer',
+                    snippet: '\n<div style="height: 18pt; font-size: 0">&nbsp;</div>\n',
+                    title: 'Vertical breathing room'
+                },
+                {
+                    key: 'blk_pagebreak',
+                    label: 'Page break',
+                    snippet: '\n<div style="page-break-before: always; font-size: 0">&nbsp;</div>\n',
+                    title: 'Starts a new PDF page here (invisible in the editor)'
+                }
+            ]
+        },
+        {
+            key: 'blk_content',
+            label: 'Content',
+            hint: 'Drop in, then click the text to rewrite it.',
+            items: [
+                {
+                    key: 'blk_band',
+                    label: 'Header band',
+                    snippet:
+                        '\n<table style="width: 100%; border-collapse: collapse; background: #1f3a5f"><tr>' +
+                        '<td style="padding: 14pt 16pt">' +
+                        '<span style="color: #ffffff; font-size: 20pt">Document Title</span><br />' +
+                        '<span style="color: #9fb8cf; font-size: 9pt">Subtitle — drop fields from Insert Tags here</span>' +
+                        '</td></tr></table>\n',
+                    title: 'Navy title banner'
+                },
+                {
+                    key: 'blk_heading',
+                    label: 'Section heading',
+                    snippet:
+                        '\n<h2 style="font-size: 13pt; color: #1f3a5f; border-bottom: 2pt solid #1f3a5f; padding-bottom: 3pt; margin: 18pt 0 6pt 0">Section Title</h2>\n',
+                    title: 'Underlined section header'
+                },
+                {
+                    key: 'blk_para',
+                    label: 'Paragraph',
+                    snippet:
+                        '\n<p style="margin: 6pt 0">Your text here — mix in fields from Insert Tags anywhere.</p>\n',
+                    title: 'Plain text block'
+                },
+                {
+                    key: 'blk_callout',
+                    label: 'Callout box',
+                    snippet:
+                        '\n<table style="width: 100%; border-collapse: collapse"><tr>' +
+                        '<td style="background: #f2f6fc; border-left: 4pt solid #1f3a5f; padding: 8pt 12pt">Callout — great for notes, terms, or highlights.</td>' +
+                        '</tr></table>\n',
+                    title: 'Accented highlight box'
+                },
+                {
+                    key: 'blk_footer',
+                    label: 'Footer note',
+                    snippet:
+                        '\n<div style="margin-top: 24pt; padding-top: 6pt; border-top: 1pt solid #cccccc; color: #888888; font-size: 8.5pt">Generated {Today:MM/dd/yyyy} by {RunningUser.Name}</div>\n',
+                    title: 'Small gray footer line'
+                }
+            ]
+        }
+    ];
+
+    // Ready-made pieces built from THIS template's query.
+    const readyItems = [];
+    const detailFields = [...(shape.baseFields || []), ...(shape.parentFields || [])];
+    if (detailFields.length) {
+        const rows = detailFields
+            .map((f) => {
+                const tag = isMoneyField(f) ? '{' + f + ':currency}' : '{' + f + '}';
+                return (
+                    '<tr><td style="width: 35%; font-weight: bold; color: #444444; background: #f2f4f7; padding: 5pt 7pt">' +
+                    humanizeField(f) +
+                    '</td><td style="border-bottom: 1pt solid #eeeeee; padding: 5pt 7pt">' +
+                    tag +
+                    '</td></tr>'
+                );
+            })
+            .join('');
+        readyItems.push({
+            key: 'blk_details',
+            label: 'Details table (your fields)',
+            snippet: '\n<table style="width: 100%; border-collapse: collapse">' + rows + '</table>\n',
+            title: 'Label/value rows for every field in your Query Config'
+        });
+    }
+    readyItems.push({
+        key: 'blk_sig',
+        label: 'Signature block (two-party)',
+        snippet:
+            '\n<table style="width: 100%; border-collapse: collapse; margin-top: 24pt"><tr>' +
+            '<td style="width: 48%; vertical-align: bottom">{@Signature_Customer:1:Full}' +
+            '<div style="border-top: 1pt solid #333333; margin-top: 4pt; padding-top: 3pt; color: #666666; font-size: 9pt">Customer &#8226; Date: {@Signature_Customer:1:Date}</div></td>' +
+            '<td style="width: 4%">&nbsp;</td>' +
+            '<td style="width: 48%; vertical-align: bottom">{@Signature_Company_Representative:2:Full}' +
+            '<div style="border-top: 1pt solid #333333; margin-top: 4pt; padding-top: 3pt; color: #666666; font-size: 9pt">Company &#8226; Date: {@Signature_Company_Representative:2:Date}</div></td>' +
+            '</tr></table>\n',
+        title: 'E-signature areas for both parties, wired to DocGen signing'
+    });
+    sections.push({
+        key: 'blk_ready',
+        label: 'Ready-made',
+        hint: 'Built from this template’s own Query Config.',
+        items: readyItems
+    });
+
+    return sections;
+}
+
 export function buildTagPalette(shape) {
     const sections = [];
     const tagFor = (f) => (isMoneyField(f) ? '{' + f + ':currency}' : '{' + f + '}');

--- a/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
@@ -966,6 +966,74 @@ export function buildTagPalette(shape) {
         });
     }
 
+    // Chart gallery: all nine engine styles, wired to the first child
+    // relationship's first bucketable field — pills are editable, so authors
+    // retarget by double-clicking. SVG-only styles carry htmlRender=svg.
+    const chartRel = (shape.children || [])[0];
+    const chartField = chartRel ? (chartRel.fields || []).find((f) => f !== 'Id' && !f.includes('.')) : null;
+    if (chartRel && chartField) {
+        const cr = chartRel.relationshipName;
+        const mkChart = (style, svg) =>
+            '{Chart:' +
+            cr +
+            ':' +
+            chartField +
+            ':' +
+            style +
+            ':title=' +
+            humanizeField(cr) +
+            ' by ' +
+            humanizeField(chartField) +
+            (svg ? '&htmlRender=svg' : '') +
+            '}';
+        sections.push({
+            key: 'chartstyles',
+            label: 'Chart gallery',
+            hint: 'Nine styles. SVG styles (pie, donut, column, line, area) render in HTML output; for PDFs prefer bar/stacked/clustered/pivot. Double-click the pill to retarget.',
+            items: [
+                {
+                    key: 'ch_bar',
+                    label: 'Bar chart',
+                    snippet: mkChart('bar', false),
+                    title: 'Horizontal bars — PDF-safe'
+                },
+                {
+                    key: 'ch_stacked',
+                    label: 'Stacked bar',
+                    snippet: mkChart('stacked', false),
+                    title: 'Needs groupBy= and colSort= options — PDF-safe'
+                },
+                {
+                    key: 'ch_clustered',
+                    label: 'Clustered bars',
+                    snippet: mkChart('clustered', false),
+                    title: 'Needs groupBy= and colSort= — PDF-safe'
+                },
+                {
+                    key: 'ch_pivot',
+                    label: 'Pivot table',
+                    snippet: mkChart('pivot', false),
+                    title: 'Cross-tab counts — needs groupBy= and colSort= — PDF-safe'
+                },
+                {
+                    key: 'ch_column',
+                    label: 'Column chart (SVG)',
+                    snippet: mkChart('column', true),
+                    title: 'Vertical columns — HTML output'
+                },
+                { key: 'ch_pie', label: 'Pie chart (SVG)', snippet: mkChart('pie', true), title: 'HTML output' },
+                {
+                    key: 'ch_donut',
+                    label: 'Donut chart (SVG)',
+                    snippet: mkChart('donut', true),
+                    title: 'HTML output — innerRadius= tunes the hole'
+                },
+                { key: 'ch_line', label: 'Line chart (SVG)', snippet: mkChart('line', true), title: 'HTML output' },
+                { key: 'ch_area', label: 'Area chart (SVG)', snippet: mkChart('area', true), title: 'HTML output' }
+            ]
+        });
+    }
+
     sections.push({
         key: 'builtins',
         label: 'Built-ins',
@@ -991,6 +1059,36 @@ export function buildTagPalette(shape) {
                 label: 'Running user email',
                 snippet: '{RunningUser.Email}',
                 title: '{RunningUser.Email}'
+            },
+            {
+                key: 'ru_phone',
+                label: 'Running user phone',
+                snippet: '{RunningUser.Phone}',
+                title: '{RunningUser.Phone} — also: MobilePhone, Fax, Extension'
+            },
+            {
+                key: 'ru_dept',
+                label: 'Running user department',
+                snippet: '{RunningUser.Department}',
+                title: '{RunningUser.Department} — also: CompanyName, EmployeeNumber, Alias'
+            },
+            {
+                key: 'ru_company',
+                label: 'Running user company',
+                snippet: '{RunningUser.CompanyName}',
+                title: '{RunningUser.CompanyName} — address fields too: Street, City, State, PostalCode, Country'
+            },
+            {
+                key: 'pagenum',
+                label: 'Page number',
+                snippet: '{PageNumber}',
+                title: 'Current page — ONLY works in the template Header/Footer, not the body'
+            },
+            {
+                key: 'pagetotal',
+                label: 'Total pages',
+                snippet: '{TotalPages}',
+                title: 'Page count — ONLY works in the template Header/Footer, not the body'
             }
         ]
     });
@@ -1023,6 +1121,18 @@ export function buildTagPalette(shape) {
                 label: 'Signature (Company rep)',
                 snippet: '{@Signature_Company_Representative:2:Full}',
                 title: 'Second signer, order 2'
+            },
+            {
+                key: 'sig_datepick',
+                label: 'Date picker (signer chooses)',
+                snippet: '{@Signature_Customer:1:DatePick}',
+                title: 'Signer picks a date instead of auto-fill'
+            },
+            {
+                key: 'sig_inline',
+                label: 'Inline signature (compact)',
+                snippet: '{@Signature_Customer:1:Full:inline}',
+                title: 'Compact in-place mark — sits inside a sentence instead of a block'
             }
         ]
     });
@@ -1087,6 +1197,30 @@ export function buildTagPalette(shape) {
             label: 'If / else block',
             snippet: '{#FieldName}shown when set{:else}shown when empty{/FieldName}',
             title: 'Conditional content — swap FieldName for one of yours'
+        },
+        {
+            key: 'inverse',
+            label: 'Show when EMPTY (inverse)',
+            snippet: '{^FieldName}shown only when FieldName is blank{/FieldName}',
+            title: 'Renders only when the field is null, false, or an empty list'
+        },
+        {
+            key: 'if_compare',
+            label: 'If — number comparison',
+            snippet: '{#IF Amount >= 100000}big deal content{:else}standard content{/IF}',
+            title: 'Operators: == != > < >= <= — close with {/IF}'
+        },
+        {
+            key: 'if_text',
+            label: 'If — text equals',
+            snippet: "{#IF StageName == 'Closed Won'}congratulations{/IF}",
+            title: "Quote text values: {#IF Status == 'Active'}"
+        },
+        {
+            key: 'if_logic',
+            label: 'If — AND / OR / NOT',
+            snippet: "{#IF (Amount > 1000 AND StageName == 'Closed Won') OR Type == 'Renewal'}...{/IF}",
+            title: 'Combine with AND, OR, NOT and parentheses'
         },
         {
             key: 'checkbox',

--- a/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
+++ b/force-app/main/default/lwc/docGenAdmin/docGenAuthoringKit.js
@@ -719,6 +719,20 @@ export function buildBlockPalette(shape) {
                     title: 'Plain text block'
                 },
                 {
+                    key: 'blk_panel',
+                    label: 'Tinted panel',
+                    snippet:
+                        '\n<div style="background: #f2f6fc; padding: 10pt 12pt; margin: 8pt 0"><p style="margin: 0">Panel text — a soft background block for callouts, summaries, or sidebars.</p></div>\n',
+                    title: 'Light background panel — recolor it with the Cell/Fill swatches'
+                },
+                {
+                    key: 'blk_darkpanel',
+                    label: 'Dark panel',
+                    snippet:
+                        '\n<div style="background: #1f3a5f; color: #ffffff; padding: 10pt 12pt; margin: 8pt 0"><p style="margin: 0; color: #ffffff">Bold statement text on a navy panel.</p></div>\n',
+                    title: 'Navy background block with white text'
+                },
+                {
                     key: 'blk_callout',
                     label: 'Callout box',
                     snippet:

--- a/force-app/main/default/lwc/docGenCommandHub/docGenCommandHub.html
+++ b/force-app/main/default/lwc/docGenCommandHub/docGenCommandHub.html
@@ -38,6 +38,14 @@
             </div>
 
             <div class="sidebar-footer">
+                <a
+                    href="mailto:support@portwood.dev?subject=DocGen%20bug%20report"
+                    class="community-link"
+                    title="Something broken or confusing? Tell us — it goes straight to the team."
+                >
+                    <lightning-icon icon-name="utility:bug" size="xx-small" class="nav-icon"></lightning-icon>
+                    Report a Bug
+                </a>
                 <a href="https://portwood.dev/community" target="_blank" class="community-link">
                     <lightning-icon icon-name="utility:comments" size="xx-small" class="nav-icon"></lightning-icon>
                     Join the Community


### PR DESCRIPTION
## What this is

35 commits turning template creation HTML-first and shipping a full visual design studio (marked **Beta**), built and live-verified over two days in the `docgen-wizard` scratch org with real-time user feedback.

### Wizard — one place to move forward on every path
- Four authoring cards, defaulting to **I Have an Existing File**: Start from a Design (per-starter objects + prebuilt queries, no object picker), Generate with AI (in-wizard prompt → paste → designer, assets included in the prompt), **Start From Scratch** (rich auto-query: all usable fields + child lists), file upload.
- Company logo select-only from the shared Asset Library with thumbnail preview; sample record above the single CTA; power-user fields behind Advanced options.

### Designer (Beta)
- **Visual canvas**: click/double-click anywhere and type; merge-tag pills with a 45-option format catalog (currency incl. `:auto` + 11 ISO locales, locale dates, numbers, QR/barcode/image); type-to-pill; safe pill editing.
- **`` ` `` command palette**: plain-language searchable menu at the caret — blocks, flexipage-style 2–12 column sections, every tag from the query, loops ("Start/Close loop"), inverse + `{#IF}` conditionals, formatting commands, chart gallery (all 9 engine styles), image assets, signer `{?key}` fields; feedback footer (hello@portwood.dev).
- **Right-click context menu**; mouse-driven drag-and-drop (LWS-proof); searchable floating panels replacing the fixed rail; sticky glass chrome.
- **Header/Footer panel** (Page X of Y chips), **Repeat Hdr** table toggle, colgroup-aware column resize, oversized converted-table auto-fit (persists into the saved body), **Versions panel** (load any version), template switcher, **Edit Template** round-trip, **live PDF Preview** of the unsaved draft through the real engine (native file viewer).
- Save as New Version auto-applies editor edits; calm save toasts; Word→HTML keeps the original filename.

### Apex
- `DocGenController.previewDraftPdf` + `DocGenService.draftHtmlBodyOverride` (+`DocGenTemplateManager` pre-first-save support), `getHtmlTemplateBody`, `getConvertedHtmlSnapshot`, `listHtmlTemplateImages`.
- `DocGenHtmlTemplateTest` 32/32 incl. draft-preview isolation and the full aggregate format-suffix surface (`currency:EUR:de_DE`, `currency:auto=Field`).

### Known follow-ups (tracked in branch memory)
Numeric-aggregate SOQL fallback for unqueried fields; side-by-side PDF iframe needs a VF page; chart builder UI; drag feel on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)